### PR TITLE
fix: 修复 Legacy HTTP 请求插件 SSRF

### DIFF
--- a/pipeline_plugins/components/collections/common.py
+++ b/pipeline_plugins/components/collections/common.py
@@ -22,6 +22,7 @@ from pipeline.component_framework.component import Component
 from pipeline.core.flow.activity import StaticIntervalGenerator
 from pipeline.core.flow.io import IntItemSchema, ObjectItemSchema, StringItemSchema
 
+from gcloud.utils.validate import DomainValidator
 from pipeline_plugins.base import BasePluginService
 
 __group_name__ = _("蓝鲸服务(BK)")
@@ -85,6 +86,14 @@ class HttpRequestService(BasePluginService):
             other["headers"] = {"Content-type": "application/json"}
 
         self.logger.info("send %s request to %s" % (method, url))
+
+        valid_url, allowed_domains = DomainValidator.validate(url)
+        if not valid_url:
+            data.set_outputs(
+                "ex_data",
+                _("仅允许访问域名({allowed_domains})下的URL").format(allowed_domains=",".join(allowed_domains)),
+            )
+            return False
 
         try:
             response = requests.request(method=method, url=url, verify=False, timeout=30, **other)

--- a/pipeline_plugins/tests/components/collections/http_test/test_legacy.py
+++ b/pipeline_plugins/tests/components/collections/http_test/test_legacy.py
@@ -12,44 +12,33 @@ specific language governing permissions and limitations under the License.
 """
 
 from django.test import TestCase
-from mock import MagicMock
-from pipeline.component_framework.test import (
-    CallAssertion,
-    ComponentTestCase,
-    ComponentTestMixin,
-    ExecuteAssertion,
-    Patcher,
-    ScheduleAssertion,
-)
+from mock import MagicMock, patch
 
-from pipeline_plugins.components.collections.common import HttpComponent
+from pipeline_plugins.components.collections.common import HttpRequestService
 
 
-class LegacyHttpComponentValidateTestCase(TestCase, ComponentTestMixin):
-    def cases(self):
-        return [HTTP_CALL_REQUEST_VALIDATE_CASE]
+class LegacyHttpComponentValidateTestCase(TestCase):
+    def test_domain_validator_rejects_request_before_http_call(self):
+        data = MagicMock()
+        data.get_one_of_inputs.side_effect = {
+            "bk_http_request_method": "GET",
+            "bk_http_request_url": "http://127.0.0.1",
+            "bk_http_request_body": "",
+        }.get
+        data.outputs = {}
+        data.set_outputs.side_effect = data.outputs.__setitem__
 
-    def component_cls(self):
-        return HttpComponent
+        parent_data = MagicMock()
+        parent_data.get_one_of_inputs.return_value = None
 
+        with patch(
+            "pipeline_plugins.components.collections.common.DomainValidator.validate",
+            return_value=(False, ["bk.example.com"]),
+        ), patch("pipeline_plugins.components.collections.common.requests.request") as request:
+            service = HttpRequestService()
+            service.logger = MagicMock()
+            result = service.plugin_schedule(data, parent_data)
 
-HTTP_REQUEST = "pipeline_plugins.components.collections.common.requests.request"
-HTTP_VALIDATE = "pipeline_plugins.components.collections.common.DomainValidator.validate"
-
-
-HTTP_CALL_REQUEST_VALIDATE_CASE = ComponentTestCase(
-    name="legacy http call request validate error case",
-    inputs={
-        "bk_http_request_method": "GET",
-        "bk_http_request_url": "http://127.0.0.1",
-        "bk_http_request_body": "",
-    },
-    parent_data={},
-    execute_assertion=ExecuteAssertion(success=True, outputs={}),
-    schedule_assertion=ScheduleAssertion(success=False, outputs={"ex_data": "仅允许访问域名(bk.example.com)下的URL"}),
-    schedule_call_assertion=[CallAssertion(func=HTTP_REQUEST, calls=[])],
-    patchers=[
-        Patcher(target=HTTP_VALIDATE, return_value=(False, ["bk.example.com"])),
-        Patcher(target=HTTP_REQUEST, return_value=MagicMock()),
-    ],
-)
+        self.assertFalse(result)
+        self.assertEqual(data.outputs["ex_data"], "仅允许访问域名(bk.example.com)下的URL")
+        request.assert_not_called()

--- a/pipeline_plugins/tests/components/collections/http_test/test_legacy.py
+++ b/pipeline_plugins/tests/components/collections/http_test/test_legacy.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.test import TestCase
+from mock import MagicMock
+from pipeline.component_framework.test import (
+    CallAssertion,
+    ComponentTestCase,
+    ComponentTestMixin,
+    ExecuteAssertion,
+    Patcher,
+    ScheduleAssertion,
+)
+
+from pipeline_plugins.components.collections.common import HttpComponent
+
+
+class LegacyHttpComponentValidateTestCase(TestCase, ComponentTestMixin):
+    def cases(self):
+        return [HTTP_CALL_REQUEST_VALIDATE_CASE]
+
+    def component_cls(self):
+        return HttpComponent
+
+
+HTTP_REQUEST = "pipeline_plugins.components.collections.common.requests.request"
+HTTP_VALIDATE = "pipeline_plugins.components.collections.common.DomainValidator.validate"
+
+
+HTTP_CALL_REQUEST_VALIDATE_CASE = ComponentTestCase(
+    name="legacy http call request validate error case",
+    inputs={
+        "bk_http_request_method": "GET",
+        "bk_http_request_url": "http://127.0.0.1",
+        "bk_http_request_body": "",
+    },
+    parent_data={},
+    execute_assertion=ExecuteAssertion(success=True, outputs={}),
+    schedule_assertion=ScheduleAssertion(success=False, outputs={"ex_data": "仅允许访问域名(bk.example.com)下的URL"}),
+    schedule_call_assertion=[CallAssertion(func=HTTP_REQUEST, calls=[])],
+    patchers=[
+        Patcher(target=HTTP_VALIDATE, return_value=(False, ["bk.example.com"])),
+        Patcher(target=HTTP_REQUEST, return_value=MagicMock()),
+    ],
+)


### PR DESCRIPTION
## 变更说明
- 在 legacy `bk_http_request` 执行路径补齐 `DomainValidator.validate` 校验
- URL 不在允许域名范围内时直接失败，不再发起 `requests.request`
- 补充 legacy HTTP 插件回归测试，覆盖校验失败不发请求场景

## 验证
- `SKIP=check-migrate,check-sensitive-info pre-commit run --files pipeline_plugins/components/collections/common.py pipeline_plugins/tests/components/collections/http_test/test_legacy.py`
- `python -m compileall pipeline_plugins/components/collections/common.py pipeline_plugins/tests/components/collections/http_test/test_legacy.py`

说明：本地 Python 环境未安装 Django/pipeline，未运行完整 `manage.py test`。