### PR TITLE
fix: 升级 bamboo-pipeline 依赖到 3.24.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pyinstrument==3.1.3
 djangorestframework==3.11.2
 django-filter==2.4.0
 prometheus-client==0.9.0
-bamboo-pipeline==3.24.10
+bamboo-pipeline==3.24.11
 drf-yasg==1.20.0
 typing-extensions==3.7.4.3
 pyyaml==5.4.1


### PR DESCRIPTION
## 变更说明

- 将 `bamboo-pipeline` 依赖从 `3.24.10` 升级到 `3.24.11`。
- `3.24.11` 包含 callback 锁重试的 `ServiceWrapper` 转发修复，以及普通 `CALLBACK` 的递增式重试延迟优化。

## 验证

- `git diff --check`
- `rg -n "bamboo-pipeline==" requirements.txt`

说明：本次只修改 `requirements.txt` 一行依赖版本。

bug: 1010131351157180998