### PR TITLE
[codex] 优化任务列表关键词筛选执行计划

### DIFF
--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -344,7 +344,12 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
             self.paginator.offset = self.paginator.get_offset(request)
             self.paginator.count = -1
             self.paginator.request = request
-            page = list(queryset[self.paginator.offset : self.paginator.offset + self.paginator.limit])
+            if self._should_ignore_primary_index_for_task_list(request):
+                page = TaskFlowInstance.objects.fetch_task_list_page_ignore_primary_index(
+                    queryset=queryset, limit=self.paginator.limit, offset=self.paginator.offset
+                )
+            else:
+                page = list(queryset[self.paginator.offset : self.paginator.offset + self.paginator.limit])
         else:
             page = self.paginate_queryset(queryset)
 
@@ -561,6 +566,18 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
         new_query = re.sub("ORDER BY (.*?) DESC", "ORDER BY `pipeline_pipelineinstance`.`create_time` DESC", new_query)
         new_query += f" LIMIT {limit} OFFSET {offset}"
         return TaskFlowInstance.objects.raw(new_query, params)
+
+    @staticmethod
+    def _should_ignore_primary_index_for_task_list(request):
+        """
+        优化任务列表按名称关键词检索时 MySQL 误选 PRIMARY 倒序扫描的问题。
+        """
+        query_params = request.query_params
+        return bool(
+            query_params.get("project__id")
+            and query_params.get("pipeline_instance__name__icontains")
+            and not query_params.get("order_by")
+        )
 
     @swagger_auto_schema(
         method="GET",

--- a/gcloud/taskflow3/models.py
+++ b/gcloud/taskflow3/models.py
@@ -569,6 +569,26 @@ class TaskFlowStatisticsMixin(ClassificationCountMixin):
 
 
 class TaskFlowInstanceManager(models.Manager, TaskFlowStatisticsMixin):
+    TASKFLOW_INSTANCE_TABLE_SQL = "`taskflow3_taskflowinstance`"
+    IGNORE_PRIMARY_INDEX_HINT_SQL = "IGNORE INDEX (`PRIMARY`)"
+
+    @classmethod
+    def _inject_ignore_primary_index_hint(cls, sql):
+        table_with_hint = "{} {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL, cls.IGNORE_PRIMARY_INDEX_HINT_SQL)
+        if table_with_hint in sql:
+            return sql
+
+        return sql.replace("FROM {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL), "FROM {}".format(table_with_hint), 1)
+
+    def fetch_task_list_page_ignore_primary_index(self, queryset, limit, offset):
+        sliced_queryset = queryset[offset : offset + limit]
+        if connection.vendor != "mysql":
+            return list(sliced_queryset)
+
+        sql, params = sliced_queryset.query.sql_with_params()
+        sql = self._inject_ignore_primary_index_hint(sql)
+        return list(self.raw(sql, params))
+
     @staticmethod
     def create_pipeline_instance(template, **kwargs):
         independent_subprocess = kwargs.pop(

--- a/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
@@ -21,6 +21,7 @@ from django_test_toolkit.mixins.account import SuperUserMixin
 from django_test_toolkit.mixins.blueking import LoginExemptMixin, StandardResponseAssertionMixin
 from django_test_toolkit.mixins.drf import DrfPermissionExemptMixin
 from django_test_toolkit.testcases import ToolkitApiTestCase
+from mock import patch
 from pipeline.eri.models import State
 from pipeline.models import PipelineInstance, PipelineTemplate, Snapshot
 
@@ -135,6 +136,26 @@ class TestTaskInstanceView(
         resp = self.client.get(path=self.task_url, data=query_params)
         self.assertTrue(resp.data["result"])
         self.assertEqual(resp.data["data"]["count"], 1)
+
+    def test_task_name_search_without_count_uses_ignore_primary_index_hint(self):
+        query_params = {
+            "project__id": self.test_project.id,
+            "pipeline_instance__name__icontains": "tlogd",
+            "is_child_taskflow": False,
+            "without_count": True,
+            "limit": 15,
+            "offset": 0,
+        }
+
+        with patch.object(
+            TaskFlowInstance.objects, "fetch_task_list_page_ignore_primary_index", return_value=[]
+        ) as mock_fetch:
+            resp = self.client.get(path=self.task_url, data=query_params)
+
+        self.assertTrue(resp.data["result"])
+        mock_fetch.assert_called_once()
+        self.assertEqual(mock_fetch.call_args[1]["limit"], 15)
+        self.assertEqual(mock_fetch.call_args[1]["offset"], 0)
 
     def test_task_list_filter_days_disabled(self):
         """测试当项目配置了 task_list_filter_days 为 False 时，跳过日期过滤"""

--- a/gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
+++ b/gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017-2022 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.test import SimpleTestCase
+from mock import patch
+
+from gcloud.taskflow3.models import TaskFlowInstance
+
+
+class MockQuery(object):
+    def __init__(self, sql, params):
+        self.sql = sql
+        self.params = params
+
+    def sql_with_params(self):
+        return self.sql, self.params
+
+
+class MockSlicedQuerySet(object):
+    def __init__(self, sql, params, rows=None):
+        self.query = MockQuery(sql, params)
+        self.rows = rows or []
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class MockQuerySet(object):
+    def __init__(self, sql, params, rows=None):
+        self.sliced_queryset = MockSlicedQuerySet(sql, params, rows)
+        self.used_slice = None
+
+    def __getitem__(self, used_slice):
+        self.used_slice = used_slice
+        return self.sliced_queryset
+
+
+class TaskFlowInstanceManagerTestCase(SimpleTestCase):
+    def test_fetch_task_list_page_ignore_primary_index_injects_mysql_index_hint(self):
+        sql = (
+            "SELECT `taskflow3_taskflowinstance`.`id` "
+            "FROM `taskflow3_taskflowinstance` "
+            "INNER JOIN `pipeline_pipelineinstance` "
+            "ON (`taskflow3_taskflowinstance`.`pipeline_instance_id` = `pipeline_pipelineinstance`.`id`) "
+            "ORDER BY `taskflow3_taskflowinstance`.`id` DESC LIMIT 15"
+        )
+        params = ["%tlogd%"]
+        queryset = MockQuerySet(sql, params)
+
+        with patch("gcloud.taskflow3.models.connection.vendor", "mysql"):
+            with patch.object(TaskFlowInstance.objects, "raw", return_value=["row"]) as mock_raw:
+                result = TaskFlowInstance.objects.fetch_task_list_page_ignore_primary_index(
+                    queryset=queryset, limit=15, offset=5
+                )
+
+        expected_sql = sql.replace(
+            "FROM `taskflow3_taskflowinstance`",
+            "FROM `taskflow3_taskflowinstance` IGNORE INDEX (`PRIMARY`)",
+            1,
+        )
+        self.assertEqual(result, ["row"])
+        self.assertEqual(queryset.used_slice, slice(5, 20, None))
+        mock_raw.assert_called_once_with(expected_sql, params)
+
+    def test_fetch_task_list_page_ignore_primary_index_falls_back_for_non_mysql(self):
+        sql = "SELECT `taskflow3_taskflowinstance`.`id` FROM `taskflow3_taskflowinstance`"
+        queryset = MockQuerySet(sql, [], rows=["row"])
+
+        with patch("gcloud.taskflow3.models.connection.vendor", "sqlite"):
+            with patch.object(TaskFlowInstance.objects, "raw") as mock_raw:
+                result = TaskFlowInstance.objects.fetch_task_list_page_ignore_primary_index(
+                    queryset=queryset, limit=15, offset=0
+                )
+
+        self.assertEqual(result, ["row"])
+        self.assertEqual(queryset.used_slice, slice(0, 15, None))
+        mock_raw.assert_not_called()


### PR DESCRIPTION
## 变更说明

任务列表在 `without_count` 分页场景下，如果按项目和任务名称关键词过滤，MySQL 可能为了满足 `ORDER BY id DESC LIMIT` 误选 `PRIMARY` 倒序扫描。对于命中稀疏的关键词，需要扫描大量候选行才能凑够第一页数据，导致接口明显变慢。

本次在任务列表的窄场景中注入 `IGNORE INDEX (PRIMARY)`，让优化器避开主键倒序扫描，回到项目维度索引执行。该逻辑封装在 `TaskFlowInstanceManager`，非 MySQL 环境回退普通 QuerySet 切片。

## 影响范围

只影响任务列表接口中同时满足以下条件的查询：

- `without_count`
- `project__id`
- `pipeline_instance__name__icontains`
- 未显式传入 `order_by`

## 验证

- 线上 case 手工验证：`tlogd` 查询 default 约 8.3s，`IGNORE INDEX(PRIMARY)` 约 0.075s，返回首尾数据一致。
- `python -m py_compile gcloud/taskflow3/models.py gcloud/core/apis/drf/viewsets/taskflow.py gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py`
- `git diff --check -- gcloud/taskflow3/models.py gcloud/core/apis/drf/viewsets/taskflow.py gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py`
- `python manage.py test gcloud.tests.taskflow3.models.test_taskflow_instance_manager gcloud.tests.core.apis.drf.views_set.test_task_instance_view.TestTaskInstanceView.test_task_name_search_without_count_uses_ignore_primary_index_hint --keepdb -v 1`

目标测试运行结果：`Ran 3 tests ... OK`。