### PR TITLE
fix: 增加独立子流程 callback 竞态修复与恢复工具 --bug=1010131351157180998

### DIFF
--- a/docs/plans/2026-04-22-subprocess-callback-race-phase1.md
+++ b/docs/plans/2026-04-22-subprocess-callback-race-phase1.md
@@ -1,0 +1,291 @@
+# 独立子流程 Callback 竞态一期修复 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复独立子流程节点成功 callback 因 `schedule lock` 冲突被静默丢弃的问题，并提供专用排查与安全恢复工具。
+
+**Architecture:** 在 `bamboo-engine` 的 `CALLBACK` 锁冲突分支增加一个默认关闭的 service 级重试扩展点，一期仅让 `subprocess_plugin` 对 `task_success=True` 开启该能力。`bk-sops` 增加离线竞态分析命令和安全重放命令，所有人工恢复都必须回到正式 callback 链路。
+
+**Tech Stack:** Python 3.6, Django management command, bamboo-engine runtime, pytest, Django test
+
+**Spec:** `docs/specs/2026-04-22-subprocess-callback-race-phase1-design.md`
+
+---
+
+## File Structure
+
+| 文件 | 操作 | 职责 |
+|------|------|------|
+| `../bamboo-engine/runtime/bamboo-pipeline/pipeline/core/flow/activity/service_activity.py` | 修改 | 新增 service 级 callback 锁冲突重试扩展点 |
+| `../bamboo-engine/bamboo_engine/engine.py` | 修改 | 在 `schedule lock` 冲突分支增加“受控 callback 重试”逻辑 |
+| `../bamboo-engine/tests/engine/test_engine_schedule.py` | 修改 | 覆盖可重试 callback、重试上限和非重试节点行为 |
+| `pipeline_plugins/components/collections/subprocess_plugin/v1_0_0.py` | 修改 | 仅对独立子流程成功 callback 开启锁冲突重试能力 |
+| `pipeline_plugins/tests/components/collections/subprocess_plugin/test_v1_0_0.py` | 新增 | 验证 `callback_lock_retryable` 语义 |
+| `gcloud/taskflow3/management/commands/analyze_subprocess_callback_race.py` | 新增 | 识别导出数据中的独立子流程 callback 竞态 |
+| `gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py` | 新增 | 对符合条件的独立子流程节点进行安全重放 |
+| `gcloud/tests/taskflow3/commands/test_analyze_subprocess_callback_race.py` | 新增 | 验证竞态识别输出 |
+| `gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py` | 新增 | 验证安全检查和重放路径 |
+
+---
+
+### Task 1: 为 `bamboo-engine` 增加 service 级 callback 锁重试扩展点
+
+**Files:**
+- Modify: `../bamboo-engine/runtime/bamboo-pipeline/pipeline/core/flow/activity/service_activity.py`
+- Test: `../bamboo-engine/tests/engine/test_engine_schedule.py`
+
+- [x] **Step 1: 在 `Service` 基类中新增默认实现**
+
+```python
+    def callback_lock_retryable(self, callback_data=None):
+        return False
+```
+
+- [x] **Step 2: 运行现有 engine 相关测试确认无基础回归**
+
+Run: `PYTHONPATH=../bamboo-engine python -m pytest ../bamboo-engine/tests/engine/test_engine_schedule.py -k 'lock_get_failed_but_not_retry' -q`
+Expected: PASS
+
+- [x] **Step 3: 提交到工作区，等待后续 Task 2 一起回归**
+
+本任务不单独提交，和 Task 2 一起形成 engine 补丁。
+
+---
+
+### Task 2: 在 `Engine.schedule` 的锁冲突分支增加受控 callback 重试
+
+**Files:**
+- Modify: `../bamboo-engine/bamboo_engine/engine.py`
+- Test: `../bamboo-engine/tests/engine/test_engine_schedule.py`
+
+- [x] **Step 1: 先写失败测试，覆盖“可重试 callback”场景**
+
+新增测试：
+
+```python
+def test_schedule__lock_get_failed_and_retry_enabled_callback(...):
+    runtime = Mock()
+    runtime.apply_schedule_lock.return_value = False
+    runtime.get_callback_data.return_value = Mock(id=1, data={"task_success": True})
+    runtime.get_node.return_value = Mock(code="subprocess_plugin", version="1.0.0", name="subprocess")
+    runtime.get_service.return_value = Mock(callback_lock_retryable=Mock(return_value=True))
+
+    Engine(runtime).schedule(...)
+
+    runtime.set_next_schedule.assert_called_once()
+```
+
+- [x] **Step 2: 再写达到重试上限的测试**
+
+新增测试：
+
+```python
+def test_schedule__lock_get_failed_and_retry_enabled_callback_reaches_retry_limit(...):
+    headers = {Engine.CALLBACK_LOCK_RETRY_HEADER: Engine.CALLBACK_LOCK_RETRY_LIMIT}
+    ...
+    runtime.set_next_schedule.assert_not_called()
+```
+
+- [x] **Step 3: 实现最小补丁**
+
+核心逻辑：
+
+```python
+if not lock_get:
+    callback_data = None
+    should_retry = schedule.type is ScheduleType.MULTIPLE_CALLBACK
+    if not should_retry:
+        callback_data, should_retry = self._callback_lock_retry_context(node_id, callback_data_id)
+        retry_count = self._schedule_lock_retry_count(headers)
+        if should_retry and retry_count >= self.CALLBACK_LOCK_RETRY_LIMIT:
+            logger.error(...)
+            return
+
+    if not should_retry:
+        logger.info(...)
+        return
+
+    retry_headers = dict(headers or {})
+    if schedule.type is ScheduleType.CALLBACK:
+        retry_headers[self.CALLBACK_LOCK_RETRY_HEADER] = self._schedule_lock_retry_count(headers) + 1
+    self.runtime.set_next_schedule(...)
+    return
+```
+
+- [x] **Step 4: 跑聚焦 engine 回归**
+
+Run: `PYTHONPATH=../bamboo-engine python -m pytest ../bamboo-engine/tests/engine/test_engine_schedule.py -k 'lock_get_failed_and_retry_enabled_callback or lock_get_failed_but_not_retry' -q`
+Expected: `3 passed`
+
+- [ ] **Step 5: 提交 engine 补丁**
+
+```bash
+git -C ../bamboo-engine add runtime/bamboo-pipeline/pipeline/core/flow/activity/service_activity.py bamboo_engine/engine.py tests/engine/test_engine_schedule.py
+git -C ../bamboo-engine commit -m "fix: retry subprocess success callback on schedule lock conflict"
+```
+
+---
+
+### Task 3: 仅让独立子流程成功 callback 开启该能力
+
+**Files:**
+- Modify: `pipeline_plugins/components/collections/subprocess_plugin/v1_0_0.py`
+- Test: `pipeline_plugins/tests/components/collections/subprocess_plugin/test_v1_0_0.py`
+
+- [x] **Step 1: 写测试**
+
+```python
+class SubprocessPluginServiceTestCase(SimpleTestCase):
+    def test_callback_lock_retryable_only_for_success_callback(self):
+        service = SubprocessPluginService()
+        assert service.callback_lock_retryable({"task_success": True}) is True
+        assert service.callback_lock_retryable({"task_success": False}) is False
+        assert service.callback_lock_retryable({}) is False
+```
+
+- [x] **Step 2: 实现最小代码**
+
+```python
+def callback_lock_retryable(self, callback_data=None):
+    return bool(callback_data and callback_data.get("task_success") is True)
+```
+
+- [x] **Step 3: 跑聚焦测试**
+
+Run: `python manage.py test pipeline_plugins.tests.components.collections.subprocess_plugin.test_v1_0_0 -v 2`
+Expected: `OK`
+
+- [ ] **Step 4: 提交 `bk-sops` 侧插件适配**
+
+```bash
+git add pipeline_plugins/components/collections/subprocess_plugin/v1_0_0.py pipeline_plugins/tests/components/collections/subprocess_plugin/test_v1_0_0.py
+git commit -m "test: cover subprocess callback lock retry policy"
+```
+
+---
+
+### Task 4: 新增离线竞态识别命令
+
+**Files:**
+- Create: `gcloud/taskflow3/management/commands/analyze_subprocess_callback_race.py`
+- Test: `gcloud/tests/taskflow3/commands/test_analyze_subprocess_callback_race.py`
+
+- [x] **Step 1: 写失败测试**
+
+测试目标：
+
+- 同一 `node_id + version` 下同时存在 `task_success=False/True`
+- `callback_data_count > schedule_times`
+- 节点仍有活跃 schedule
+- 输出候选并标记 `safe_to_replay`
+
+- [x] **Step 2: 实现命令**
+
+核心输出字段包括：
+
+- `callback_record_id`
+- `node_id`
+- `version`
+- `active_schedule_ids`
+- `latest_failed_callback_data_id`
+- `latest_success_callback_data_id`
+- `safe_to_replay`
+- `replay_blockers`
+
+- [x] **Step 3: 运行聚焦测试**
+
+Run: `python manage.py test gcloud.tests.taskflow3.commands.test_analyze_subprocess_callback_race -v 2`
+Expected: `OK`
+
+- [ ] **Step 4: 提交**
+
+```bash
+git add gcloud/taskflow3/management/commands/analyze_subprocess_callback_race.py gcloud/tests/taskflow3/commands/test_analyze_subprocess_callback_race.py
+git commit -m "feat: add subprocess callback race analyzer"
+```
+
+---
+
+### Task 5: 新增安全重放命令
+
+**Files:**
+- Create: `gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py`
+- Test: `gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py`
+
+- [x] **Step 1: 写失败测试**
+
+测试目标：
+
+- `inspect_candidate` 能识别一个处于 `FAILED` 的独立子流程节点且找到最新成功 callback
+- `apply_replay` 在节点为 `FAILED` 时先恢复 `schedule/state`，再走正式 callback dispatch
+
+- [x] **Step 2: 实现 `inspect_candidate`**
+
+安全检查项：
+
+- engine v2
+- 节点是 `subprocess_plugin`
+- `state` 是 `RUNNING / FAILED`
+- `schedule` 未 finished
+- root pipeline 一致
+- 存在最新成功 callback data
+
+- [x] **Step 3: 实现 `apply_replay`**
+
+```python
+if candidate["state"] == bamboo_states.FAILED:
+    DBSchedule.objects.filter(id=candidate["schedule_id"]).update(expired=False)
+    runtime.set_state(... READY)
+    runtime.set_state(... RUNNING)
+
+dispatcher = NodeCommandDispatcher(...)
+dispatcher.dispatch(command="callback", operator="system", version=..., data=...)
+```
+
+- [x] **Step 4: 跑聚焦测试**
+
+Run: `python manage.py test gcloud.tests.taskflow3.commands.test_replay_subprocess_success_callback -v 2`
+Expected: `OK`
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py
+git commit -m "feat: add safe replay for subprocess success callback"
+```
+
+---
+
+### Task 6: 做一期联调回归并准备回修发布
+
+**Files:**
+- Verify: `../bamboo-engine/tests/engine/test_engine_schedule.py`
+- Verify: `pipeline_plugins/tests/components/collections/subprocess_plugin/test_v1_0_0.py`
+- Verify: `gcloud/tests/taskflow3/commands/test_analyze_subprocess_callback_race.py`
+- Verify: `gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py`
+
+- [x] **Step 1: 跑 engine 聚焦测试**
+
+Run: `PYTHONPATH=../bamboo-engine python -m pytest ../bamboo-engine/tests/engine/test_engine_schedule.py -k 'lock_get_failed_and_retry_enabled_callback or lock_get_failed_but_not_retry' -q`
+Expected: `3 passed`
+
+- [x] **Step 2: 跑 `bk-sops` 聚焦测试**
+
+Run: `python manage.py test pipeline_plugins.tests.components.collections.subprocess_plugin.test_v1_0_0 gcloud.tests.taskflow3.commands.test_analyze_subprocess_callback_race gcloud.tests.taskflow3.commands.test_replay_subprocess_success_callback -v 2`
+Expected: `OK`
+
+- [ ] **Step 3: 输出回修说明**
+
+需要在发布说明里明确：
+
+- 该补丁依赖 `bamboo-engine` 与 `bk-sops` 同步回修
+- 默认只影响独立子流程成功 callback 的锁冲突处理
+- 仍保留现有 callback / version / state 门禁
+
+- [ ] **Step 4: 按版本策略发布**
+
+```bash
+# 先在对应线上 tag 完成 bamboo-engine 回修
+# 再回修 bk-sops
+# 通过灰度验证后再同步到主干和最新维护分支
+```

--- a/docs/specs/2026-04-22-stuck-governance-phase2-design.md
+++ b/docs/specs/2026-04-22-stuck-governance-phase2-design.md
@@ -1,0 +1,342 @@
+# 流程卡住治理二期设计
+
+## 概述
+
+二期目标不是继续围绕本次独立子流程 callback 竞态做定点修补，而是把“流程为什么卡住、如何快速识别、如何安全介入、何时触发告警”沉淀成一套可复用的治理能力。
+
+设计上采用两层结构：
+
+- `bamboo-engine`：沉淀通用运行时诊断、分型、安全操作和告警底座
+- `bk-sops`：补业务语义映射、任务级展示入口、业务增强规则和运维操作包装
+
+这样其他使用 `bamboo-engine` 的平台也能复用大部分能力，只有少量和 `TaskFlowInstance / TaskCallBackRecord / 独立子流程业务语义` 强耦合的内容留在 `bk-sops`。
+
+## 背景与问题抽象
+
+一期暴露的是一个典型症状：运行时对象已经出现 `Process / State / Schedule / CallbackData` 漂移，但现有系统很难快速回答以下问题：
+
+1. 当前任务到底卡在哪一种类型的问题上
+2. 是运行时本身异常，还是业务层关系断裂
+3. 现在是否还能安全恢复，应该恢复哪一步
+4. 哪类问题在一段时间内正在变多，是否是某次发布引入的回归
+
+因此二期不应继续按“发现一个 case 修一个 case”的方式推进，而应建设一套：
+
+- 能采集关键运行时事件
+- 能对历史 case 做统计和分型
+- 能在实时场景下给出明确诊断结论
+- 能对人工操作施加边界和审计
+- 能按类型触发更有意义告警
+
+## 二期目标
+
+- 建立 `bamboo-engine` 通用的流程卡住事件埋点与诊断底座
+- 建立历史卡住 case 样本库和可扩展的分型体系
+- 建立可复用的“实时诊断 + 安全操作”框架
+- 在 `bk-sops` 提供任务级诊断视角和业务增强能力
+- 建立从基础症状到趋势异常的分层告警体系
+
+## 非目标
+
+- 不在二期直接重构整个 callback / schedule / process 状态模型
+- 不尝试一次性覆盖所有历史异常场景，先从高价值类型开始
+- 不把所有平台逻辑都塞进 `bamboo-engine`
+- 不在本期做大规模前端重构，优先保证底座和诊断能力可用
+
+## 设计原则
+
+### 1. 先通用，后平台适配
+
+只要问题判断依赖的对象是 `Process / State / Schedule / CallbackData / Node / ack` 这些引擎运行时对象，就优先进入 `bamboo-engine`。只有依赖 `bk-sops` 自身业务概念的规则和展示才留在 `bk-sops`。
+
+### 2. 先可观测，再自动化
+
+在缺乏运行时事件和历史样本的情况下，过早做通用自动修复风险很高。二期先建立“看得见、分得清、可追溯”的底座，再逐步开放更多安全操作。
+
+### 3. 诊断与操作分离
+
+诊断引擎负责判断“是什么问题”；安全操作框架负责判断“能不能动、怎么动、动完如何审计”。避免把判断逻辑散落在人工脚本里。
+
+### 4. 最小侵入现网模型
+
+优先通过事件埋点、日志、指标和少量持久化诊断信息解决问题；只有在确实需要时才增加少量兼容字段，不进行重型迁移。
+
+## 总体架构
+
+二期采用如下分层：
+
+### 一、`bamboo-engine` 通用治理底座
+
+负责：
+
+- 统一事件埋点
+- 运行时快照与诊断输入
+- 历史异常样本沉淀
+- 通用卡住分型
+- 通用安全操作
+- 通用告警原语
+
+### 二、`bk-sops` 业务适配层
+
+负责：
+
+- `task_id / project_id / template_id` 等业务对象与引擎对象的映射
+- 独立子流程、任务回调记录、任务实例状态等业务增强规则
+- 面向运维同学的任务级诊断入口
+- 权限、审计、操作记录和提示文案
+
+## `bamboo-engine` 通用建设项
+
+## 一、统一事件埋点模型
+
+二期在 `bamboo-engine` 内部沉淀统一事件模型，覆盖流程执行关键路径上的重要时刻。第一批建议覆盖：
+
+- `callback_accepted`
+- `callback_data_persisted`
+- `schedule_sent`
+- `schedule_received`
+- `schedule_lock_conflict`
+- `schedule_retried`
+- `schedule_consumed`
+- `process_child_finished`
+- `parent_ack_updated`
+- `parent_wakeup`
+- `state_changed`
+- `manual_action_triggered`
+
+建议统一字段：
+
+- `root_pipeline_id`
+- `node_id`
+- `version`
+- `process_id`
+- `schedule_id`
+- `callback_data_id`
+- `event_type`
+- `result`
+- `reason`
+- `duration`
+- `operator`
+- `engine_version`
+
+这些字段全部使用引擎概念，不强制依赖 `bk-sops` 的任务语义。
+
+## 二、历史异常样本库
+
+基于引擎事件和运行时快照，建立一套历史 case 统计任务。目标是把“过去出现过哪些卡住任务”沉淀成结构化样本，而不是散落在临时日志里。
+
+建议每条样本包含：
+
+- `case_id`
+- `root_pipeline_id`
+- `first_seen_at`
+- `severity`
+- `stuck_type`
+- `key_evidence`
+- `last_status`
+- `manual_actions`
+- `final_resolution`
+
+`bk-sops` 可以在此基础上补充业务字段，例如 `task_id / project_id / template_source`，但底层样本结构应先保持 engine 通用。
+
+## 三、通用卡住分型框架
+
+分型框架是二期核心。第一版优先从纯引擎运行时特征出发，建立可扩展规则集。建议先支持以下类型：
+
+- `callback_lock_conflict`
+- `schedule_lock_stuck`
+- `missing_state_for_live_process`
+- `process_alive_but_terminal_state`
+- `parallel_ack_not_converged`
+- `multiple_sleep_process_for_node`
+- `version_mismatch_dropped_schedule`
+- `schedule_finished_but_process_not_exited`
+
+每种类型都定义：
+
+- 命中条件
+- 关键证据字段
+- 风险等级
+- 推荐检查项
+- 可用安全操作
+- 禁止直接操作项
+
+规则输出格式必须统一，便于被 CLI、工作台和告警系统复用。
+
+## 四、通用安全操作框架
+
+二期需要在 `bamboo-engine` 提供受控操作入口，而不是继续让平台侧或人工脚本直接调用底层 runtime。
+
+第一批建议提供的通用操作：
+
+- replay callback data
+- resend schedule
+- expire schedule
+- inspect process ack / converge status
+- inspect node runtime readiness
+
+每个操作都必须支持：
+
+- `dry-run`
+- 前置校验
+- 风险提示
+- 执行结果结构化返回
+- 操作审计钩子
+
+具体哪些操作对外开放，由上层平台按权限和风险决定。
+
+## 五、通用告警原语
+
+二期在 `bamboo-engine` 先沉淀最基础的异常症状告警能力，建议包括：
+
+- callback 锁冲突重试耗尽
+- schedule 长时间 `scheduling=True`
+- 同节点存在多个 sleep process
+- live process 当前节点缺少 state
+- 父进程 `need_ack > ack_num` 持续超阈值
+
+这些原语不直接面向业务方展示“任务故障原因”，而是作为平台侧更高层任务告警的输入。
+
+## `bk-sops` 适配层建设项
+
+## 一、业务增强规则
+
+在通用分型结果基础上，`bk-sops` 增加依赖自身业务语义的增强规则。首批建议包括：
+
+- `subprocess_relation_broken`
+- `task_callback_record_inconsistent`
+- `manual_bypass_caused_state_drift`
+- `taskflow_terminal_state_mismatch`
+
+这些规则可以引用：
+
+- `TaskFlowInstance`
+- `TaskFlowRelation`
+- `TaskCallBackRecord`
+- `TaskCallBackRecord.extra_info`
+- `PipelineInstance`
+
+但要避免把底层引擎分型逻辑反向塞进 `bamboo-engine`。
+
+## 二、任务级实时诊断入口
+
+`bk-sops` 负责把引擎侧诊断结果翻译成运维可直接使用的任务级视图，至少提供：
+
+- 当前卡住类型
+- 关键证据
+- 当前风险等级
+- 推荐检查动作
+- 可执行人工操作
+- 禁止直接操作的原因
+
+初期可以先用命令行或管理页形式提供，不要求一开始就建设完整前端工作台。
+
+## 三、任务级人工操作包装
+
+平台侧负责把 engine 的通用安全操作包装成更容易理解的任务级动作，例如：
+
+- 重放某个独立子流程节点的最新成功 callback
+- 重投某个任务节点当前 schedule
+- 标记某个过期 schedule 为人工失效
+
+所有操作都必须具备：
+
+- 操作权限校验
+- 任务上下文校验
+- 审计记录
+- 风险说明
+- 执行后结果回显
+
+## 四、任务级告警编排
+
+`bk-sops` 在通用告警原语之上做任务视角的聚合，分三层输出：
+
+### 1. 基础症状告警
+
+直接来自 `bamboo-engine` 的异常原语。
+
+### 2. 任务级卡住告警
+
+以任务实例为单位，聚合症状和分型结果，输出“任务卡住类型 + 证据摘要 + 推荐动作”。
+
+### 3. 趋势类告警
+
+按版本、组件、节点类型或时间窗口观测某类异常是否显著上升，用于识别回归发布或系统性风险。
+
+## 实施阶段建议
+
+二期按以下顺序推进：
+
+### 阶段一：通用事件与样本沉淀
+
+先把关键事件打全，并建立历史 case 样本库，解决“没有足够数据支撑通用治理”的问题。
+
+### 阶段二：通用分型与实时诊断
+
+在有样本和事件后，建设分型框架和诊断结果输出，让系统能稳定回答“当前是什么问题”。
+
+### 阶段三：安全操作与任务级包装
+
+在规则和边界稳定后，再把受控操作逐步开放给平台侧，并提供任务级入口和审计。
+
+### 阶段四：全面告警
+
+最后把基础症状、任务级异常和趋势异常接入完整告警体系，形成值班闭环。
+
+## 与一期的关系
+
+一期是二期的前置止血和最小验证：
+
+- 一期新增的 callback 重试日志和 `callback_data_id / retry_count` 信息，可以直接复用到二期事件模型
+- 一期的专用竞态分析命令和重放命令，可以演进为二期任务级工具的早期原型
+- 一期验证了“引擎通用扩展点 + 平台业务适配层”这一分层策略是成立的
+
+## 风险与控制
+
+### 风险 1：过早把业务逻辑塞进 `bamboo-engine`
+
+控制方式：
+
+- 运行时特征进 engine
+- 业务关系和任务语义留在 `bk-sops`
+- 任何规则设计先判断依赖的是 engine 对象还是业务对象
+
+### 风险 2：规则泛化过快导致误判
+
+控制方式：
+
+- 先从高确定性的纯运行时特征规则开始
+- 用历史样本回放评估命中准确率
+- 允许规则版本演进和逐步扩充
+
+### 风险 3：安全操作开放过早
+
+控制方式：
+
+- 所有操作必须先支持 `dry-run`
+- 默认只开放读操作和低风险动作
+- 高风险动作必须经过更严格校验与审计
+
+## 成功标准
+
+二期完成后，至少应能回答：
+
+- 某个引擎实例当前属于哪一类卡住问题
+- 这种问题在过去一段时间是否高发
+- 哪些人工操作是安全的，哪些不应执行
+- 哪类异常是否在某个版本发布后显著上升
+
+对于 `bk-sops`，额外要求：
+
+- 运维同学输入任务 ID 后，能实时看到任务级诊断结果
+- 常见卡住场景不再依赖人工翻表和临时脚本
+
+## 发布建议
+
+二期虽然整体由 `bk-sops` 牵头推动，但底座应优先从 `bamboo-engine` 开始：
+
+1. 先在 `bamboo-engine` 落事件埋点、样本库和分型基础框架
+2. 再在 `bk-sops` 增加业务增强规则和任务级展示
+3. 最后分批开放安全操作和告警编排
+
+这样可以最大化复用价值，也能降低未来多平台重复建设成本。

--- a/docs/specs/2026-04-22-subprocess-callback-race-phase1-design.md
+++ b/docs/specs/2026-04-22-subprocess-callback-race-phase1-design.md
@@ -1,0 +1,201 @@
+# 独立子流程 Callback 竞态一期修复设计
+
+## 概述
+
+本设计聚焦修复独立子流程节点在 `task_success=False` 与 `task_success=True` callback 近时间触发时，成功 callback 可能因为 `schedule lock` 冲突被静默丢弃的问题。
+
+一期目标是尽快止血，并为后续更通用的卡住诊断与恢复能力建设留出扩展点；不在本期重构 callback 事件模型，不引入全局事件排序语义。
+
+## 问题背景
+
+本次线上 case 体现出的核心问题链路如下：
+
+1. 独立子流程节点会收到多次 callback，至少包含失败态通知和最终完成通知
+2. `bamboo-engine` 对普通 `CALLBACK` 类型节点在 `schedule lock` 获取失败时直接返回，不会重试
+3. 当失败 callback 持锁较久、成功 callback 随后到达时，成功 callback 可能已经写入 `CallbackData`，但对应的 `schedule` 未被真正消费
+4. 父流程节点状态未能正确推进，后续容易衍生 `Process / State / Schedule / CallbackData` 漂移，人工误用 `runtime.execute()` 还会进一步放大问题
+
+## 一期目标
+
+- 修复独立子流程节点“最终成功 callback 因锁竞争静默丢失”的问题
+- 不扩大 `bamboo-engine` 对所有 `CALLBACK` 节点的既有行为面
+- 提供专用的竞态识别工具和安全重放工具，替代裸 `runtime.execute()` 人工恢复
+- 保持现网数据模型兼容，不引入必须的数据迁移
+
+## 非目标
+
+- 不做全局“最新 callback 胜出”的事件排序机制
+- 不把所有 `CALLBACK` 节点改造成可重试语义
+- 不在本期建设通用卡住分型平台和工作台
+- 不修改 `bk-sops` 的独立子流程业务语义和已有状态流转定义
+
+## 设计原则
+
+### 1. 优先修复 `bamboo-engine` 侧核心竞态
+
+真正导致成功 callback 丢失的根因在 `bamboo-engine` 的 `schedule lock` 冲突处理逻辑里，因此一期修复必须落在引擎侧。
+
+### 2. 默认关闭，按节点能力精确开启
+
+新增能力必须是 `bamboo-engine` 的通用扩展点，但默认关闭。一期仅允许独立子流程节点开启，且仅对 `task_success=True` 的 callback 生效。
+
+### 3. 不改主状态模型
+
+一期不增加 `Process / State / Schedule / CallbackData` 的状态字段和迁移，只通过调度行为补丁、日志与工具实现止血。
+
+### 4. 人工恢复必须走正式 callback 链路
+
+恢复工具只能走已有的 callback / schedule / state 逻辑，不允许用 `runtime.execute()` 直接推动汇聚或后继节点。
+
+## 方案设计
+
+## 一、`bamboo-engine` 运行时补丁
+
+### 1. 新增 Service 级扩展点
+
+在 `Service` 基类新增一个默认返回 `False` 的能力钩子：
+
+- 文件：`../bamboo-engine/runtime/bamboo-pipeline/pipeline/core/flow/activity/service_activity.py`
+- 方法：`callback_lock_retryable(callback_data=None)`
+
+用途：声明“当前 callback 在 `schedule lock` 冲突时是否允许有界重试”。
+
+### 2. 独立子流程节点开启该能力
+
+在 `SubprocessPluginService` 中重写该方法，仅当 callback payload 中 `task_success is True` 时返回 `True`。
+
+- 文件：`pipeline_plugins/components/collections/subprocess_plugin/v1_0_0.py`
+
+这样可以保证：
+
+- `task_success=False` 仍保持现有行为，不会因为一期补丁被重复放大
+- 只有“最终成功 callback”在锁竞争时得到一次补偿机会
+
+### 3. 调整 `Engine.schedule` 的锁冲突分支
+
+在 `../bamboo-engine/bamboo_engine/engine.py` 中：
+
+- 保留 `MULTIPLE_CALLBACK` 既有重试行为
+- 对普通 `CALLBACK` 节点，增加一段精确判定：
+  - 若存在 `callback_data_id`
+  - 且对应 service 声明 `callback_lock_retryable == True`
+  - 则允许对当前 callback 做有界重试
+- 重试次数放在 `headers` 中，不改数据库字段
+- 达到上限后记录错误日志并返回
+
+### 4. 一期不引入全局乱序仲裁
+
+本期不做 callback 序号、最新事件水位等机制，依赖现有门禁兜底：
+
+- `schedule.finished`
+- `state.version != schedule.version`
+- `state.name != RUNNING`
+
+这保证了旧 callback 就算重放，也不会越过已有状态门禁错误覆盖终态。
+
+## 二、`bk-sops` 工具补充
+
+### 1. 离线识别竞态候选
+
+新增管理命令，针对导出的任务关联记录识别“独立子流程 false/true callback 竞态”：
+
+- 文件：`gcloud/taskflow3/management/commands/analyze_subprocess_callback_race.py`
+
+识别特征包括：
+
+- 同一 `node_id + version` 下同时存在 `task_success=False/True`
+- `callback_data_count > schedule_times`
+- 节点仍有未结束 schedule
+- 节点状态仍为 `RUNNING / FAILED`
+
+### 2. 安全重放最新成功 callback
+
+新增管理命令，专用于独立子流程节点安全重放最新成功 callback：
+
+- 文件：`gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py`
+
+校验条件包括：
+
+- 当前任务为 engine v2
+- 当前节点是 `subprocess_plugin`
+- `state` 为 `RUNNING / FAILED`
+- `schedule` 未 finished
+- 当前节点能定位到唯一 sleep process
+- 存在最新成功 callback data
+
+如果节点当前为 `FAILED`，先按既有恢复语义把节点从 `FAILED -> READY -> RUNNING`，再通过 `NodeCommandDispatcher(...).dispatch(command="callback")` 进入正式 callback 链路。
+
+## 三、日志与观测
+
+一期不做完整埋点体系，但在引擎锁冲突分支补充足够的排障信息：
+
+- `callback_data_id`
+- `retry_count`
+- callback payload
+- retry exhausted 错误日志
+
+这样后续再遇到类似问题时，至少能明确回答：
+
+- 哪条 callback 因锁冲突进入重试
+- 是否达到重试上限
+- 当时的 callback payload 是失败还是成功
+
+## 影响范围评估
+
+### `bamboo-engine`
+
+- 改动仅落在 `schedule lock` 冲突分支
+- 默认行为不变
+- 仅当 service 显式声明可重试时，普通 `CALLBACK` 节点才会重试
+- 一期只有 `subprocess_plugin` 命中该逻辑
+
+### `bk-sops`
+
+- 独立子流程节点仅新增一个“成功 callback 可重试”的 service 级声明
+- 新增两个应急命令，不影响线上主流程执行
+- 未修改既有业务 API、前端、数据库模型
+
+## 风险与控制
+
+### 风险 1：旧 callback 乱序到达
+
+控制方式：
+
+- 仅对 `task_success=True` 开启重试
+- 保留现有 `schedule.finished / version mismatch / state not running` 门禁
+
+### 风险 2：把单次 callback 节点语义改宽
+
+控制方式：
+
+- 一期不修改全局 `CALLBACK` 语义
+- 仅通过 service 钩子对白名单节点生效
+
+### 风险 3：人工恢复误操作
+
+控制方式：
+
+- 官方恢复工具只支持独立子流程节点
+- 默认 `dry-run`
+- 必须通过安全校验才允许 `--apply`
+
+## 测试策略
+
+### `bamboo-engine`
+
+- `subprocess_plugin` 的 `false -> true` 锁冲突补偿路径
+- 重试达到上限后的退出路径
+- 普通 `CALLBACK` 节点在锁冲突时仍保持原行为
+
+### `bk-sops`
+
+- `SubprocessPluginService.callback_lock_retryable`
+- `analyze_subprocess_callback_race` 对竞态样本的识别
+- `replay_subprocess_success_callback` 的安全检查与恢复路径
+
+## 发布建议
+
+1. 先回修 `bamboo-engine` 对应线上 tag
+2. 同步落 `bk-sops` 的 service 适配和命令工具
+3. 灰度观察引擎日志中的 callback 重试信息
+4. 稳定后再评估同步到主干和其他维护分支

--- a/gcloud/taskflow3/management/commands/analyze_subprocess_callback_race.py
+++ b/gcloud/taskflow3/management/commands/analyze_subprocess_callback_race.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import json
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+from django.core.management import BaseCommand, CommandError
+from pipeline.eri.models import CallbackData, Process, Schedule, State
+
+from gcloud.taskflow3.models import TaskCallBackRecord
+
+
+class SubprocessCallbackRaceAnalyzer(object):
+    def __init__(self, payload):
+        self.payload = payload
+        self.tables = payload.get("tables", {})
+        self.callback_records = self._records(TaskCallBackRecord)
+        self.callback_data = self._records(CallbackData)
+        self.schedules = self._records(Schedule)
+        self.states = self._records(State)
+        self.processes = self._records(Process)
+
+        self.callback_data_by_node_version = defaultdict(list)
+        for record in self.callback_data:
+            self.callback_data_by_node_version[(record.get("node_id"), record.get("version"))].append(record)
+
+        self.active_schedules_by_node_version = defaultdict(list)
+        for schedule in self.schedules:
+            if schedule.get("finished") or schedule.get("expired"):
+                continue
+            self.active_schedules_by_node_version[(schedule.get("node_id"), schedule.get("version"))].append(schedule)
+
+        self.state_by_node_version = {(record.get("node_id"), record.get("version")): record for record in self.states}
+        self.live_processes_by_node_id = defaultdict(list)
+        for process in self.processes:
+            if process.get("dead"):
+                continue
+            self.live_processes_by_node_id[process.get("current_node_id")].append(process)
+
+    def analyze(self):
+        candidates = []
+
+        for record in self.callback_records:
+            callback_info = self._parse_json(record.get("extra_info"))
+            if not callback_info:
+                continue
+
+            node_id = callback_info.get("node_id")
+            version = callback_info.get("node_version")
+            if not node_id or not version:
+                continue
+
+            matched_callback_data = sorted(
+                self.callback_data_by_node_version.get((node_id, version), []),
+                key=lambda item: item.get("id", 0),
+            )
+            if len(matched_callback_data) < 2:
+                continue
+
+            latest_failed = None
+            latest_success = None
+            for callback_data in matched_callback_data:
+                callback_payload = self._parse_json(callback_data.get("data")) or {}
+                if callback_payload.get("task_success") is True:
+                    latest_success = callback_data
+                elif callback_payload.get("task_success") is False:
+                    latest_failed = callback_data
+
+            if not latest_failed or not latest_success:
+                continue
+
+            active_schedules = self.active_schedules_by_node_version.get((node_id, version), [])
+            total_schedule_times = sum(schedule.get("schedule_times") or 0 for schedule in active_schedules)
+            if total_schedule_times >= len(matched_callback_data):
+                continue
+
+            state = self.state_by_node_version.get((node_id, version)) or {}
+            live_processes = self.live_processes_by_node_id.get(node_id, [])
+
+            replay_blockers = []
+            if not active_schedules:
+                replay_blockers.append("当前节点没有未结束 schedule")
+            if len(live_processes) != 1:
+                replay_blockers.append("当前节点对应的存活 process 数量不是 1")
+            if state.get("name") not in {"RUNNING", "FAILED"}:
+                replay_blockers.append("当前节点状态不是 RUNNING/FAILED")
+
+            candidates.append(
+                {
+                    "task_id": record.get("task_id"),
+                    "callback_record_id": record.get("id"),
+                    "node_id": node_id,
+                    "version": version,
+                    "callback_data_count": len(matched_callback_data),
+                    "active_schedule_ids": [schedule.get("id") for schedule in active_schedules],
+                    "active_schedule_times": total_schedule_times,
+                    "latest_failed_callback_data_id": latest_failed.get("id"),
+                    "latest_success_callback_data_id": latest_success.get("id"),
+                    "state": state.get("name"),
+                    "live_process_ids": [process.get("id") for process in live_processes],
+                    "safe_to_replay": not replay_blockers,
+                    "replay_blockers": replay_blockers,
+                    "evidence": {
+                        "callback_record_status": record.get("status"),
+                        "callback_record_callback_time": record.get("callback_time"),
+                    },
+                }
+            )
+
+        candidates.sort(key=lambda item: (item["safe_to_replay"] is False, item["task_id"] or 0, item["node_id"]))
+        return {
+            "meta": {
+                "analyzed_at": datetime.now().isoformat(),
+                "command": "analyze_subprocess_callback_race",
+                "source_command": self.payload.get("meta", {}).get("command"),
+                "source_exported_at": self.payload.get("meta", {}).get("exported_at"),
+            },
+            "scope": self.payload.get("scope", {}),
+            "summary": {
+                "race_candidates": len(candidates),
+                "safe_to_replay": len([candidate for candidate in candidates if candidate["safe_to_replay"]]),
+                "unsafe_to_replay": len([candidate for candidate in candidates if not candidate["safe_to_replay"]]),
+            },
+            "candidates": candidates,
+        }
+
+    def _records(self, model):
+        table = self.tables.get(model._meta.db_table, {})
+        return list(table.get("records", []))
+
+    @staticmethod
+    def _parse_json(raw):
+        if isinstance(raw, dict):
+            return raw
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except Exception:
+            return {}
+
+
+class Command(BaseCommand):
+    help = "根据导出的任务关联记录，识别独立子流程 callback false/true 竞态及是否可安全重放"
+
+    def add_arguments(self, parser):
+        parser.add_argument("export_file", help="export_taskflow_related_records 生成的 JSON 文件路径")
+        parser.add_argument("--output", default="", help="分析结果输出目录或 JSON 文件路径，默认仅打印")
+
+    def handle(self, *args, **options):
+        export_file = Path(options["export_file"]).expanduser()
+        if not export_file.exists():
+            raise CommandError("export file {} does not exist".format(export_file))
+
+        payload = self._load_payload(export_file)
+        analysis = self.analyze_payload(payload)
+        self.stdout.write(json.dumps(analysis, ensure_ascii=False, indent=2))
+
+        if options["output"]:
+            output_path = self._resolve_output_path(options["output"], export_file)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(json.dumps(analysis, ensure_ascii=False, indent=2), encoding="utf-8")
+            self.stdout.write(self.style.SUCCESS("analysis also written to {}".format(output_path)))
+
+    @staticmethod
+    def _load_payload(export_file):
+        try:
+            payload = json.loads(export_file.read_text(encoding="utf-8"))
+        except Exception as e:
+            raise CommandError("failed to load export file {}: {}".format(export_file, e))
+
+        for key in ("meta", "scope", "tables"):
+            if key not in payload:
+                raise CommandError("export file {} missing key '{}'".format(export_file, key))
+        return payload
+
+    def analyze_payload(self, payload):
+        return SubprocessCallbackRaceAnalyzer(payload).analyze()
+
+    @staticmethod
+    def _resolve_output_path(output, export_file):
+        candidate = Path(output).expanduser()
+        if candidate.suffix.lower() == ".json":
+            return candidate
+        return candidate / "{}_subprocess_callback_race.json".format(export_file.stem)

--- a/gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py
+++ b/gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py
@@ -13,6 +13,7 @@ specific language governing permissions and limitations under the License.
 import json
 
 from bamboo_engine import states as bamboo_states
+from django.db import transaction
 from django.core.management import BaseCommand, CommandError
 from pipeline.eri.models import CallbackData
 from pipeline.eri.models import Schedule as DBSchedule
@@ -72,6 +73,8 @@ class Command(BaseCommand):
             blockers.append("当前节点状态不是 RUNNING/FAILED")
         if schedule.finished:
             blockers.append("当前 schedule 已 finished")
+        # expired schedule is replayable here: apply_replay will reactivate it before dispatching
+        # the latest success callback through the formal engine callback path.
         if process_info and getattr(task.pipeline_instance, "instance_id", None) != process_info.root_pipeline_id:
             blockers.append("任务实例与节点所属 root pipeline 不匹配")
 
@@ -107,11 +110,14 @@ class Command(BaseCommand):
 
         runtime = BambooDjangoRuntime()
         if candidate["state"] == bamboo_states.FAILED:
-            DBSchedule.objects.filter(id=candidate["schedule_id"]).update(expired=False)
-            runtime.set_state(node_id=candidate["node_id"], version=candidate["version"], to_state=bamboo_states.READY)
-            runtime.set_state(
-                node_id=candidate["node_id"], version=candidate["version"], to_state=bamboo_states.RUNNING
-            )
+            with transaction.atomic():
+                DBSchedule.objects.filter(id=candidate["schedule_id"]).update(expired=False)
+                runtime.set_state(
+                    node_id=candidate["node_id"], version=candidate["version"], to_state=bamboo_states.READY
+                )
+                runtime.set_state(
+                    node_id=candidate["node_id"], version=candidate["version"], to_state=bamboo_states.RUNNING
+                )
 
         dispatcher = NodeCommandDispatcher(
             engine_ver=candidate["engine_ver"],

--- a/gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py
+++ b/gcloud/taskflow3/management/commands/replay_subprocess_success_callback.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+import json
+
+from bamboo_engine import states as bamboo_states
+from django.core.management import BaseCommand, CommandError
+from pipeline.eri.models import CallbackData
+from pipeline.eri.models import Schedule as DBSchedule
+from pipeline.eri.runtime import BambooDjangoRuntime
+
+from gcloud.taskflow3.domains.dispatchers.node import NodeCommandDispatcher
+from gcloud.taskflow3.models import TaskFlowInstance
+
+
+class Command(BaseCommand):
+    help = "安全重放独立子流程节点最新一条成功 callback，默认 dry-run"
+
+    def add_arguments(self, parser):
+        parser.add_argument("task_id", type=int, help="父任务实例 ID")
+        parser.add_argument("node_id", help="独立子流程节点 ID")
+        parser.add_argument("--version", default="", help="节点版本，不传则取当前 State.version")
+        parser.add_argument("--apply", action="store_true", help="确认执行重放，默认仅检查不执行")
+
+    def handle(self, *args, **options):
+        candidate = self.inspect_candidate(options["task_id"], options["node_id"], options.get("version") or None)
+        self.stdout.write(json.dumps(candidate, ensure_ascii=False, indent=2))
+
+        if not options["apply"]:
+            return
+
+        if not candidate["safe_to_replay"]:
+            raise CommandError("candidate is not safe to replay: {}".format("; ".join(candidate["blockers"])))
+
+        result = self.apply_replay(candidate)
+        self.stdout.write(json.dumps(result, ensure_ascii=False, indent=2))
+
+    def inspect_candidate(self, task_id, node_id, version=None):
+        task = TaskFlowInstance.objects.filter(id=task_id).select_related("pipeline_instance").first()
+        if not task:
+            raise CommandError("taskflow instance {} does not exist".format(task_id))
+
+        runtime = BambooDjangoRuntime()
+        state = runtime.get_state(node_id)
+        version = version or state.version
+        node = runtime.get_node(node_id)
+        schedule = runtime.get_schedule_with_node_and_version(node_id, version)
+
+        blockers = []
+        process_info = None
+        try:
+            process_info = runtime.get_sleep_process_info_with_current_node_id(node_id)
+        except Exception as e:
+            blockers.append(str(e))
+
+        if task.engine_ver != 2:
+            blockers.append("仅支持 bamboo-engine v2 任务")
+        if getattr(node, "code", "") != "subprocess_plugin":
+            blockers.append("当前节点不是 subprocess_plugin")
+        if state.version != version:
+            blockers.append("当前 state.version 与待重放版本不一致")
+        if state.name not in {bamboo_states.RUNNING, bamboo_states.FAILED}:
+            blockers.append("当前节点状态不是 RUNNING/FAILED")
+        if schedule.finished:
+            blockers.append("当前 schedule 已 finished")
+        if process_info and getattr(task.pipeline_instance, "instance_id", None) != process_info.root_pipeline_id:
+            blockers.append("任务实例与节点所属 root pipeline 不匹配")
+
+        latest_success_callback = None
+        for callback_data in CallbackData.objects.filter(node_id=node_id, version=version).order_by("-id"):
+            payload = self._parse_json(callback_data.data)
+            if payload.get("task_success") is True:
+                latest_success_callback = {"id": callback_data.id, "data": payload}
+                break
+        if not latest_success_callback:
+            blockers.append("未找到可重放的成功 callback_data")
+
+        return {
+            "task_id": task.id,
+            "engine_ver": task.engine_ver,
+            "node_id": node_id,
+            "version": version,
+            "state": state.name,
+            "schedule_id": schedule.id,
+            "schedule_finished": schedule.finished,
+            "schedule_expired": schedule.expired,
+            "live_process_id": getattr(process_info, "process_id", None),
+            "root_pipeline_id": getattr(process_info, "root_pipeline_id", None),
+            "latest_success_callback_data_id": latest_success_callback["id"] if latest_success_callback else None,
+            "latest_success_callback_data": latest_success_callback["data"] if latest_success_callback else None,
+            "safe_to_replay": not blockers,
+            "blockers": blockers,
+        }
+
+    def apply_replay(self, candidate):
+        if not candidate["safe_to_replay"]:
+            raise CommandError("candidate is not safe to replay")
+
+        runtime = BambooDjangoRuntime()
+        if candidate["state"] == bamboo_states.FAILED:
+            DBSchedule.objects.filter(id=candidate["schedule_id"]).update(expired=False)
+            runtime.set_state(node_id=candidate["node_id"], version=candidate["version"], to_state=bamboo_states.READY)
+            runtime.set_state(
+                node_id=candidate["node_id"], version=candidate["version"], to_state=bamboo_states.RUNNING
+            )
+
+        dispatcher = NodeCommandDispatcher(
+            engine_ver=candidate["engine_ver"],
+            node_id=candidate["node_id"],
+            taskflow_id=candidate["task_id"],
+        )
+        return dispatcher.dispatch(
+            command="callback",
+            operator="system",
+            version=candidate["version"],
+            data=candidate["latest_success_callback_data"],
+        )
+
+    @staticmethod
+    def _parse_json(raw):
+        if isinstance(raw, dict):
+            return raw
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw)
+        except Exception:
+            return {}

--- a/gcloud/tests/taskflow3/commands/test_analyze_subprocess_callback_race.py
+++ b/gcloud/tests/taskflow3/commands/test_analyze_subprocess_callback_race.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+import json
+
+from django.test import SimpleTestCase
+from pipeline.eri.models import CallbackData, Process, Schedule, State
+
+from gcloud.taskflow3.management.commands.analyze_subprocess_callback_race import Command
+from gcloud.taskflow3.models import TaskCallBackRecord
+
+
+class AnalyzeSubprocessCallbackRaceCommandTestCase(SimpleTestCase):
+    @staticmethod
+    def _table(records):
+        return {"count": len(records), "records": records}
+
+    def test_analyze_payload_detects_subprocess_callback_race_candidate(self):
+        payload = {
+            "meta": {
+                "exported_at": "2026-04-22T10:00:00",
+                "command": "export_taskflow_related_records",
+                "engine_versions": [2],
+                "warnings": [],
+            },
+            "scope": {
+                "input_task_id": 129568046,
+                "root_task_id": 129568046,
+                "task_ids": [129568046, 129570155],
+                "pipeline_instance_ids": ["nbbf48c8619e3e858a338072abeb11f3"],
+                "node_ids": ["n954ea0446fb3641b5990232fc896259"],
+            },
+            "tables": {
+                TaskCallBackRecord._meta.db_table: self._table(
+                    [
+                        {
+                            "id": 269651,
+                            "task_id": 129570155,
+                            "url": "",
+                            "create_time": "2026-04-20T15:00:00",
+                            "status": "success",
+                            "extra_info": json.dumps(
+                                {
+                                    "source": "subprocess task 129570155",
+                                    "node_id": "n954ea0446fb3641b5990232fc896259",
+                                    "node_version": "v668546486bc04d1fa1733a596c49e9b2",
+                                    "engine_ver": 2,
+                                }
+                            ),
+                            "callback_time": "2026-04-20T15:13:58",
+                        }
+                    ]
+                ),
+                CallbackData._meta.db_table: self._table(
+                    [
+                        {
+                            "id": 234568504,
+                            "node_id": "n954ea0446fb3641b5990232fc896259",
+                            "version": "v668546486bc04d1fa1733a596c49e9b2",
+                            "data": json.dumps({"task_success": False, "task_id": 129570155}),
+                        },
+                        {
+                            "id": 234568563,
+                            "node_id": "n954ea0446fb3641b5990232fc896259",
+                            "version": "v668546486bc04d1fa1733a596c49e9b2",
+                            "data": json.dumps({"task_success": True, "task_id": 129570155}),
+                        },
+                    ]
+                ),
+                Schedule._meta.db_table: self._table(
+                    [
+                        {
+                            "id": 342957720,
+                            "type": 1,
+                            "process_id": 189270456,
+                            "node_id": "n954ea0446fb3641b5990232fc896259",
+                            "finished": False,
+                            "expired": False,
+                            "scheduling": False,
+                            "version": "v668546486bc04d1fa1733a596c49e9b2",
+                            "schedule_times": 1,
+                        }
+                    ]
+                ),
+                State._meta.db_table: self._table(
+                    [
+                        {
+                            "id": 1,
+                            "node_id": "n954ea0446fb3641b5990232fc896259",
+                            "root_id": "nbbf48c8619e3e858a338072abeb11f3",
+                            "parent_id": "nbbf48c8619e3e858a338072abeb11f3",
+                            "name": "FAILED",
+                            "version": "v668546486bc04d1fa1733a596c49e9b2",
+                            "loop": 1,
+                            "inner_loop": 1,
+                            "retry": 1,
+                            "skip": False,
+                            "error_ignored": False,
+                            "created_time": "2026-04-20T15:00:00",
+                            "started_time": "2026-04-20T15:00:00",
+                            "archived_time": "2026-04-20T15:13:57",
+                        }
+                    ]
+                ),
+                Process._meta.db_table: self._table(
+                    [
+                        {
+                            "id": 189270456,
+                            "parent_id": 189270383,
+                            "ack_num": 0,
+                            "need_ack": 0,
+                            "asleep": True,
+                            "suspended": False,
+                            "frozen": False,
+                            "dead": False,
+                            "last_heartbeat": "2026-04-20T15:14:00",
+                            "destination_id": "nb5f7a4c93ef37aca8ca721ae68d68af",
+                            "current_node_id": "n954ea0446fb3641b5990232fc896259",
+                            "root_pipeline_id": "nbbf48c8619e3e858a338072abeb11f3",
+                            "suspended_by": "",
+                        }
+                    ]
+                ),
+            },
+        }
+
+        analysis = Command().analyze_payload(payload)
+
+        self.assertEqual(analysis["summary"]["race_candidates"], 1)
+        candidate = analysis["candidates"][0]
+        self.assertEqual(candidate["node_id"], "n954ea0446fb3641b5990232fc896259")
+        self.assertEqual(candidate["version"], "v668546486bc04d1fa1733a596c49e9b2")
+        self.assertEqual(candidate["latest_success_callback_data_id"], 234568563)
+        self.assertEqual(candidate["latest_failed_callback_data_id"], 234568504)
+        self.assertTrue(candidate["safe_to_replay"])

--- a/gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py
+++ b/gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+import json
+from unittest.mock import MagicMock, patch
+
+from bamboo_engine import states as bamboo_states
+from django.test import SimpleTestCase
+
+from gcloud.taskflow3.management.commands.replay_subprocess_success_callback import Command
+
+
+class ReplaySubprocessSuccessCallbackCommandTestCase(SimpleTestCase):
+    @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.CallbackData")
+    @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.BambooDjangoRuntime")
+    @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.TaskFlowInstance")
+    def test_inspect_candidate_allows_failed_subprocess_node_with_latest_success_callback(
+        self, taskflow_cls, runtime_cls, callback_data_cls
+    ):
+        task = MagicMock()
+        task.id = 129568046
+        task.engine_ver = 2
+        task.pipeline_instance.instance_id = "nbbf48c8619e3e858a338072abeb11f3"
+        taskflow_cls.objects.filter.return_value.select_related.return_value.first.return_value = task
+
+        runtime = runtime_cls.return_value
+        state = MagicMock()
+        state.name = bamboo_states.FAILED
+        state.version = "v668546486bc04d1fa1733a596c49e9b2"
+        runtime.get_state.return_value = state
+        runtime.get_node.return_value = MagicMock(code="subprocess_plugin", version="1.0.0", name="subprocess")
+        runtime.get_schedule_with_node_and_version.return_value = MagicMock(id=342957720, finished=False, expired=True)
+        runtime.get_sleep_process_info_with_current_node_id.return_value = MagicMock(
+            process_id=189270456, root_pipeline_id="nbbf48c8619e3e858a338072abeb11f3"
+        )
+
+        callback_data_cls.objects.filter.return_value.order_by.return_value = [
+            MagicMock(id=234568563, data=json.dumps({"task_success": True, "task_id": 129570155})),
+            MagicMock(id=234568504, data=json.dumps({"task_success": False, "task_id": 129570155})),
+        ]
+
+        candidate = Command().inspect_candidate(129568046, "n954ea0446fb3641b5990232fc896259", None)
+
+        self.assertTrue(candidate["safe_to_replay"])
+        self.assertEqual(candidate["state"], bamboo_states.FAILED)
+        self.assertEqual(candidate["latest_success_callback_data_id"], 234568563)
+        self.assertEqual(candidate["schedule_id"], 342957720)
+        self.assertEqual(candidate["live_process_id"], 189270456)
+
+    @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.DBSchedule")
+    @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.NodeCommandDispatcher")
+    @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.BambooDjangoRuntime")
+    def test_apply_replay_restores_failed_node_before_dispatch(self, runtime_cls, dispatcher_cls, db_schedule_cls):
+        runtime = runtime_cls.return_value
+        dispatcher = dispatcher_cls.return_value
+        dispatcher.dispatch.return_value = {"result": True, "message": "ok", "data": None}
+
+        candidate = {
+            "task_id": 129568046,
+            "node_id": "n954ea0446fb3641b5990232fc896259",
+            "version": "v668546486bc04d1fa1733a596c49e9b2",
+            "state": bamboo_states.FAILED,
+            "schedule_id": 342957720,
+            "latest_success_callback_data_id": 234568563,
+            "latest_success_callback_data": {"task_success": True, "task_id": 129570155},
+            "engine_ver": 2,
+            "safe_to_replay": True,
+            "blockers": [],
+        }
+
+        result = Command().apply_replay(candidate)
+
+        db_schedule_cls.objects.filter.assert_called_once_with(id=342957720)
+        db_schedule_cls.objects.filter.return_value.update.assert_called_once_with(expired=False)
+        runtime.set_state.assert_any_call(
+            node_id="n954ea0446fb3641b5990232fc896259",
+            version="v668546486bc04d1fa1733a596c49e9b2",
+            to_state=bamboo_states.READY,
+        )
+        runtime.set_state.assert_any_call(
+            node_id="n954ea0446fb3641b5990232fc896259",
+            version="v668546486bc04d1fa1733a596c49e9b2",
+            to_state=bamboo_states.RUNNING,
+        )
+        dispatcher.dispatch.assert_called_once_with(
+            command="callback",
+            operator="system",
+            version="v668546486bc04d1fa1733a596c49e9b2",
+            data={"task_success": True, "task_id": 129570155},
+        )
+        self.assertEqual(result["message"], "ok")

--- a/gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py
+++ b/gcloud/tests/taskflow3/commands/test_replay_subprocess_success_callback.py
@@ -45,10 +45,13 @@ class ReplaySubprocessSuccessCallbackCommandTestCase(SimpleTestCase):
         self.assertEqual(candidate["schedule_id"], 342957720)
         self.assertEqual(candidate["live_process_id"], 189270456)
 
+    @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.transaction.atomic")
     @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.DBSchedule")
     @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.NodeCommandDispatcher")
     @patch("gcloud.taskflow3.management.commands.replay_subprocess_success_callback.BambooDjangoRuntime")
-    def test_apply_replay_restores_failed_node_before_dispatch(self, runtime_cls, dispatcher_cls, db_schedule_cls):
+    def test_apply_replay_restores_failed_node_before_dispatch(
+        self, runtime_cls, dispatcher_cls, db_schedule_cls, atomic
+    ):
         runtime = runtime_cls.return_value
         dispatcher = dispatcher_cls.return_value
         dispatcher.dispatch.return_value = {"result": True, "message": "ok", "data": None}
@@ -68,6 +71,7 @@ class ReplaySubprocessSuccessCallbackCommandTestCase(SimpleTestCase):
 
         result = Command().apply_replay(candidate)
 
+        atomic.assert_called_once_with()
         db_schedule_cls.objects.filter.assert_called_once_with(id=342957720)
         db_schedule_cls.objects.filter.return_value.update.assert_called_once_with(expired=False)
         runtime.set_state.assert_any_call(

--- a/pipeline_plugins/components/collections/subprocess_plugin/v1_0_0.py
+++ b/pipeline_plugins/components/collections/subprocess_plugin/v1_0_0.py
@@ -52,6 +52,9 @@ class SubprocessPluginService(BasePluginService):
     __need_schedule__ = True
     runtime = BambooDjangoRuntime()
 
+    def callback_lock_retryable(self, callback_data=None):
+        return bool(callback_data and callback_data.get("task_success") is True)
+
     def outputs_format(self):
         return [
             self.OutputItem(name="任务ID", key="task_id", type="int", schema=IntItemSchema(description="Task ID")),

--- a/pipeline_plugins/tests/components/collections/subprocess_plugin/test_v1_0_0.py
+++ b/pipeline_plugins/tests/components/collections/subprocess_plugin/test_v1_0_0.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from django.test import SimpleTestCase
+
+from pipeline_plugins.components.collections.subprocess_plugin.v1_0_0 import SubprocessPluginService
+
+
+class SubprocessPluginServiceTestCase(SimpleTestCase):
+    def test_callback_lock_retryable_only_for_success_callback(self):
+        service = SubprocessPluginService()
+
+        self.assertFalse(service.callback_lock_retryable(None))
+        self.assertFalse(service.callback_lock_retryable({}))
+        self.assertFalse(service.callback_lock_retryable({"task_success": False}))
+        self.assertTrue(service.callback_lock_retryable({"task_success": True}))

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pyinstrument==3.1.3
 djangorestframework==3.11.2
 django-filter==2.4.0
 prometheus-client==0.9.0
-bamboo-pipeline==3.24.2
+bamboo-pipeline==3.24.10
 drf-yasg==1.20.0
 typing-extensions==3.7.4.3
 pyyaml==5.4.1


### PR DESCRIPTION
## Summary
- 独立子流程组件仅对 `task_success=True` 的 callback 开启引擎侧锁冲突重试能力
- 新增竞态分析命令和安全回放命令，替代直接裸调 `runtime.execute()` 的恢复方式
- 补充一期实施文档和二期整体方向文档，沉淀这次流程卡住治理方案

## Test Plan
- [x] `direnv exec /Users/dengyh/Projects/bk-sops /Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test pipeline_plugins.tests.components.collections.subprocess_plugin.test_v1_0_0 gcloud.tests.taskflow3.commands.test_analyze_subprocess_callback_race gcloud.tests.taskflow3.commands.test_replay_subprocess_success_callback -v 2`