### PR TITLE
feat: 增加AI排版功能开关

### DIFF
--- a/frontend/desktop/src/components/common/TemplateCanvas/ToolPanel/index.vue
+++ b/frontend/desktop/src/components/common/TemplateCanvas/ToolPanel/index.vue
@@ -84,7 +84,7 @@
                 </div>
                 <div
                     class="ai-format-wrap"
-                    v-if="editable">
+                    v-if="editable && aiLayoutEnabled">
                     <div
                         :class="['tool-icon', 'ai-format-icon', { 'disabled': aiFormatLoading }]"
                         v-bk-tooltips="{
@@ -214,6 +214,10 @@
             aiFormatResult: {
                 type: String,
                 default: ''
+            },
+            aiLayoutEnabled: {
+                type: Boolean,
+                default: false
             }
         },
         data () {

--- a/frontend/desktop/src/components/common/TemplateCanvas/index.vue
+++ b/frontend/desktop/src/components/common/TemplateCanvas/index.vue
@@ -61,6 +61,7 @@
                     :zoom-ratio="zoomRatio"
                     :is-show-hot-key="isShowHotKey"
                     :is-perspective="isPerspective"
+                    :ai-layout-enabled="aiLayoutEnabled"
                     :ai-format-loading="aiFormatLoading"
                     :ai-format-result="aiFormatResult"
                     @onShowMap="onToggleMapShow"
@@ -268,6 +269,10 @@
             nodeExecRecordInfo: {
                 type: Object,
                 default: () => ({})
+            },
+            aiLayoutEnabled: {
+                type: Boolean,
+                default: false
             },
             aiFormatLoading: {
                 type: Boolean,

--- a/frontend/desktop/src/pages/template/TemplateEdit/index.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/index.vue
@@ -58,6 +58,7 @@
                     :template-labels="templateLabels"
                     :canvas-data="canvasData"
                     :node-variable-info="nodeVariableInfo"
+                    :ai-layout-enabled="aiLayoutEnabled"
                     :ai-format-loading="aiFormatLoading"
                     :ai-format-result="aiFormatResult"
                     @hook:mounted="canvasMounted"
@@ -310,6 +311,7 @@
                 checkedNodes: [],
                 checkedConvergeNodes: [],
                 isolationAtomConfig: {}, // 被隔离插件的基础配置
+                aiLayoutEnabled: false, // AI排版功能开关
                 aiFormatLoading: false, // AI排版加载状态
                 aiFormatResult: '', // AI排版结果状态
                 isReplacingConnectors: false
@@ -517,6 +519,7 @@
             ]),
             ...mapActions('project/', [
                 'getProjectLabelsWithDefault',
+                'getProjectConfig',
                 'loadEnvVariableList'
             ]),
             ...mapMutations('template/', [
@@ -567,6 +570,7 @@
                 this.getSystemVars()
                 this.getSingleAtomList()
                 this.getProjectBaseInfo()
+                this.getAiLayoutEnabledConfig()
                 if (!this.common) {
                     this.getTemplateLabelList()
                 }
@@ -646,6 +650,27 @@
                     console.log(e)
                 } finally {
                     this.projectInfoLoading = false
+                }
+            },
+            /**
+             * 获取 AI 排版功能开关
+             */
+            async getAiLayoutEnabledConfig () {
+                if (!this.project_id) {
+                    this.aiLayoutEnabled = false
+                    return
+                }
+                try {
+                    const resp = await this.getProjectConfig(this.project_id)
+                    if (resp.result) {
+                        const customConfigs = resp.data.custom_display_configs || {}
+                        this.aiLayoutEnabled = !!customConfigs.enable_ai_layout
+                    } else {
+                        this.aiLayoutEnabled = false
+                    }
+                } catch (e) {
+                    this.aiLayoutEnabled = false
+                    console.log(e)
                 }
             },
             /**

--- a/gcloud/tasktmpl3/apis/django/api.py
+++ b/gcloud/tasktmpl3/apis/django/api.py
@@ -483,6 +483,21 @@ def ai_beautify_sops_template_layout(request):
         logger.error("beautify_sops_template_layout error: project not found - {}".format(project_id))
         return JsonResponse({"result": False, "message": "project not found", "code": err_code.UNKNOWN_ERROR.code})
 
+    ai_layout_enabled = False
+    project_config = ProjectConfig.objects.filter(project_id=project_id).first()
+    if project_config:
+        custom_configs = project_config.custom_display_configs or {}
+        ai_layout_enabled = custom_configs.get("enable_ai_layout", False)
+
+    if not ai_layout_enabled:
+        return JsonResponse(
+            {
+                "result": False,
+                "message": "该项目未开启 AI 排版功能",
+                "code": err_code.REQUEST_FORBIDDEN_INVALID.code,
+            }
+        )
+
     try:
         template_obj = TaskTemplate.objects.get(pk=template_id, project_id=project_id, is_deleted=False)
     except TaskTemplate.DoesNotExist:

--- a/gcloud/tests/taskflow3/test_api.py
+++ b/gcloud/tests/taskflow3/test_api.py
@@ -16,6 +16,7 @@ from copy import deepcopy
 from django.test import Client, TestCase
 from pipeline.utils.uniqid import node_uniqid
 
+from gcloud import err_code
 from gcloud.taskflow3.apis.django import api
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
@@ -270,6 +271,93 @@ class APITest(TestCase):
         result = api.last_execution_constants(request, TEST_PROJECT_ID)
 
         self.assertFalse(result["result"])
+
+    @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
+    @mock.patch("gcloud.taskflow3.apis.django.api.layout_pipeline_tree")
+    @mock.patch("gcloud.taskflow3.apis.django.api.ProjectConfig.objects.filter")
+    @mock.patch("gcloud.taskflow3.apis.django.api.TaskTemplate.objects.get")
+    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    def test_ai_beautify_layout__feature_enabled(
+        self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
+    ):
+        mock_project_get.return_value = MagicMock()
+        mock_template_get.return_value = MockBaseTemplate(
+            id=1,
+            pipeline_tree={"location": [{"id": "n1", "x": 1, "y": 2}], "line": [{"id": "l1"}]},
+        )
+        mock_project_config_filter.return_value.first.return_value = MagicMock(
+            custom_display_configs={"enable_ai_layout": True}
+        )
+
+        request = MockRequest(
+            "GET",
+            {
+                "project_id": TEST_PROJECT_ID,
+                "template_id": "1",
+                "canvas_width": "1200",
+            },
+        )
+        result = api.ai_beautify_sops_template_layout(request)
+
+        self.assertTrue(result["result"])
+        self.assertEqual(result["code"], err_code.SUCCESS.code)
+        mock_layout_pipeline_tree.assert_called_once()
+
+    @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
+    @mock.patch("gcloud.taskflow3.apis.django.api.layout_pipeline_tree")
+    @mock.patch("gcloud.taskflow3.apis.django.api.ProjectConfig.objects.filter")
+    @mock.patch("gcloud.taskflow3.apis.django.api.TaskTemplate.objects.get")
+    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    def test_ai_beautify_layout__feature_disabled(
+        self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
+    ):
+        mock_project_get.return_value = MagicMock()
+        mock_template_get.return_value = MockBaseTemplate(id=1, pipeline_tree={"location": [], "line": []})
+        mock_project_config_filter.return_value.first.return_value = MagicMock(
+            custom_display_configs={"enable_ai_layout": False}
+        )
+
+        request = MockRequest(
+            "GET",
+            {
+                "project_id": TEST_PROJECT_ID,
+                "template_id": "1",
+                "canvas_width": "1200",
+            },
+        )
+        result = api.ai_beautify_sops_template_layout(request)
+
+        self.assertFalse(result["result"])
+        self.assertEqual(result["message"], "该项目未开启 AI 排版功能")
+        self.assertEqual(result["code"], err_code.REQUEST_FORBIDDEN_INVALID.code)
+        mock_layout_pipeline_tree.assert_not_called()
+
+    @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
+    @mock.patch("gcloud.taskflow3.apis.django.api.layout_pipeline_tree")
+    @mock.patch("gcloud.taskflow3.apis.django.api.ProjectConfig.objects.filter")
+    @mock.patch("gcloud.taskflow3.apis.django.api.TaskTemplate.objects.get")
+    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    def test_ai_beautify_layout__feature_missing_key(
+        self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
+    ):
+        mock_project_get.return_value = MagicMock()
+        mock_template_get.return_value = MockBaseTemplate(id=1, pipeline_tree={"location": [], "line": []})
+        mock_project_config_filter.return_value.first.return_value = MagicMock(custom_display_configs={})
+
+        request = MockRequest(
+            "GET",
+            {
+                "project_id": TEST_PROJECT_ID,
+                "template_id": "1",
+                "canvas_width": "1200",
+            },
+        )
+        result = api.ai_beautify_sops_template_layout(request)
+
+        self.assertFalse(result["result"])
+        self.assertEqual(result["message"], "该项目未开启 AI 排版功能")
+        self.assertEqual(result["code"], err_code.REQUEST_FORBIDDEN_INVALID.code)
+        mock_layout_pipeline_tree.assert_not_called()
 
     @mock.patch("gcloud.utils.decorators.JsonResponse", MockJsonResponse())
     @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())

--- a/gcloud/tests/taskflow3/test_api.py
+++ b/gcloud/tests/taskflow3/test_api.py
@@ -278,8 +278,14 @@ class APITest(TestCase):
     @mock.patch("gcloud.tasktmpl3.apis.django.api.ProjectConfig.objects.filter")
     @mock.patch("gcloud.tasktmpl3.apis.django.api.TaskTemplate.objects.get")
     @mock.patch("gcloud.tasktmpl3.apis.django.api.Project.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.AgentBeautifyTemplateLayoutInterceptor.process")
     def test_ai_beautify_layout__feature_enabled(
-        self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
+        self,
+        mock_interceptor_process,
+        mock_project_get,
+        mock_template_get,
+        mock_project_config_filter,
+        mock_layout_pipeline_tree,
     ):
         mock_project_get.return_value = MagicMock()
         mock_template_get.return_value = MockBaseTemplate(
@@ -309,8 +315,14 @@ class APITest(TestCase):
     @mock.patch("gcloud.tasktmpl3.apis.django.api.ProjectConfig.objects.filter")
     @mock.patch("gcloud.tasktmpl3.apis.django.api.TaskTemplate.objects.get")
     @mock.patch("gcloud.tasktmpl3.apis.django.api.Project.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.AgentBeautifyTemplateLayoutInterceptor.process")
     def test_ai_beautify_layout__feature_disabled(
-        self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
+        self,
+        mock_interceptor_process,
+        mock_project_get,
+        mock_template_get,
+        mock_project_config_filter,
+        mock_layout_pipeline_tree,
     ):
         mock_project_get.return_value = MagicMock()
         mock_template_get.return_value = MockBaseTemplate(id=1, pipeline_tree={"location": [], "line": []})
@@ -338,8 +350,14 @@ class APITest(TestCase):
     @mock.patch("gcloud.tasktmpl3.apis.django.api.ProjectConfig.objects.filter")
     @mock.patch("gcloud.tasktmpl3.apis.django.api.TaskTemplate.objects.get")
     @mock.patch("gcloud.tasktmpl3.apis.django.api.Project.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.AgentBeautifyTemplateLayoutInterceptor.process")
     def test_ai_beautify_layout__feature_missing_key(
-        self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
+        self,
+        mock_interceptor_process,
+        mock_project_get,
+        mock_template_get,
+        mock_project_config_filter,
+        mock_layout_pipeline_tree,
     ):
         mock_project_get.return_value = MagicMock()
         mock_template_get.return_value = MockBaseTemplate(id=1, pipeline_tree={"location": [], "line": []})

--- a/gcloud/tests/taskflow3/test_api.py
+++ b/gcloud/tests/taskflow3/test_api.py
@@ -18,6 +18,7 @@ from pipeline.utils.uniqid import node_uniqid
 
 from gcloud import err_code
 from gcloud.taskflow3.apis.django import api
+from gcloud.tasktmpl3.apis.django import api as tasktmpl_api
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
 
@@ -272,11 +273,11 @@ class APITest(TestCase):
 
         self.assertFalse(result["result"])
 
-    @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
-    @mock.patch("gcloud.taskflow3.apis.django.api.layout_pipeline_tree")
-    @mock.patch("gcloud.taskflow3.apis.django.api.ProjectConfig.objects.filter")
-    @mock.patch("gcloud.taskflow3.apis.django.api.TaskTemplate.objects.get")
-    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.JsonResponse", MockJsonResponse())
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.layout_pipeline_tree")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.ProjectConfig.objects.filter")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.TaskTemplate.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.Project.objects.get")
     def test_ai_beautify_layout__feature_enabled(
         self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
     ):
@@ -297,17 +298,17 @@ class APITest(TestCase):
                 "canvas_width": "1200",
             },
         )
-        result = api.ai_beautify_sops_template_layout(request)
+        result = tasktmpl_api.ai_beautify_sops_template_layout(request)
 
         self.assertTrue(result["result"])
         self.assertEqual(result["code"], err_code.SUCCESS.code)
         mock_layout_pipeline_tree.assert_called_once()
 
-    @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
-    @mock.patch("gcloud.taskflow3.apis.django.api.layout_pipeline_tree")
-    @mock.patch("gcloud.taskflow3.apis.django.api.ProjectConfig.objects.filter")
-    @mock.patch("gcloud.taskflow3.apis.django.api.TaskTemplate.objects.get")
-    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.JsonResponse", MockJsonResponse())
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.layout_pipeline_tree")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.ProjectConfig.objects.filter")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.TaskTemplate.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.Project.objects.get")
     def test_ai_beautify_layout__feature_disabled(
         self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
     ):
@@ -325,18 +326,18 @@ class APITest(TestCase):
                 "canvas_width": "1200",
             },
         )
-        result = api.ai_beautify_sops_template_layout(request)
+        result = tasktmpl_api.ai_beautify_sops_template_layout(request)
 
         self.assertFalse(result["result"])
         self.assertEqual(result["message"], "该项目未开启 AI 排版功能")
         self.assertEqual(result["code"], err_code.REQUEST_FORBIDDEN_INVALID.code)
         mock_layout_pipeline_tree.assert_not_called()
 
-    @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
-    @mock.patch("gcloud.taskflow3.apis.django.api.layout_pipeline_tree")
-    @mock.patch("gcloud.taskflow3.apis.django.api.ProjectConfig.objects.filter")
-    @mock.patch("gcloud.taskflow3.apis.django.api.TaskTemplate.objects.get")
-    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.JsonResponse", MockJsonResponse())
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.layout_pipeline_tree")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.ProjectConfig.objects.filter")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.TaskTemplate.objects.get")
+    @mock.patch("gcloud.tasktmpl3.apis.django.api.Project.objects.get")
     def test_ai_beautify_layout__feature_missing_key(
         self, mock_project_get, mock_template_get, mock_project_config_filter, mock_layout_pipeline_tree
     ):
@@ -352,7 +353,7 @@ class APITest(TestCase):
                 "canvas_width": "1200",
             },
         )
-        result = api.ai_beautify_sops_template_layout(request)
+        result = tasktmpl_api.ai_beautify_sops_template_layout(request)
 
         self.assertFalse(result["result"])
         self.assertEqual(result["message"], "该项目未开启 AI 排版功能")


### PR DESCRIPTION
## 变更内容
- 为 AI 排版新增独立项目级功能开关 `ProjectConfig.custom_display_configs.enable_ai_layout`
- 模板编辑页读取项目配置，只有开关开启时才展示 `AI排版` 按钮
- AI 排版后端接口增加同口径兜底校验，关闭或缺失时返回明确提示
- 补充后端测试，覆盖开启、关闭、缺失 key 三种场景

## 变更原因
- 当前 AI 生成流程已有独立功能开关控制，AI 排版缺少对应项目级控制能力
- 需要参考现有模式，为 AI 排版补充独立开关，且不复用 `enable_agent_generate`

## 影响范围
- 仅影响 AI 排版功能入口展示和接口可用性
- 不影响普通排版
- 不影响 AI 生成流程

## 验证
- `git diff --check`
- `python -m py_compile gcloud/tasktmpl3/apis/django/api.py gcloud/tests/taskflow3/test_api.py`
- `pytest` 在当前环境未能完成，因为 Django 启动时会尝试写 `/data1/Projects/logs/bk_sops/component.log`，被只读环境阻塞
