### PR TITLE
perf: 优化 APIGW 任务列表分页查询

### DIFF
--- a/gcloud/apigw/views/get_task_list.py
+++ b/gcloud/apigw/views/get_task_list.py
@@ -26,6 +26,17 @@ from gcloud.iam_auth.view_interceptors.apigw import ProjectViewInterceptor
 from gcloud.taskflow3.models import TaskFlowInstance
 
 
+def _fetch_ordered_task_details_by_id_queryset(task_ids_queryset):
+    task_ids = list(task_ids_queryset)
+    if not task_ids:
+        return []
+
+    task_map = {
+        task.id: task for task in TaskFlowInstance.objects.select_related("pipeline_instance").filter(id__in=task_ids)
+    }
+    return [task_map[task_id] for task_id in task_ids]
+
+
 @login_exempt
 @require_GET
 @apigw_require
@@ -59,14 +70,15 @@ def get_task_list(request, project_id):
     if "create_time_end" in request.GET and params_validator.cleaned_data.get("create_time_end"):
         filter_kwargs["pipeline_instance__create_time__lte"] = params_validator.cleaned_data["create_time_end"]
 
-    tasks = TaskFlowInstance.objects.select_related("pipeline_instance").filter(**filter_kwargs)
+    tasks = TaskFlowInstance.objects.filter(**filter_kwargs)
 
     try:
         without_count = params_validator.cleaned_data["without_count"]
-        tasks, count = paginate_list_data(request, tasks, without_count)
+        task_ids_queryset, count = paginate_list_data(request, tasks.values_list("id", flat=True), without_count)
     except Exception as e:
         return {"result": False, "data": "", "message": e, "code": err_code.INVALID_OPERATION.code}
 
+    tasks = _fetch_ordered_task_details_by_id_queryset(task_ids_queryset)
     task_list, task_id_list = format_task_list_data(tasks, project, True, request.tz)
     # 注入用户有权限的action
 

