### PR TITLE
fix: 补充轻应用页面入口权限校验

### DIFF
--- a/gcloud/contrib/appmaker/decorators.py
+++ b/gcloud/contrib/appmaker/decorators.py
@@ -14,11 +14,16 @@ specific language governing permissions and limitations under the License.
 from functools import wraps
 
 from django.http import HttpResponseForbidden
+from iam import Action, Subject
+from iam.shortcuts import allow_or_raise_auth_failed
 
 from gcloud.contrib.appmaker.models import AppMaker
+from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
+
+iam = get_iam_client()
 
 
-def check_db_object_exists(model):
+def check_db_object_exists(model, iam_action=None):
     """
     @summary 请求的DB数据是否存在
     @return:
@@ -30,9 +35,18 @@ def check_db_object_exists(model):
             project_id = kwargs.get("project_id")
             if model == "AppMaker":
                 app_id = kwargs.get("app_id")
-                if not AppMaker.objects.filter(pk=app_id, project_id=project_id, is_deleted=False).exists():
+                app_maker = AppMaker.objects.filter(pk=app_id, project_id=project_id, is_deleted=False).first()
+                if not app_maker:
                     # return HttpResponseNotFound() 返回404不能显示404.html
                     return HttpResponseForbidden()
+                if iam_action:
+                    allow_or_raise_auth_failed(
+                        iam=iam,
+                        system=IAMMeta.SYSTEM_ID,
+                        subject=Subject("user", request.user.username),
+                        action=Action(iam_action),
+                        resources=res_factory.resources_for_mini_app_obj(app_maker),
+                    )
             return view_func(request, *args, **kwargs)
 
         return _wrapped_view

--- a/gcloud/contrib/appmaker/views.py
+++ b/gcloud/contrib/appmaker/views.py
@@ -13,12 +13,13 @@ specific language governing permissions and limitations under the License.
 
 from django.shortcuts import render
 
-from gcloud.contrib.appmaker.models import AppMaker
 from gcloud.contrib.appmaker.decorators import check_db_object_exists
+from gcloud.contrib.appmaker.models import AppMaker
 from gcloud.core.signals import user_enter
+from gcloud.iam_auth import IAMMeta
 
 
-@check_db_object_exists("AppMaker")
+@check_db_object_exists("AppMaker", iam_action=IAMMeta.MINI_APP_VIEW_ACTION)
 def task_home(request, app_id, project_id):
     """
     @summary 通过appmaker创建任务
@@ -38,7 +39,7 @@ def task_home(request, app_id, project_id):
     return render(request, "core/base_vue.html", ctx)
 
 
-@check_db_object_exists("AppMaker")
+@check_db_object_exists("AppMaker", iam_action=IAMMeta.MINI_APP_VIEW_ACTION)
 def newtask_selectnode(request, app_id, project_id):
     """
     @summary 通过appmaker创建任务
@@ -56,7 +57,7 @@ def newtask_selectnode(request, app_id, project_id):
     return render(request, "core/base_vue.html", context)
 
 
-@check_db_object_exists("AppMaker")
+@check_db_object_exists("AppMaker", iam_action=IAMMeta.MINI_APP_VIEW_ACTION)
 def newtask_paramfill(request, app_id, project_id):
     """
     @summary 通过appmaker创建任务
@@ -74,7 +75,7 @@ def newtask_paramfill(request, app_id, project_id):
     return render(request, "core/base_vue.html", context)
 
 
