### PR TITLE
fix: 远程插件执行时未传递tenant_id导致跨租户调用被拒绝

### DIFF
--- a/pipeline_plugins/components/collections/remote_plugin/v1_0_0.py
+++ b/pipeline_plugins/components/collections/remote_plugin/v1_0_0.py
@@ -86,9 +86,10 @@ class RemotePluginService(BasePluginService):
     def plugin_execute(self, data, parent_data):
         plugin_code = data.get_one_of_inputs("plugin_code")
         plugin_version = data.get_one_of_inputs("plugin_version")
+        tenant_id = parent_data.get_one_of_inputs("tenant_id")
 
         try:
-            plugin_client = PluginServiceApiClient(plugin_code)
+            plugin_client = PluginServiceApiClient(plugin_code, tenant_id=tenant_id)
         except PluginServiceException as e:
             message = _(f"第三方插件client初始化失败, 错误内容: {e}")
             logger.error(message)
@@ -125,9 +126,7 @@ class RemotePluginService(BasePluginService):
 
         ok, result_data = plugin_client.invoke(plugin_version, {"inputs": data.inputs, "context": plugin_context})
         if not ok:
-            message = _(
-                f"调用第三方插件invoke接口错误, 错误内容: {result_data['message']}, trace_id: {result_data.get('trace_id')}"
-            )
+            message = _(f"调用第三方插件invoke接口错误, 错误内容: {result_data['message']}, trace_id: {result_data.get('trace_id')}")
             logger.error(message)
             data.set_outputs("ex_data", message)
             return False
@@ -162,8 +161,9 @@ class RemotePluginService(BasePluginService):
             data.set_outputs("ex_data", message)
             return False
 
+        tenant_id = parent_data.get_one_of_inputs("tenant_id")
         try:
-            plugin_client = PluginServiceApiClient(plugin_code)
+            plugin_client = PluginServiceApiClient(plugin_code, tenant_id=tenant_id)
         except PluginServiceException as e:
             message = _(f"第三方插件client初始化失败, 错误内容: {e}")
             logger.error(message)


### PR DESCRIPTION
## Summary

- 修复 `RemotePluginService` 的 `plugin_execute` 和 `plugin_schedule` 方法在构造 `PluginServiceApiClient` 时未传递 `tenant_id` 的问题
- Pipeline worker 中线程变量未被设置，`get_current_tenant_id()` 回退为 `"default"`，与网关实际所属租户不匹配，导致 `CROSS_TENANT_FORBIDDEN (403)` 错误
- 从 `parent_data` 获取 `tenant_id`（来源于 `TaskContext` → `project.tenant_id`），与 JOB / Monitor 等其他插件保持一致

## Root Cause

`RemotePluginService` 在 pipeline worker 中执行时：

1. `PluginServiceApiClient(plugin_code)` 未传 `tenant_id`，`self.tenant_id = None`
2. `invoke()` → `_prepare_apigw_api_request(tenant_id=None)` → header 使用 `get_current_tenant_id()`
3. Pipeline worker 不经过 Django `TenantMiddleware`，线程变量未设置，返回默认值 `"default"`
4. 网关属于租户 `tencent`，header 是 `default` → 403 CROSS_TENANT_FORBIDDEN

## Test plan

- [ ] 在单租户环境执行包含远程插件(第三方插件)的流程任务，验证 invoke 调用不再返回 403
- [ ] 验证远程插件的 schedule 轮询阶段同样正常工作
- [ ] 回归测试：在多租户环境下执行远程插件，确认租户隔离正常


Made with [Cursor](https://cursor.com)