### PR TITLE
优化集群ip选择器筛选逻辑

### DIFF
--- a/pipeline_plugins/tests/variables/collections/sites/open/cc/test_var_cmdb_set_module_ip_selector.py
+++ b/pipeline_plugins/tests/variables/collections/sites/open/cc/test_var_cmdb_set_module_ip_selector.py
@@ -649,15 +649,7 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             [
                 {
                     "func": self.client.new().cc.find_module_with_relation,
-                    "calls": [
-                        call(
-                            bk_biz_id=1,
-                            bk_service_template_ids=[],
-                            bk_set_ids=[31],
-                            fields=["bk_module_id"],
-                            page={"start": 0, "limit": 1},
-                        )
-                    ],
+                    "calls": [],
                 },
                 {"func": self.client.new().cc.list_biz_hosts, "calls": []},
             ]
@@ -821,15 +813,7 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             [
                 {
                     "func": self.client.new().cc.find_module_with_relation,
-                    "calls": [
-                        call(
-                            bk_biz_id=1,
-                            bk_service_template_ids=[],
-                            bk_set_ids=[31],
-                            fields=["bk_module_id"],
-                            page={"start": 0, "limit": 1},
-                        )
-                    ],
+                    "calls": [],
                 },
                 {"func": self.client.new().cc.list_biz_hosts, "calls": []},
             ]
@@ -858,15 +842,7 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             [
                 {
                     "func": self.client.new().cc.find_module_with_relation,
-                    "calls": [
-                        call(
-                            bk_biz_id=1,
-                            bk_service_template_ids=[],
-                            bk_set_ids=[31],
-                            fields=["bk_module_id"],
-                            page={"start": 0, "limit": 1},
-                        )
-                    ],
+                    "calls": [],
                 },
                 {"func": self.client.new().cc.list_biz_hosts, "calls": []},
             ]
@@ -979,15 +955,7 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             [
                 {
                     "func": self.client.new().cc.find_module_with_relation,
-                    "calls": [
-                        call(
-                            bk_biz_id=1,
-                            bk_service_template_ids=[],
-                            bk_set_ids=[31],
-                            fields=["bk_module_id"],
-                            page={"start": 0, "limit": 1},
-                        )
-                    ],
+                    "calls": [],
                 },
                 {"func": self.client.new().cc.list_biz_hosts, "calls": []},
             ]
@@ -1012,22 +980,7 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             [
                 {
                     "func": self.client.new().cc.find_module_with_relation,
-                    "calls": [
-                        call(
-                            bk_biz_id=1,
-                            bk_service_template_ids=[61],
-                            bk_set_ids=[31, 32],
-                            fields=["bk_module_id"],
-                            page={"start": 0, "limit": 1},
-                        ),
-                        call(
-                            bk_biz_id=1,
-                            bk_service_template_ids=[61],
-                            bk_set_ids=[31, 32],
-                            fields=["bk_module_id"],
-                            page={"limit": 500, "start": 0},
-                        ),
-                    ],
+                    "calls": [],
                 },
                 {
                     "func": self.client.new().cc.list_biz_hosts,
@@ -1070,15 +1023,7 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             [
                 {
                     "func": self.client.new().cc.find_module_with_relation,
-                    "calls": [
-                        call(
-                            bk_biz_id=1,
-                            bk_service_template_ids=[],
-                            bk_set_ids=[31, 32],
-                            fields=["bk_module_id"],
-                            page={"start": 0, "limit": 1},
-                        )
-                    ],
+                    "calls": [],
                 },
                 {"func": self.client.new().cc.list_biz_hosts, "calls": []},
             ]

--- a/pipeline_plugins/variables/collections/sites/open/cmdb/var_cmdb_set_module_ip_selector.py
+++ b/pipeline_plugins/variables/collections/sites/open/cmdb/var_cmdb_set_module_ip_selector.py
@@ -88,8 +88,6 @@ class SetModuleIpSelector(LazyVariable, SelfExplainVariable):
             logger.info("[SetModuleIpSelector.get_value] module_ids: %s" % module_ids)
 
             # 如果没有过滤到任何模块id，此时返回空
-            if not module_ids:
-                return ""
             # 自定义输入ip
             custom_value = var_ip_selector["var_ip_custom_value"]
             if settings.ENABLE_IPV6:


### PR DESCRIPTION
当服务模板筛选条件全部不存在时，此时将不再查询全部