### PR TITLE
fix: 加固 DomainValidator SSRF 校验

### DIFF
--- a/gcloud/tests/utils/test_validate.py
+++ b/gcloud/tests/utils/test_validate.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.test import TestCase
+from django.test.utils import override_settings
+from mock import patch
+
+from gcloud.utils.validate import DomainValidator
+
+
+def getaddrinfo_result(ip):
+    return [(None, None, None, "", (ip, 0))]
+
+
+class DomainValidatorTestCase(TestCase):
+    @override_settings(ENABLE_HTTP_PLUGIN_DOMAINS_CHECK=True, ALLOWED_HTTP_PLUGIN_DOMAINS="example.com")
+    def test_allow_allowed_domain_resolved_to_public_ip(self):
+        with patch("gcloud.utils.validate.socket.getaddrinfo", return_value=getaddrinfo_result("93.184.216.34")):
+            valid, allowed_domains = DomainValidator.validate("https://api.example.com/resource")
+
+        self.assertTrue(valid)
+        self.assertEqual(allowed_domains, [])
+
+    @override_settings(ENABLE_HTTP_PLUGIN_DOMAINS_CHECK=True, ALLOWED_HTTP_PLUGIN_DOMAINS="example.com")
+    def test_reject_allowed_domain_resolved_to_private_ip(self):
+        with patch("gcloud.utils.validate.socket.getaddrinfo", return_value=getaddrinfo_result("127.0.0.1")):
+            valid, allowed_domains = DomainValidator.validate("https://api.example.com/resource")
+
+        self.assertFalse(valid)
+        self.assertEqual(allowed_domains, ["example.com"])
+
+    @override_settings(ENABLE_HTTP_PLUGIN_DOMAINS_CHECK=True, ALLOWED_HTTP_PLUGIN_DOMAINS="127.0.0.1")
+    def test_reject_private_ip_literal(self):
+        valid, allowed_domains = DomainValidator.validate("http://127.0.0.1/metadata")
+
+        self.assertFalse(valid)
+        self.assertEqual(allowed_domains, ["127.0.0.1"])
+
+    @override_settings(ENABLE_HTTP_PLUGIN_DOMAINS_CHECK=True, ALLOWED_HTTP_PLUGIN_DOMAINS="2130706433")
+    def test_reject_integer_encoded_loopback(self):
+        with patch("gcloud.utils.validate.socket.getaddrinfo", return_value=getaddrinfo_result("127.0.0.1")):
+            valid, allowed_domains = DomainValidator.validate("http://2130706433/metadata")
+
+        self.assertFalse(valid)
+        self.assertEqual(allowed_domains, ["2130706433"])
+
+    @override_settings(ENABLE_HTTP_PLUGIN_DOMAINS_CHECK=True, ALLOWED_HTTP_PLUGIN_DOMAINS="example.com")
+    def test_reject_disallowed_domain_before_dns_resolve(self):
+        with patch("gcloud.utils.validate.socket.getaddrinfo") as mocked_getaddrinfo:
+            valid, allowed_domains = DomainValidator.validate("https://api.other.com/resource")
+
+        self.assertFalse(valid)
+        self.assertEqual(allowed_domains, ["example.com"])
+        mocked_getaddrinfo.assert_not_called()
+
+    @override_settings(ENABLE_HTTP_PLUGIN_DOMAINS_CHECK=True, ALLOWED_HTTP_PLUGIN_DOMAINS="example.com")
+    def test_reject_unsupported_scheme(self):
+        valid, allowed_domains = DomainValidator.validate("file://example.com/etc/passwd")
+
+        self.assertFalse(valid)
+        self.assertEqual(allowed_domains, ["example.com"])

--- a/gcloud/utils/validate.py
+++ b/gcloud/utils/validate.py
@@ -10,8 +10,11 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import ipaddress
 import logging
+import socket
 from abc import ABCMeta, abstractmethod
+from urllib.parse import urlparse
 
 import tldextract
 import ujson as json
@@ -20,6 +23,9 @@ from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger("root")
 
+HTTP_PLUGIN_ALLOWED_SCHEMES = {"http", "https"}
+UNSAFE_IP_ATTRS = ("is_private", "is_loopback", "is_link_local", "is_multicast", "is_reserved", "is_unspecified")
+
 
 def get_top_level_domain(url):
     # 提取域名部分