-@check_db_object_exists("AppMaker")
+@check_db_object_exists("AppMaker", iam_action=IAMMeta.MINI_APP_VIEW_ACTION)
 def execute(request, app_id, project_id):
     """
     @summary: 在轻应用中查看任务详情

--- a/gcloud/tests/contrib/appmaker/test_decorators.py
+++ b/gcloud/tests/contrib/appmaker/test_decorators.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from django.http import HttpResponse, HttpResponseForbidden
+
+from gcloud.contrib.appmaker.decorators import check_db_object_exists
+from gcloud.iam_auth import IAMMeta
+
+
+class CheckDbObjectExistsTestCase(TestCase):
+    @mock.patch("gcloud.contrib.appmaker.decorators.allow_or_raise_auth_failed")
+    @mock.patch("gcloud.contrib.appmaker.decorators.res_factory.resources_for_mini_app_obj")
+    @mock.patch("gcloud.contrib.appmaker.decorators.AppMaker")
+    def test_check_app_maker__check_mini_app_permission(
+        self,
+        mocked_app_maker_model,
+        mocked_resources_for_mini_app_obj,
+        mocked_allow_or_raise_auth_failed,
+    ):
+        app_maker = SimpleNamespace(id=1, project_id=2, creator="tester", name="mini-app")
+        request = SimpleNamespace(user=SimpleNamespace(username="tester"))
+        mocked_app_maker_model.objects.filter.return_value.first.return_value = app_maker
+        mocked_resources_for_mini_app_obj.return_value = ["mini-app-resource"]
+
+        @check_db_object_exists("AppMaker", iam_action=IAMMeta.MINI_APP_VIEW_ACTION)
+        def view_func(request, app_id, project_id):
+            return HttpResponse("ok")
+
+        response = view_func(request, app_id=1, project_id=2)
+
+        self.assertEqual(response.status_code, 200)
+        mocked_app_maker_model.objects.filter.assert_called_once_with(pk=1, project_id=2, is_deleted=False)
+        mocked_resources_for_mini_app_obj.assert_called_once_with(app_maker)
+        mocked_allow_or_raise_auth_failed.assert_called_once()
+        self.assertEqual(mocked_allow_or_raise_auth_failed.call_args[1]["action"].id, IAMMeta.MINI_APP_VIEW_ACTION)
+
+    @mock.patch("gcloud.contrib.appmaker.decorators.allow_or_raise_auth_failed")
+    @mock.patch("gcloud.contrib.appmaker.decorators.AppMaker")
+    def test_check_app_maker__forbidden_when_app_maker_not_exists(
+        self,
+        mocked_app_maker_model,
+        mocked_allow_or_raise_auth_failed,
+    ):
+        request = SimpleNamespace(user=SimpleNamespace(username="tester"))
+        mocked_app_maker_model.objects.filter.return_value.first.return_value = None
+        view_func = mock.Mock(return_value=HttpResponse("ok"))
+
+        response = check_db_object_exists("AppMaker", iam_action=IAMMeta.MINI_APP_VIEW_ACTION)(view_func)(
+            request, app_id=1, project_id=2
+        )
+
+        self.assertIsInstance(response, HttpResponseForbidden)
+        view_func.assert_not_called()
+        mocked_allow_or_raise_auth_failed.assert_not_called()


### PR DESCRIPTION
## 变更说明

- 为 AppMaker 页面入口的对象存在性装饰器补充可选 IAM 鉴权能力。
- 对轻应用任务首页、新建任务选择节点、填写参数、任务详情页面统一校验 `mini_app_view`，避免直连 URL 绕过前端入口权限判断。
- 增加装饰器单元测试，覆盖存在对象时触发 IAM 校验、不存在对象时返回 403 且不进入 view 的场景。
- PR 已基于 `release_humming_bird` 分支提交。

## 测试

- `uvx --from black==22.8.0 black --check gcloud/contrib/appmaker/decorators.py gcloud/contrib/appmaker/views.py gcloud/tests/contrib/appmaker/test_decorators.py`
- `uvx --from flake8==3.7.9 flake8 gcloud/contrib/appmaker/decorators.py gcloud/contrib/appmaker/views.py gcloud/tests/contrib/appmaker/test_decorators.py`
- `uvx --from isort==5.6.4 isort --profile black --filter-files --check-only gcloud/contrib/appmaker/decorators.py gcloud/contrib/appmaker/views.py gcloud/tests/contrib/appmaker/test_decorators.py`
- `APP_ID=bk_sops BKPAAS_APP_ID=bk_sops APP_TOKEN=dummy BKPAAS_APP_SECRET=dummy PYENV_VERSION=3.6.15 python manage.py test gcloud.tests.contrib.appmaker.test_decorators --keepdb`
- `APP_ID=bk_sops BKPAAS_APP_ID=bk_sops APP_TOKEN=dummy BKPAAS_APP_SECRET=dummy PYENV_VERSION=3.6.15 python -m py_compile gcloud/contrib/appmaker/decorators.py gcloud/contrib/appmaker/views.py gcloud/tests/contrib/appmaker/test_decorators.py`

备注：本地 pre-commit 当前由 Python 3.11 版 virtualenv 创建 hook 环境，无法再创建 `python3.6` hook 环境；上述检查已手动执行。