### PR TITLE
fix: 移除未使用的业务角色人员接口

### DIFF
--- a/gcloud/core/api.py
+++ b/gcloud/core/api.py
@@ -16,7 +16,6 @@ import re
 from datetime import datetime
 
 from blueapps.account.decorators import login_exempt
-from django.contrib.auth.models import Group
 from django.http import JsonResponse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_GET, require_POST
@@ -31,7 +30,6 @@ from gcloud.core import roles
 from gcloud.core.api_adapter import get_all_users
 from gcloud.core.footer import FOOTER, FOOTER_INFO
 from gcloud.core.models import ProjectCounter, UserDefaultProject
-from gcloud.core.utils import convert_group_name
 from gcloud.openapi.schema import AnnotationAutoSchema
 
 logger = logging.getLogger("root")
@@ -52,37 +50,6 @@ def change_default_project(request, project_id):
     ProjectCounter.objects.increase_or_create(username=request.user.username, project_id=project_id)
 
     return JsonResponse({"result": True, "data": {}, "message": _("用户默认项目切换成功")})
-
-
-@require_GET
-def get_roles_and_personnel(request, biz_cc_id):
-    """
-    @summary: 获取用户角色和业务人员
-    @param request:
-    @param biz_cc_id:
-    @return:
-    """
-    use_for = request.GET.get("use_for", "")
-    # 模板授权需要去掉运维角色，运维默认有所有权限，并添加职能化人员
-    if use_for == "template_auth":
-        role_list = [role for role in roles.CC_ROLES if role != roles.MAINTAINERS]
-        # 添加职能化人员
-        role_list.append(roles.FUNCTOR)
-    else:
-        role_list = roles.CC_ROLES
-
-    data = []
-    for key in role_list:
-        name = roles.ROLES_DECS[key]
-        group_name = convert_group_name(biz_cc_id, key)
-        group = Group.objects.get(name=group_name)
-        user_list = group.user_set.all()
-        personnel_list = []
-        for user in user_list:
-            personnel_list.append({"text": user.full_name, "id": user.username})
-        personnel_list.insert(0, {"text": _("所有%s") % name, "id": key})
-        data.append({"text": name, "children": personnel_list})
-    return JsonResponse({"result": True, "data": {"roles": data}})
 
 
 @require_GET

--- a/gcloud/core/urls.py
+++ b/gcloud/core/urls.py
@@ -28,7 +28,6 @@ urlpatterns = [
     re_path(r"^$", views.home),
     re_path(r"^logout$", views.user_exit),
     re_path(r"^core/api/change_default_project/(?P<project_id>\d+)/$", api.change_default_project),
-    re_path(r"^core/api/get_roles_and_personnel/(?P<biz_cc_id>\d+)/$", api.get_roles_and_personnel),
     re_path(r"^core/api/get_basic_info/$", api.get_basic_info),
     re_path(r"^core/footer/$", api.get_footer),
     re_path(r"^core/footer_info/$", api.get_footer_info),

--- a/gcloud/tests/core/test_urls.py
+++ b/gcloud/tests/core/test_urls.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+from django.test import SimpleTestCase
+
+from gcloud.core.urls import urlpatterns
+
+
+class CoreUrlsTestCase(SimpleTestCase):
+    def test_unused_roles_and_personnel_api_removed(self):
+        patterns = [url_pattern.pattern.regex.pattern for url_pattern in urlpatterns]
+
+        self.assertNotIn(r"^core/api/get_roles_and_personnel/(?P<biz_cc_id>\d+)/$", patterns)


### PR DESCRIPTION
## 变更说明

- 删除已确认不再使用的 `/core/api/get_roles_and_personnel/{biz_cc_id}/` 路由。
- 移除对应的 `get_roles_and_personnel` view，避免登录用户按 `biz_cc_id` 枚举业务角色成员信息。
- 增加 URL 回归测试，防止该历史接口被误恢复。
- PR 基于 `release_humming_bird` 分支提交。

## TAPD

- https://tapd.woa.com/10131351/bugtrace/bugs/view/1010131351157886771

## 测试

- `uvx --from flake8 flake8 gcloud/core/api.py gcloud/core/urls.py gcloud/tests/core/test_urls.py`
- `uvx --from black==22.8.0 black --check gcloud/core/api.py gcloud/core/urls.py gcloud/tests/core/test_urls.py`
- `APP_ID=bk_sops BKPAAS_APP_ID=bk_sops APP_TOKEN=dummy BKPAAS_APP_SECRET=dummy PYENV_VERSION=3.6.15 python -m py_compile gcloud/core/api.py gcloud/core/urls.py gcloud/tests/core/test_urls.py`
- `APP_ID=bk_sops BKPAAS_APP_ID=bk_sops APP_TOKEN=dummy BKPAAS_APP_SECRET=dummy PYENV_VERSION=3.6.15 python manage.py test gcloud.tests.core.test_urls --keepdb`