### PR TITLE
修复 create_template 接口按业务 ID 调用失败

### DIFF
--- a/gcloud/iam_auth/view_interceptors/apigw/create_template.py
+++ b/gcloud/iam_auth/view_interceptors/apigw/create_template.py
@@ -27,5 +27,5 @@ class CreateTemplateInterceptor(ViewInterceptor):
 
         subject = Subject("user", request.user.username)
         action = Action(IAMMeta.FLOW_CREATE_ACTION)
-        resources = res_factory.resources_for_project(kwargs["project_id"])
+        resources = res_factory.resources_for_project_obj(request.project)
         allow_or_raise_auth_failed(iam, IAMMeta.SYSTEM_ID, subject, action, resources, cache=True)

--- a/gcloud/tests/apigw/views/test_create_template_interceptor.py
+++ b/gcloud/tests/apigw/views/test_create_template_interceptor.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from gcloud.iam_auth.view_interceptors.apigw.create_template import CreateTemplateInterceptor
+
+
+class CreateTemplateInterceptorTestCase(TestCase):
+    @mock.patch("gcloud.iam_auth.view_interceptors.apigw.create_template.allow_or_raise_auth_failed")
+    @mock.patch("gcloud.iam_auth.view_interceptors.apigw.create_template.res_factory.resources_for_project_obj")
+    @mock.patch(
+        "gcloud.iam_auth.view_interceptors.apigw.create_template.res_factory.resources_for_project",
+        side_effect=AssertionError("resources_for_project should not be used here"),
+    )
+    def test_process__use_injected_project_for_scope_lookup(
+        self,
+        mocked_resources_for_project,
+        mocked_resources_for_project_obj,
+        mocked_allow_or_raise_auth_failed,
+    ):
+        interceptor = CreateTemplateInterceptor()
+        request = SimpleNamespace(
+            is_trust=False,
+            user=SimpleNamespace(username="tester"),
+            project=SimpleNamespace(id=42, name="project-for-biz-100605"),
+        )
+        mocked_resources_for_project_obj.return_value = ["project-resource"]
+
+        interceptor.process(request, project_id="100605")
+
+        mocked_resources_for_project_obj.assert_called_once_with(request.project)
+        mocked_allow_or_raise_auth_failed.assert_called_once()


### PR DESCRIPTION
## 功能描述

修复 `create_template` 网关接口在使用 `biz_id` 调用时，IAM 拦截器错误地将路径参数当成内部 `Project.id` 查询，导致创建模板失败的问题。

## 问题背景

`create_template` 入口通过 `project_inject` 默认按 `scope=cmdb_biz` 解析项目，因此当请求路径里传的是业务 ID 时，`request.project` 能被正确注入。

但 `CreateTemplateInterceptor` 在做权限校验时，重新使用 URL 中的 `project_id` 调用了 `resources_for_project(project_id)`。这个方法内部按 `Project.id` 查询，和前面的 `biz_id` 语义不一致，最终触发 `Project matching query does not exist`。

## 解决方案

1. `CreateTemplateInterceptor` 改为直接使用 `request.project`
2. IAM 资源构造改为 `resources_for_project_obj(request.project)`
3. 增加回归测试，覆盖“路径参数传 `biz_id`，但权限资源必须基于已注入项目对象”场景

## 兼容性说明

- 不影响传内部 `project.id` 的调用
- 修复默认 `scope=cmdb_biz` / 按业务 ID 调用 `create_template` 的失败问题
- 只调整 `create_template` 这条接口的权限资源构造逻辑

## 测试说明

- 新增拦截器级回归测试
- 未额外执行完整测试集
