### PR TITLE
fix: optimize preview last execution lookup

### DIFF
--- a/gcloud/taskflow3/apis/django/api.py
+++ b/gcloud/taskflow3/apis/django/api.py
@@ -18,6 +18,7 @@ import ujson as json
 from blueapps.account.decorators import login_exempt
 from cryptography.fernet import Fernet
 from django.db import transaction
+from django.db.models import Max
 from django.http import JsonResponse
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
@@ -425,7 +426,7 @@ def preview_task_tree(request, project_id):
         logger.exception(message)
         return JsonResponse({"result": False, "message": message})
 
-    last_task = TaskFlowInstance.objects.filter(
+    last_task_id = TaskFlowInstance.objects.filter(
         project_id=project_id,
         template_id=str(template_id),
         template_source=template_source,
@@ -433,9 +434,9 @@ def preview_task_tree(request, project_id):
         is_child_taskflow=False,
         pipeline_instance__is_started=True,
         pipeline_instance__isnull=False,
-    ).order_by("-id").only("id").first()
+    ).aggregate(max_id=Max("id"))["max_id"]
 
-    data["last_execution_id"] = last_task.id if last_task else None
+    data["last_execution_id"] = last_task_id
 
     return JsonResponse({"result": True, "data": data})
 
@@ -446,7 +447,7 @@ def last_execution_constants(request, project_id):
     template_id = request.GET.get("template_id")
     template_source = request.GET.get("template_source", PROJECT)
 
-    last_task = TaskFlowInstance.objects.filter(
+    last_task_id = TaskFlowInstance.objects.filter(
         project_id=project_id,
         template_id=str(template_id),
         template_source=template_source,
@@ -454,9 +455,21 @@ def last_execution_constants(request, project_id):
         is_child_taskflow=False,
         pipeline_instance__is_started=True,
         pipeline_instance__isnull=False,
-    ).order_by("-id").select_related("pipeline_instance").first()
+    ).aggregate(max_id=Max("id"))["max_id"]
 
-    if not last_task or not last_task.pipeline_instance:
+    if not last_task_id:
+        return JsonResponse(
+            {"result": False, "message": _("没有历史执行记录"), "code": err_code.CONTENT_NOT_EXIST.code, "data": None}
+        )
+
+    try:
+        last_task = TaskFlowInstance.objects.select_related("pipeline_instance").get(id=last_task_id)
+    except TaskFlowInstance.DoesNotExist:
+        return JsonResponse(
+            {"result": False, "message": _("没有历史执行记录"), "code": err_code.CONTENT_NOT_EXIST.code, "data": None}
+        )
+
+    if not last_task.pipeline_instance:
         return JsonResponse(
             {"result": False, "message": _("没有历史执行记录"), "code": err_code.CONTENT_NOT_EXIST.code, "data": None}
         )