@@ -27,6 +33,97 @@ def get_top_level_domain(url):
     # 拼合主域名和顶级域名，形成一级域名
     top_level_domain = "{}.{}".format(extracted.domain, extracted.suffix)
     return top_level_domain
+
+
+def normalize_domain(domain):
+    if not domain:
+        return ""
+    parsed = urlparse(domain if "://" in domain else "//{}".format(domain))
+    try:
+        hostname = parsed.hostname or domain
+    except ValueError:
+        hostname = domain
+    return hostname.strip().strip(".").lower()
+
+
+def get_url_hostname(url):
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if parsed.scheme not in HTTP_PLUGIN_ALLOWED_SCHEMES:
+        return None
+    try:
+        hostname = parsed.hostname
+    except ValueError:
+        return None
+    if not parsed.netloc or not hostname:
+        return None
+    return hostname.strip().strip(".").lower()
+
+
+def host_match_allowed_domains(hostname, allowed_domains):
+    for allowed_domain in allowed_domains:
+        allowed_domain = normalize_domain(allowed_domain)
+        if not allowed_domain:
+            continue
+
+        if allowed_domain.startswith("*."):
+            suffix = allowed_domain[2:]
+            if hostname.endswith(".{}".format(suffix)):
+                return True
+            continue
+
+        if hostname == allowed_domain or hostname.endswith(".{}".format(allowed_domain)):
+            return True
+
+    return False
+
+
+def is_safe_ip_address(ip):
+    if getattr(ip, "ipv4_mapped", None):
+        return is_safe_ip_address(ip.ipv4_mapped)
+
+    for attr in UNSAFE_IP_ATTRS:
+        if getattr(ip, attr):
+            return False
+    return True
+
+
+def parse_ip_address(hostname):
+    try:
+        return ipaddress.ip_address(hostname)
+    except ValueError:
+        return None
+
+
+def resolve_host_ips(hostname):
+    try:
+        address_infos = socket.getaddrinfo(hostname, None, type=socket.SOCK_STREAM)
+    except OSError:
+        logger.warning("resolve http plugin domain failed: %s", hostname)
+        return []
+
+    ips = set()
+    for address_info in address_infos:
+        ip = address_info[4][0].split("%", 1)[0]
+        try:
+            ips.add(ipaddress.ip_address(ip))
+        except ValueError:
+            logger.warning("ignore invalid resolved ip: %s", ip)
+
+    return list(ips)
+
+
+def host_resolves_to_safe_ips(hostname):
+    ip = parse_ip_address(hostname)
+    if ip:
+        return is_safe_ip_address(ip)
+
+    ips = resolve_host_ips(hostname)
+    if not ips:
+        return False
+
+    return all(is_safe_ip_address(ip) for ip in ips)
 
 
 class RequestValidator(object, metaclass=ABCMeta):
@@ -72,10 +169,16 @@ class DomainValidator(object):
             # 默认只允许访问蓝鲸域名
             allowed_domains = [get_top_level_domain(settings.BK_URL)]
         else:
-            allowed_domains = settings.ALLOWED_HTTP_PLUGIN_DOMAINS.split(",")
+            allowed_domains = [normalize_domain(domain) for domain in settings.ALLOWED_HTTP_PLUGIN_DOMAINS.split(",")]
 
-        for allowed_domain in allowed_domains:
-            if get_top_level_domain(url) == allowed_domain:
-                return True, []
+        hostname = get_url_hostname(url)
+        if not hostname:
+            return False, allowed_domains
 
-        return False, allowed_domains
+        if not host_match_allowed_domains(hostname, allowed_domains):
+            return False, allowed_domains
+
+        if not host_resolves_to_safe_ips(hostname):
+            return False, allowed_domains
+
+        return True, []


### PR DESCRIPTION
## 变更说明
- `DomainValidator` 改为先解析 URL host，并限制仅允许 HTTP/HTTPS
- 保留域名白名单匹配，同时拒绝私有、回环、链路本地、保留地址等 IP 字面量或 DNS 解析结果
- 补充单元测试覆盖公网域名放行、私网解析拒绝、IP 字面量拒绝、整数编码回环拒绝、非法 scheme 拒绝等场景

## 验证
- `SKIP=check-migrate,check-sensitive-info pre-commit run --files gcloud/utils/validate.py gcloud/tests/utils/test_validate.py`
- `python -m compileall gcloud/utils/validate.py gcloud/tests/utils/test_validate.py`

说明：本地 Python 环境未安装 Django/pipeline，未运行完整 `manage.py test`。