### PR TITLE
fix: 升级 requirements 依赖版本

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ drf-yasg==1.21.8
 typing-extensions==4.12.2
 pyyaml==6.0.2
 bkstorages==2.0.0
-ujson==5.9.0
+ujson==5.12.0
 django-dbconn-retry==0.1.8
 pydantic==2.6.4
 
@@ -51,7 +51,7 @@ django-timezone-field==5.1
 importlib-metadata==6.11.0
 
 # otel
-protobuf==5.29.5
+protobuf==5.29.6
 
 # blueapps
 blueapps[opentelemetry,bkcrypto]==4.15.8


### PR DESCRIPTION
## 变更内容

- 将 `ujson` 从 `5.9.0` 升级到 `5.12.0`
- 将 `protobuf` 从 `5.29.5` 升级到 `5.29.6`

## 风险评估

- `protobuf` 仍保持在 5.x 版本，满足当前 `opentelemetry-proto==1.29.0` 的 `protobuf<6.0,>=5.0` 约束，没有越过主版本边界。
- `ujson` 为 5.x 内升级，未引入额外传递依赖；主要风险是 JSON 序列化/反序列化细节差异，整体风险较低。

## 验证

- `uv pip install --dry-run --python /tmp/bk-sops-dep-check.N14PKG/.venv/bin/python --python-platform x86_64-manylinux2014 -r requirements.txt`
- `uv pip install --python /tmp/bk-sops-dep-check.N14PKG/.venv/bin/python -r requirements.txt`
- `uv pip check --python /tmp/bk-sops-dep-check.N14PKG/.venv/bin/python`

TAPD: https://tapd.woa.com/10131351/bugtrace/bugs/view/1010131351157888084