### PR TITLE
fix: 补充默认项目切换权限校验

### DIFF
--- a/gcloud/core/api.py
+++ b/gcloud/core/api.py
@@ -10,6 +10,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import keyword
 import logging
 import re
@@ -30,6 +31,7 @@ from gcloud.core import roles
 from gcloud.core.api_adapter import get_all_users
 from gcloud.core.footer import FOOTER, FOOTER_INFO
 from gcloud.core.models import ProjectCounter, UserDefaultProject
+from gcloud.iam_auth.utils import get_user_projects
 from gcloud.openapi.schema import AnnotationAutoSchema
 
 logger = logging.getLogger("root")
@@ -43,6 +45,9 @@ def change_default_project(request, project_id):
     """
     @summary: 切换用户默认项目
     """
+    if not get_user_projects(request.user.username).filter(id=project_id, is_disable=False).exists():
+        return JsonResponse({"result": False, "data": {}, "message": _("用户无权限访问该项目")})
+
     UserDefaultProject.objects.update_or_create(
         username=request.user.username, defaults={"default_project_id": project_id}
     )

--- a/gcloud/core/apis/drf/viewsets/common_project.py
+++ b/gcloud/core/apis/drf/viewsets/common_project.py
@@ -38,14 +38,13 @@ class CommonProjectViewSet(GcloudListViewSet):
     filterset_class = CommonProjectFilter
 
     @staticmethod
-    def get_default_projects(username):
+    def get_default_projects(username, projects=None):
         """初始化并返回用户有权限的项目"""
 
-        projects = get_user_projects(username)
-        if not projects:
+        projects = projects if projects is not None else get_user_projects(username)
+        project_ids = list(projects.values_list("id", flat=True))
+        if not project_ids:
             return ProjectCounter.objects.none()