--- a/gcloud/taskflow3/apis/drf/viewsets/preview_task_tree.py
+++ b/gcloud/taskflow3/apis/drf/viewsets/preview_task_tree.py
@@ -12,20 +12,20 @@ specific lan
 """
 
 import logging
-from rest_framework import serializers
-from rest_framework.views import APIView
+
+from django.db.models import Max
+from django.utils.translation import ugettext_lazy as _
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import permissions, serializers
 from rest_framework.decorators import action
-from rest_framework import permissions
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from gcloud.common_template.models import CommonTemplate
 from gcloud.constants import PROJECT
-from drf_yasg.utils import swagger_auto_schema
-
-from gcloud.tasktmpl3.models import TaskTemplate
 from gcloud.taskflow3.models import TaskFlowInstance
+from gcloud.tasktmpl3.models import TaskTemplate
 from pipeline_web.preview import preview_template_tree_with_schemes
-from django.utils.translation import ugettext_lazy as _
 
 logger = logging.getLogger("root")
 
@@ -92,7 +92,7 @@ class PreviewTaskTreeWithSchemesView(APIView):
             return Response({"result": False, "message": message, "data": {}})
 
         if project_id:
-            last_task = TaskFlowInstance.objects.filter(
+            last_task_id = TaskFlowInstance.objects.filter(
                 project_id=project_id,
                 template_id=str(template_id),
                 template_source=template_source,
@@ -100,8 +100,8 @@ class PreviewTaskTreeWithSchemesView(APIView):
                 is_child_taskflow=False,
                 pipeline_instance__is_started=True,
                 pipeline_instance__isnull=False,
-            ).order_by("-id").only("id").first()
-            data["last_execution_id"] = last_task.id if last_task else None
+            ).aggregate(max_id=Max("id"))["max_id"]
+            data["last_execution_id"] = last_task_id
         else:
             data["last_execution_id"] = None
 

--- a/gcloud/tests/taskflow3/test_api.py
+++ b/gcloud/tests/taskflow3/test_api.py
@@ -178,9 +178,7 @@ class APITest(TestCase):
     @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
     @mock.patch("gcloud.taskflow3.apis.django.api.TaskFlowInstance.objects.filter")
     def test_preview_task_tree__last_execution_id_exists(self, mock_filter):
-        mock_task = MagicMock()
-        mock_task.id = 999
-        mock_filter.return_value.order_by.return_value.only.return_value.first.return_value = mock_task
+        mock_filter.return_value.aggregate.return_value = {"max_id": 999}
 
         with mock.patch(
             TASKTEMPLATE_GET, MagicMock(return_value=MockBaseTemplate(id=1, pipeline_tree=deepcopy(TEST_PIPELINE_TREE)))
@@ -194,11 +192,12 @@ class APITest(TestCase):
             result = api.preview_task_tree(MockJsonBodyRequest("POST", data), TEST_PROJECT_ID)
             self.assertTrue(result["result"])
             self.assertEqual(result["data"]["last_execution_id"], 999)
+            mock_filter.return_value.aggregate.assert_called_once()
 
     @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
     @mock.patch("gcloud.taskflow3.apis.django.api.TaskFlowInstance.objects.filter")
     def test_preview_task_tree__last_execution_id_none(self, mock_filter):
-        mock_filter.return_value.order_by.return_value.only.return_value.first.return_value = None
+        mock_filter.return_value.aggregate.return_value = {"max_id": None}
 
         with mock.patch(
             TASKTEMPLATE_GET, MagicMock(return_value=MockBaseTemplate(id=1, pipeline_tree=deepcopy(TEST_PIPELINE_TREE)))
@@ -214,8 +213,9 @@ class APITest(TestCase):
             self.assertIsNone(result["data"]["last_execution_id"])
 
     @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
+    @mock.patch("gcloud.taskflow3.apis.django.api.TaskFlowInstance.objects.select_related")
     @mock.patch("gcloud.taskflow3.apis.django.api.TaskFlowInstance.objects.filter")
-    def test_last_execution_constants__success(self, mock_filter):
+    def test_last_execution_constants__success(self, mock_filter, mock_select_related):
         mock_pipeline_instance = MagicMock()
         mock_pipeline_instance.execution_data = {
             "constants": {
@@ -245,7 +245,8 @@ class APITest(TestCase):
         mock_task.id = 123
         mock_task.pipeline_instance = mock_pipeline_instance
 
-        mock_filter.return_value.order_by.return_value.select_related.return_value.first.return_value = mock_task
+        mock_filter.return_value.aggregate.return_value = {"max_id": 123}
+        mock_select_related.return_value.get.return_value = mock_task
 
         request = MockJsonBodyRequest("GET", {})
         request.GET = {"template_id": "1", "template_source": "project"}
@@ -261,11 +262,14 @@ class APITest(TestCase):
         self.assertEqual(returned_ip["value"], "10.0.0.1")
         self.assertEqual(returned_ip["name"], "目标IP")
         self.assertEqual(returned_ip["custom_type"], "input")
+        mock_filter.return_value.aggregate.assert_called_once()
+        mock_select_related.assert_called_once_with("pipeline_instance")
+        mock_select_related.return_value.get.assert_called_once_with(id=123)
 
     @mock.patch("gcloud.taskflow3.apis.django.api.JsonResponse", MockJsonResponse())
     @mock.patch("gcloud.taskflow3.apis.django.api.TaskFlowInstance.objects.filter")
     def test_last_execution_constants__no_history(self, mock_filter):
-        mock_filter.return_value.order_by.return_value.select_related.return_value.first.return_value = None
+        mock_filter.return_value.aggregate.return_value = {"max_id": None}
 
         request = MockJsonBodyRequest("GET", {})
         request.GET = {"template_id": "1", "template_source": "project"}

--- a/gcloud/tests/taskflow3/test_preview_task_tree_with_schemes.py
+++ b/gcloud/tests/taskflow3/test_preview_task_tree_with_schemes.py
@@ -7,15 +7,12 @@ from gcloud.taskflow3.apis.drf.viewsets.preview_task_tree import PreviewTaskTree
 
 
 class PreviewTaskTreeWithSchemesLastExecutionTest(TestCase):
-
     @mock.patch("gcloud.taskflow3.apis.drf.viewsets.preview_task_tree.preview_template_tree_with_schemes")
     @mock.patch("gcloud.taskflow3.apis.drf.viewsets.preview_task_tree.TaskFlowInstance.objects.filter")
     @mock.patch("gcloud.taskflow3.apis.drf.viewsets.preview_task_tree.TaskTemplate.objects.get")
     def test_last_execution_id_with_project_id(self, mock_tmpl_get, mock_filter, mock_preview):
         mock_preview.return_value = {"pipeline_tree": {}, "constants_not_referred": {}}
-        mock_task = mock.MagicMock()
-        mock_task.id = 888
-        mock_filter.return_value.order_by.return_value.only.return_value.first.return_value = mock_task
+        mock_filter.return_value.aggregate.return_value = {"max_id": 888}
 
         request = mock.MagicMock()
         request.data = {
@@ -33,6 +30,7 @@ class PreviewTaskTreeWithSchemesLastExecutionTest(TestCase):
 
         self.assertTrue(response.data["result"])
         self.assertEqual(response.data["data"]["last_execution_id"], 888)
+        mock_filter.return_value.aggregate.assert_called_once()
 
     @mock.patch("gcloud.taskflow3.apis.drf.viewsets.preview_task_tree.preview_template_tree_with_schemes")
     @mock.patch("gcloud.taskflow3.apis.drf.viewsets.preview_task_tree.CommonTemplate.objects.get")


### PR DESCRIPTION
## Summary
- replace `order_by("-id").first()` lookups for latest task execution with `aggregate(Max("id"))`
- apply the change in `preview_task_tree`, `preview_task_tree_with_schemes`, and `last_execution_constants`
- update related tests to match the new query flow

## Root Cause
The slow path was not `preview_template_tree_with_schemes` itself. The hot query was the latest execution lookup on `taskflow3_taskflowinstance`.

For the affected template, the query shaped like:

```sql
... WHERE project_id = ? AND template_id = ? AND template_source = ? AND ...
ORDER BY id DESC LIMIT 1
```

could pick a bad execution plan and scan through the primary key in reverse order. In the online verification shared in investigation:
- original query: about 31s
- `FORCE INDEX` on the dedicated composite index: about 11ms
- `MAX(id)` rewrite: about 102ms

This change avoids the `ORDER BY ... LIMIT 1` plan choice while keeping the behavior equivalent.

## Verification
- `python -m py_compile gcloud/taskflow3/apis/django/api.py gcloud/taskflow3/apis/drf/viewsets/preview_task_tree.py gcloud/tests/taskflow3/test_api.py gcloud/tests/taskflow3/test_preview_task_tree_with_schemes.py`
- `git diff --check`

## Limitations
- Full Django tests were not runnable in this environment because local MySQL was unavailable.

TAPD: https://tapd.woa.com/10131351/bugtrace/bugs/view/1010131351157241928