### PR TITLE
fix: 升级 cryptography 依赖版本

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-tastypie==0.15.0
 rsa==4.9
 coverage==7.6.8
 python-magic==0.4.27
-cryptography==42.0.5
+cryptography==46.0.7
 GitPython==3.1.42
 PyJWT==2.8.0
 future==1.0.0


### PR DESCRIPTION
## 变更内容

- 将 `cryptography` 从 `42.0.5` 升级到 `46.0.7`

## 风险评估

- 原始更新目标 `46.0.6` 可以通过依赖解析，但同系列 `46.0.7` 已包含后续安全修复，因此本 PR 采用 `46.0.7`。
- `cryptography==46.0.7` 在 Python 3.11 下要求 `cffi>=2.0.0`，当前完整依赖树解析为 `cffi==2.0.0`，与 `apigw-manager[cryptography]`、`blueapps[opentelemetry,bkcrypto]` 等依赖约束兼容。
- 主要剩余风险是 `cryptography` 跨多个 minor 版本升级，可能影响底层加解密、证书解析或运行镜像平台 wheel 兼容性；本 PR 已按 CI Python 3.11 和 Linux 平台做依赖解析，并做了基础导入校验。

## 验证

- `uv pip install --dry-run --python /tmp/bk-sops-crypto-check.4KACcE/.venv/bin/python --python-platform x86_64-manylinux2014 -r requirements.txt`
- `uv pip install --python /tmp/bk-sops-crypto-check.4KACcE/.venv/bin/python -r requirements.txt`
- `uv pip check --python /tmp/bk-sops-crypto-check.4KACcE/.venv/bin/python`
- 基础导入校验：`cryptography.x509`、`AESGCM`、`rsa.generate_private_key`