--- a/gcloud/tests/apigw/views/test_get_task_list.py
+++ b/gcloud/tests/apigw/views/test_get_task_list.py
@@ -12,18 +12,21 @@ specific language governing permissions and limitations under the License.
 """
 
 
+import unittest
+
 import ujson as json
 
-
+from gcloud.apigw.views.get_task_list import TASK_ACTIONS, _fetch_ordered_task_details_by_id_queryset
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
-from gcloud.apigw.views.get_task_list import TASK_ACTIONS
 
-from .utils import APITest, TEST_USERNAME
-
+from .utils import TEST_USERNAME, APITest
 
 MOCK_FORMAT_TASK_LIST_DATA = "gcloud.apigw.views.get_task_list.format_task_list_data"
 MOCK_GET_TASK_ALLOWED_ACTIONS = "gcloud.apigw.views.get_task_list.get_task_allowed_actions_for_user"
+MOCK_PAGINATE_LIST_DATA = "gcloud.apigw.views.get_task_list.paginate_list_data"
+MOCK_FETCH_ORDERED_TASK_DETAILS = "gcloud.apigw.views.get_task_list._fetch_ordered_task_details_by_id_queryset"
+MOCK_TASKFLOW_FILTER = "gcloud.apigw.views.get_task_list.TaskFlowInstance.objects.filter"
 
 TEST_PROJECT_ID = "123"
 TEST_PROJECT_NAME = "biz name"
@@ -36,6 +39,9 @@ TEST_ALLOWED_ACTIONS = {
     "1": {"TEST_ACTION": True},
     "2": {"TEST_ACTION": True},
 }
+TEST_TASKS = [MagicMock(id=1), MagicMock(id=2)]
+TEST_TASK_IDS_QUERYSET = [1, 2]
+TEST_COUNT = 2
 
 
 class GetTaskListAPITest(APITest):
@@ -55,29 +61,76 @@ class GetTaskListAPITest(APITest):
     )
     @mock.patch(TASKINSTANCE_GET, MagicMock(return_value=MockQuerySet()))
     def test_get_task_list__success(self):
-        with mock.patch(
-            MOCK_FORMAT_TASK_LIST_DATA, MagicMock(return_value=(TEST_TASK_LIST, TEST_TASK_ID_LIST))
-        ) as mocked_format_task_list_data:
+        id_queryset = MagicMock()
+        task_queryset = MagicMock()
+        task_queryset.values_list.return_value = id_queryset
+        with mock.patch(MOCK_TASKFLOW_FILTER, MagicMock(return_value=task_queryset)):
             with mock.patch(
-                MOCK_GET_TASK_ALLOWED_ACTIONS, MagicMock(return_value=TEST_ALLOWED_ACTIONS)
-            ) as mocked_get_task_allowed_data:
-                response = self.client.get(
-                    path=self.url().format(project_id=TEST_PROJECT_ID),
-                    data={"is_started": "true", "is_finished": "false"},
-                    HTTP_BK_APP_CODE=TEST_APP_CODE,
-                    HTTP_BK_USERNAME=TEST_USERNAME,
-                )
+                MOCK_PAGINATE_LIST_DATA, MagicMock(return_value=(TEST_TASK_IDS_QUERYSET, TEST_COUNT))
+            ) as mocked_paginate:
+                with mock.patch(
+                    MOCK_FETCH_ORDERED_TASK_DETAILS, MagicMock(return_value=TEST_TASKS)
+                ) as mocked_fetch_tasks:
+                    with mock.patch(
+                        MOCK_FORMAT_TASK_LIST_DATA, MagicMock(return_value=(TEST_TASK_LIST, TEST_TASK_ID_LIST))
+                    ) as mocked_format_task_list_data:
+                        with mock.patch(
+                            MOCK_GET_TASK_ALLOWED_ACTIONS, MagicMock(return_value=TEST_ALLOWED_ACTIONS)
+                        ) as mocked_get_task_allowed_data:
+                            response = self.client.get(
+                                path=self.url().format(project_id=TEST_PROJECT_ID),
+                                data={"is_started": "true", "is_finished": "false"},
+                                HTTP_BK_APP_CODE=TEST_APP_CODE,
+                                HTTP_BK_USERNAME=TEST_USERNAME,
+                            )
 
-                mocked_format_task_list_data.assert_called_once()
-                mocked_get_task_allowed_data.assert_called_once_with(TEST_USERNAME, TASK_ACTIONS, TEST_TASK_ID_LIST)
+                            task_queryset.values_list.assert_called_once_with("id", flat=True)
+                            self.assertIs(mocked_paginate.call_args[0][1], id_queryset)
+                            mocked_fetch_tasks.assert_called_once_with(TEST_TASK_IDS_QUERYSET)
+                            mocked_format_task_list_data.assert_called_once()
+                            mocked_get_task_allowed_data.assert_called_once_with(
+                                TEST_USERNAME, TASK_ACTIONS, TEST_TASK_ID_LIST
+                            )
 
-                assert_data = [
-                    {"id": "1", "auth_actions": ["TEST_ACTION"]},
-                    {"id": "2", "auth_actions": ["TEST_ACTION"]},
-                ]
+                            assert_data = [
+                                {"id": "1", "auth_actions": ["TEST_ACTION"]},
+                                {"id": "2", "auth_actions": ["TEST_ACTION"]},
+                            ]
 
-                response = json.loads(response.content)
+                            response = json.loads(response.content)
 
-                self.assertTrue(response["result"])
-                self.assertEqual(response["data"], assert_data)
-                self.assertEqual(response["code"], SUCCESS_CODE)
+                            self.assertTrue(response["result"])
+                            self.assertEqual(response["data"], assert_data)
+                            self.assertEqual(response["count"], TEST_COUNT)
+                            self.assertEqual(response["code"], SUCCESS_CODE)
+
+
+class MockTask:
+    def __init__(self, task_id):
+        self.id = task_id
+
+
+class FetchOrderedTaskDetailsTest(unittest.TestCase):
+    def test_fetch_ordered_task_details_by_id_queryset__preserve_page_order(self):
+        task_ids = [3, 1, 2]
+        task_1 = MockTask(1)
+        task_2 = MockTask(2)
+        task_3 = MockTask(3)
+        detail_queryset = MagicMock()
+        detail_queryset.filter.return_value = [task_1, task_2, task_3]
+
+        with mock.patch("gcloud.apigw.views.get_task_list.TaskFlowInstance.objects.select_related") as select_related:
+            select_related.return_value = detail_queryset
+
+            tasks = _fetch_ordered_task_details_by_id_queryset(task_ids)
+
+        select_related.assert_called_once_with("pipeline_instance")
+        detail_queryset.filter.assert_called_once_with(id__in=task_ids)
+        self.assertEqual(tasks, [task_3, task_1, task_2])
+
+    def test_fetch_ordered_task_details_by_id_queryset__empty_page(self):
+        with mock.patch("gcloud.apigw.views.get_task_list.TaskFlowInstance.objects.select_related") as select_related:
+            tasks = _fetch_ordered_task_details_by_id_queryset([])
+
+        select_related.assert_not_called()
+        self.assertEqual(tasks, [])


### PR DESCRIPTION
## 变更说明

- 优化 APIGW `get_task_list` 分页查询逻辑。
- 将原来的宽表 `select_related("pipeline_instance")` 后直接分页，调整为：
  1. 先基于完全相同的过滤条件分页查询任务 `id`；
  2. 再按当前页 `id` 查询任务详情和关联的 pipeline 实例；
  3. 按第一页 `id` 顺序重新组装任务列表。
- 对外接口入参、返回字段、`count` / `without_count` 语义保持不变。

## 背景

在部分业务下，APIGW 任务列表接口带大量 `template_id` 过滤时，原 SQL 会出现宽 JOIN 分页慢查询。实测同一个 case 中，两阶段查询能显著降低分页取数耗时，并保持返回 ID 顺序一致。

## 兼容性

- 没有修改 API 路由、参数、响应结构或文档定义。
- 第二阶段查询后按第一页 `id` 顺序还原，避免 `id__in` 查询返回顺序不稳定导致接口返回顺序变化。
- `format_task_list_data` 仍复用原逻辑，确保最终返回结构与原来一致。

## 测试

已执行：

- `PYENV_VERSION=3.6.15 python -m py_compile gcloud/apigw/views/get_task_list.py gcloud/tests/apigw/views/test_get_task_list.py`
- `black --check gcloud/apigw/views/get_task_list.py gcloud/tests/apigw/views/test_get_task_list.py`
- `PYENV_VERSION=3.10.6 python -m isort --check-only --profile black --filter-files gcloud/apigw/views/get_task_list.py gcloud/tests/apigw/views/test_get_task_list.py`
- `flake8 gcloud/apigw/views/get_task_list.py gcloud/tests/apigw/views/test_get_task_list.py`
- `git diff --check`

未完整执行：

- `python manage.py test gcloud.tests.apigw.views.test_get_task_list --keepdb -v 1`

原因：本机测试环境 MySQL `localhost:3306` 未启动，Django 测试库创建阶段报 `Can't connect to MySQL server on 'localhost'`。