-
-        project_ids = projects.values_list("id", flat=True)
 
         # 初始化用户有权限的项目
         ProjectCounter.objects.bulk_create(
@@ -55,12 +54,13 @@ class CommonProjectViewSet(GcloudListViewSet):
         return ProjectCounter.objects.filter(username=username, project_id__in=project_ids, project__is_disable=False)
 
     def list(self, request, *args, **kwargs):
-        user_project_ids = get_user_projects(request.user.username).values_list("id", flat=True)
+        user_projects = get_user_projects(request.user.username)
+        user_project_ids = user_projects.values_list("id", flat=True)
         self.queryset = self.queryset.filter(
             username=request.user.username, project_id__in=user_project_ids, project__is_disable=False
         )
 
         # 第一次访问或无被授权的项目
         if not self.queryset.exists():
-            self.queryset = self.get_default_projects(request.user.username)
+            self.queryset = self.get_default_projects(request.user.username, user_projects)
         return super(CommonProjectViewSet, self).list(request, *args, **kwargs)

--- a/gcloud/core/apis/drf/viewsets/common_project.py
+++ b/gcloud/core/apis/drf/viewsets/common_project.py
@@ -10,14 +10,14 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from rest_framework import permissions
 
-from gcloud.core.models import ProjectCounter
-from gcloud.iam_auth.utils import get_user_projects
+from rest_framework import permissions
 
 from gcloud.core.apis.drf.filtersets import ALL_LOOKUP, AllLookupSupportFilterSet
 from gcloud.core.apis.drf.serilaziers import CommonProjectSerializer
 from gcloud.core.apis.drf.viewsets.base import GcloudListViewSet
+from gcloud.core.models import ProjectCounter
+from gcloud.iam_auth.utils import get_user_projects
 
 
 class CommonProjectFilter(AllLookupSupportFilterSet):
@@ -55,7 +55,10 @@ class CommonProjectViewSet(GcloudListViewSet):
         return ProjectCounter.objects.filter(username=username, project_id__in=project_ids, project__is_disable=False)
 
     def list(self, request, *args, **kwargs):
-        self.queryset = self.queryset.filter(username=request.user.username, project__is_disable=False)
+        user_project_ids = get_user_projects(request.user.username).values_list("id", flat=True)
+        self.queryset = self.queryset.filter(
+            username=request.user.username, project_id__in=user_project_ids, project__is_disable=False
+        )
 
         # 第一次访问或无被授权的项目
         if not self.queryset.exists():

--- a/gcloud/core/project.py
+++ b/gcloud/core/project.py
@@ -90,16 +90,14 @@ def sync_projects_from_cmdb(username, use_cache=True):
 
 
 def get_default_project_for_user(username):
-    project = None
-
     if not username:
-        return project
+        return None
+
+    projects = get_user_projects(username).filter(is_disable=False)
 
     try:
-        project = UserDefaultProject.objects.get(username=username).default_project
+        default_project_id = UserDefaultProject.objects.get(username=username).default_project_id
     except UserDefaultProject.DoesNotExist:
-        projects = get_user_projects(username)
-        if projects:
-            project = projects.first()
+        return projects.first()
 
-    return project
+    return projects.filter(id=default_project_id).first() or projects.first()

--- a/gcloud/tests/core/test_api.py
+++ b/gcloud/tests/core/test_api.py
@@ -96,6 +96,22 @@ class CommonProjectViewSetTestCase(TestCase):
         project_ids = {item["project"]["id"] for item in response.data["data"]["results"]}
         self.assertEqual(project_ids, {self.allowed_project.id})
 
+    def test_list_initializes_common_projects_with_single_user_project_lookup(self):
+        ProjectCounter.objects.all().delete()
+        request = self.factory.get("/api/v3/common_project/")
+        request.user = SimpleNamespace(username=self.username, is_authenticated=True, is_active=True)
+        view = CommonProjectViewSet.as_view({"get": "list"})
+
+        with patch(
+            "gcloud.core.apis.drf.viewsets.common_project.get_user_projects",
+            return_value=Project.objects.filter(id=self.allowed_project.id),
+        ) as mock_get_user_projects:
+            response = view(request)
+
+        project_ids = {item["project"]["id"] for item in response.data["data"]["results"]}
+        self.assertEqual(project_ids, {self.allowed_project.id})
+        self.assertEqual(mock_get_user_projects.call_count, 1)
+
 
 class GetDefaultProjectForUserTestCase(TestCase):
     def setUp(self):

--- a/gcloud/tests/core/test_api.py
+++ b/gcloud/tests/core/test_api.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import RequestFactory, TestCase
+from rest_framework.test import APIRequestFactory
+
+from gcloud.core.api import change_default_project
+from gcloud.core.apis.drf.viewsets import CommonProjectViewSet
+from gcloud.core.models import Project, ProjectCounter, UserDefaultProject
+from gcloud.core.project import get_default_project_for_user
+
+
+class ChangeDefaultProjectTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.username = "operator"
+        self.allowed_project = Project.objects.create(
+            name="allowed_project", creator=self.username, bk_biz_id=10001, time_zone="Asia/Shanghai"
+        )
+        self.denied_project = Project.objects.create(
+            name="denied_project", creator="other", bk_biz_id=10002, time_zone="Asia/Shanghai"
+        )
+
+    def test_change_default_project_rejects_project_without_view_permission(self):
+        request = self.factory.post(f"/core/api/change_default_project/{self.denied_project.id}/")
+        request.user = SimpleNamespace(username=self.username)
+
+        with patch(
+            "gcloud.core.api.get_user_projects",
+            return_value=Project.objects.filter(id=self.allowed_project.id),
+        ):
+            response = change_default_project(request, self.denied_project.id)
+
+        payload = json.loads(response.content)
+        self.assertFalse(payload["result"])
+        self.assertFalse(UserDefaultProject.objects.filter(username=self.username).exists())
+        self.assertFalse(ProjectCounter.objects.filter(username=self.username, project=self.denied_project).exists())
+
+    def test_change_default_project_records_project_with_view_permission(self):
+        request = self.factory.post(f"/core/api/change_default_project/{self.allowed_project.id}/")
+        request.user = SimpleNamespace(username=self.username)
+
+        with patch(
+            "gcloud.core.api.get_user_projects",
+            return_value=Project.objects.filter(id=self.allowed_project.id),
+        ):
+            response = change_default_project(request, self.allowed_project.id)
+
+        payload = json.loads(response.content)
+        self.assertTrue(payload["result"])
+        self.assertEqual(
+            UserDefaultProject.objects.get(username=self.username).default_project_id,
+            self.allowed_project.id,
+        )
+        self.assertTrue(ProjectCounter.objects.filter(username=self.username, project=self.allowed_project).exists())
+
+
+class CommonProjectViewSetTestCase(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.username = "operator"
+        self.allowed_project = Project.objects.create(
+            name="allowed_project", creator=self.username, bk_biz_id=10001, time_zone="Asia/Shanghai"
+        )
+        self.denied_project = Project.objects.create(
+            name="denied_project", creator="other", bk_biz_id=10002, time_zone="Asia/Shanghai"
+        )
+        ProjectCounter.objects.create(username=self.username, project=self.allowed_project)
+        ProjectCounter.objects.create(username=self.username, project=self.denied_project)
+
+    def test_list_filters_out_project_without_view_permission(self):
+        request = self.factory.get("/api/v3/common_project/")
+        request.user = SimpleNamespace(username=self.username, is_authenticated=True, is_active=True)
+        view = CommonProjectViewSet.as_view({"get": "list"})
+
+        with patch(
+            "gcloud.core.apis.drf.viewsets.common_project.get_user_projects",
+            return_value=Project.objects.filter(id=self.allowed_project.id),
+        ):
+            response = view(request)
+
+        project_ids = {item["project"]["id"] for item in response.data["data"]["results"]}
+        self.assertEqual(project_ids, {self.allowed_project.id})
+
+
+class GetDefaultProjectForUserTestCase(TestCase):
+    def setUp(self):
+        self.username = "operator"
+        self.allowed_project = Project.objects.create(
+            name="allowed_project", creator=self.username, bk_biz_id=10001, time_zone="Asia/Shanghai"
+        )
+        self.denied_project = Project.objects.create(
+            name="denied_project", creator="other", bk_biz_id=10002, time_zone="Asia/Shanghai"
+        )
+        UserDefaultProject.objects.create(username=self.username, default_project=self.denied_project)
+
+    def test_get_default_project_falls_back_when_saved_project_has_no_view_permission(self):
+        with patch(
+            "gcloud.core.project.get_user_projects",
+            return_value=Project.objects.filter(id=self.allowed_project.id),
+        ):
+            project = get_default_project_for_user(self.username)
+
+        self.assertEqual(project.id, self.allowed_project.id)


### PR DESCRIPTION
## 变更说明

修复 `change_default_project` 接口直接信任 URL `project_id` 的权限校验缺失问题：

- 切换默认项目时，要求目标项目在当前用户 IAM 可见项目范围内且未停用
- 首页默认项目读取时，不再信任历史保存的无权限默认项目，自动回退到当前用户可访问项目
- 常用项目列表仅返回当前用户有权限访问的项目，避免被污染的 `ProjectCounter` 暴露项目基础信息
- 补充回归测试覆盖无权限项目切换、常用项目过滤、历史默认项目污染回退

## 关联

- 工蜂议题：#653488
- 漏洞报告：https://bkrepo.woa.com/generic/bk-sec-governance/ai-code/0E/aiauthbypassapi-4b3a78139fa44d0286b2bafab26f168c.html?preview=true

## 验证

- `python manage.py test gcloud.tests.core.test_api gcloud.tests.core.test_project gcloud.tests.core.models.test_user_default_project`
- `SKIP=check-migrate,check-sensitive-info pre-commit run --files gcloud/core/api.py gcloud/core/apis/drf/viewsets/common_project.py gcloud/core/project.py gcloud/tests/core/test_api.py`
- `flake8 --extend-exclude=.venv`
- `python -m compileall -q gcloud/core/api.py gcloud/core/apis/drf/viewsets/common_project.py gcloud/core/project.py gcloud/tests/core/test_api.py`

说明：本地 pre-commit 的 `check-migrate` / `check-sensitive-info` hook 在当前分支引用的脚本不存在，因此按缺脚本跳过；commitlint 本地 hook 因 Node ESM/CommonJS 兼容问题失败，提交信息已按仓库规则以 `#653488` 结尾。