### PR TITLE
perf: 优化TaskContext类，__init__方法中对于timezone.pytz.timezone(project.time_zone)的异常处理

### DIFF
--- a/gcloud/taskflow3/domains/context.py
+++ b/gcloud/taskflow3/domains/context.py
@@ -52,7 +52,10 @@ class TaskContext(object):
         self.biz_cc_name = self.bk_biz_name
         # 任务开始时间
         project = Project.objects.get(id=self.project_id)
-        project_tz = timezone.pytz.timezone(project.time_zone)
+        try:
+            project_tz = timezone.pytz.timezone(project.time_zone)
+        except timezone.pytz.exceptions.UnknownTimeZoneError as e:
+            raise Exception(f"Project Unknown time zone error: {e}")
         self.task_start_time = datetime.datetime.now(tz=project_tz).strftime("%Y-%m-%d %H:%M:%S")
         # 任务URL
         self.task_url = (


### PR DESCRIPTION
开发环境后台部署完成后，我创建了一个简单的流程，并尝试运行，前端提示报错: **引擎启动失败, 请重试. 如持续失败可联系管理员处理. ''**, 截图如下
<img width="1710" alt="image" src="https://github.com/TencentBlueKing/bk-sops/assets/72431167/d7466fa5-abb5-40dc-9dd9-83b7007c67a7">
该报错的提示信息(空字符串)对于用户, 尤其是新用户来说不是很明显，通过查看代码层层排查，最终问题定位于是Project中没有设置项目时区， 不过看gcloud/core/models.py中对于time_zone字段的定义，是允许为空的。
<img width="1005" alt="image" src="https://github.com/TencentBlueKing/bk-sops/assets/72431167/d3bcec0c-bbf7-41a9-866a-75272541b256">
```
class Project(models.Model):
    ...
    time_zone = models.CharField(_("项目时区"), max_length=100, blank=True)
    ...
```
是否可以给TaskContext类，__init__方法中增加对timezone.pytz.timezone(project.time_zone)的异常处理，让用户获得更加明显的提示信息，增加异常处理后的报错: **引擎启动失败, 请重试. 如持续失败可联系管理员处理. Project Unknown time zone error: ''**

<img width="1711" alt="image" src="https://github.com/TencentBlueKing/bk-sops/assets/72431167/b239121a-1e0e-4418-9f25-9389dfa47c6f">


