### PR TITLE
修复网关日志接口对象绑定校验

### DIFF
--- a/gcloud/apigw/log_auth.py
+++ b/gcloud/apigw/log_auth.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import logging
+
+from rest_framework.response import Response
+
+from gcloud import err_code
+
+logger = logging.getLogger("root")
+
+
+def _build_error_response(message, code):
+    return Response({"result": False, "message": message, "code": code})
+
+
+def get_taskflow_for_log(api_name, task_id, project):
+    from gcloud.taskflow3.models import TaskFlowInstance
+
+    try:
+        return TaskFlowInstance.objects.get(id=task_id, project_id=project.id), None
+    except TaskFlowInstance.DoesNotExist:
+        message = (
+            "[API] {api_name} task[id={task_id}] " "of project[project_id={project_id}, biz_id={biz_id}] does not exist"
+        ).format(api_name=api_name, task_id=task_id, project_id=project.id, biz_id=project.bk_biz_id)
+        logger.exception(message)
+        return None, _build_error_response(message, err_code.CONTENT_NOT_EXIST.code)
+
+
+def validate_task_node(api_name, taskflow, node_id):
+    if not node_id:
+        message = "[API] {api_name} node_id is required".format(api_name=api_name)
+        logger.warning(message)
+        return _build_error_response(message, err_code.REQUEST_PARAM_INVALID.code)
+
+    if not taskflow.has_node(node_id):
+        message = "[API] {api_name} task[id={task_id}] does not have node[{node_id}]".format(
+            api_name=api_name, task_id=taskflow.id, node_id=node_id
+        )
+        logger.warning(message)
+        return _build_error_response(message, err_code.CONTENT_NOT_EXIST.code)
+
+    return None
+
+
+def get_execution_data_for_node(api_name, node_id):
+    from bamboo_engine import exceptions as bamboo_exceptions
+    from pipeline.eri.runtime import BambooDjangoRuntime
+
+    try:
+        return BambooDjangoRuntime().get_execution_data(node_id=node_id), None
+    except bamboo_exceptions.NotFoundError:
+        message = "[API] {api_name} execution data not found for node_id: {node_id}".format(
+            api_name=api_name, node_id=node_id
+        )
+        logger.warning(message)
+        return None, _build_error_response(message, err_code.CONTENT_NOT_EXIST.code)
+
+
+def validate_node_plugin_trace(api_name, node_id, trace_id, plugin_code):
+    if not trace_id:
+        message = "[API] {api_name} trace_id is required".format(api_name=api_name)
+        logger.warning(message)
+        return _build_error_response(message, err_code.REQUEST_PARAM_INVALID.code)
+
+    if not plugin_code:
+        message = "[API] {api_name} plugin_code is required".format(api_name=api_name)
+        logger.warning(message)
+        return _build_error_response(message, err_code.REQUEST_PARAM_INVALID.code)
+
+    execution_data, error_response = get_execution_data_for_node(api_name, node_id)
+    if error_response is not None:
+        return error_response
+
+    outputs = getattr(execution_data, "outputs", {}) or {}
+    node_trace_id = outputs.get("trace_id")
+    if trace_id != node_trace_id:
+        message = "[API] {api_name} trace_id does not belong to node[{node_id}]".format(
+            api_name=api_name, node_id=node_id
+        )
+        logger.warning(message)
+        return _build_error_response(message, err_code.CONTENT_NOT_EXIST.code)
+
+    inputs = getattr(execution_data, "inputs", {}) or {}
+    node_plugin_code = inputs.get("plugin_code")
+    if node_plugin_code and plugin_code != node_plugin_code:
+        message = "[API] {api_name} plugin_code does not belong to node[{node_id}]".format(
+            api_name=api_name, node_id=node_id
+        )
+        logger.warning(message)
+        return _build_error_response(message, err_code.CONTENT_NOT_EXIST.code)
+
+    return None

--- a/gcloud/apigw/management/commands/data/api-resources.yml
+++ b/gcloud/apigw/management/commands/data/api-resources.yml
@@ -2458,7 +2458,7 @@ paths:
         authConfig:
           userVerifiedRequired: true
         disabledStages: []
-  /get_task_node_log/:
+  /get_task_node_log/{task_id}/{bk_biz_id}/:
     get:
       operationId: get_task_node_log
       description: 获取某个节点的执行日志
@@ -2484,12 +2484,32 @@ paths:
                     description: result=false时错误信息
           description: ''
       parameters:
+      - in: path
+        name: task_id
+        schema:
+          type: string
+        required: true
+        description: 任务ID
+      - in: path
+        name: bk_biz_id
+        schema:
+          type: string
+        required: true
+        description: 所属业务ID
       - in: query
         name: node_id
         schema:
           type: string
         required: true
         description: 任务中节点ID
+      - in: query
+        name: scope
+        schema:
+          type: string
+          default: cmdb_biz
+        required: false
+        description: bk_biz_id 检索的作用域。默认为 cmdb_biz，此时检索的是绑定的 CMDB 业务 ID 为 bk_biz_id
+          的项目；当值为 project 时则检索项目 ID 为 bk_biz_id 的项目
       - in: query
         name: version
         schema:
@@ -2513,17 +2533,17 @@ paths:
         backend:
           type: HTTP
           method: get
-          path: /{env.api_sub_path}apigw/get_task_node_log/
+          path: /{env.api_sub_path}apigw/get_task_node_log/{task_id}/{bk_biz_id}/
           matchSubpath: false
           timeout: 0
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: false
+          userVerifiedRequired: true
           appVerifiedRequired: true
           resourcePermissionRequired: true
         disabledStages: []
-  /get_task_plugin_log/:
+  /get_task_plugin_log/{task_id}/{bk_biz_id}/:
     get:
       operationId: get_task_plugin_log
       description: 查询插件日志
@@ -2555,6 +2575,32 @@ paths:
                     description: result=false时错误信息
           description: ''
       parameters:
+      - in: path
+        name: task_id
+        schema:
+          type: string
+        required: true
+        description: 任务ID
+      - in: path
+        name: bk_biz_id
+        schema:
+          type: string
+        required: true
+        description: 所属业务ID
+      - in: query
+        name: node_id
+        schema:
+          type: string
+        required: true
+        description: 任务中节点ID
+      - in: query
+        name: scope
+        schema:
+          type: string
+          default: cmdb_biz
+        required: false
+        description: bk_biz_id 检索的作用域。默认为 cmdb_biz，此时检索的是绑定的 CMDB 业务 ID 为 bk_biz_id
+          的项目；当值为 project 时则检索项目 ID 为 bk_biz_id 的项目
       - in: query
         name: plugin_code
         schema:
@@ -2579,13 +2625,13 @@ paths:
         backend:
           type: HTTP
           method: get
-          path: /{env.api_sub_path}apigw/get_task_plugin_log/
+          path: /{env.api_sub_path}apigw/get_task_plugin_log/{task_id}/{bk_biz_id}/
           matchSubpath: false
           timeout: 0
           upstreams: {}
           transformHeaders: {}
         authConfig:
-          userVerifiedRequired: false
+          userVerifiedRequired: true
           appVerifiedRequired: true
           resourcePermissionRequired: true
         disabledStages: []

--- a/gcloud/apigw/views/get_node_job_executed_log.py
+++ b/gcloud/apigw/views/get_node_job_executed_log.py
@@ -20,14 +20,12 @@ from pipeline.eri.runtime import BambooDjangoRuntime
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, mcp_apigw, project_inject
-from gcloud.apigw.views.utils import logger
+from gcloud.apigw.log_auth import get_execution_data_for_node, get_taskflow_for_log, validate_task_node
 from gcloud.conf import settings
 from gcloud.constants import JobBizScopeType
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskViewInterceptor
-from gcloud.taskflow3.models import TaskFlowInstance
 from pipeline_plugins.components.collections.sites.open.job.base import get_job_instance_log
 
 node_logger = logging.getLogger("root")
@@ -48,21 +46,24 @@ JOB_INST_ID_IN_LIST_MAP = {
 }
 
 
-def fetch_node_job_executed_log(node_id, bk_biz_id, target_ip=None, component_code=None, job_scope_type=None):
+def fetch_node_job_executed_log(
+    node_id, bk_biz_id, target_ip=None, component_code=None, job_scope_type=None, execution_data=None
+):
     """获取节点JOB执行日志的核心逻辑，供内外接口共用"""
     if job_scope_type is None:
         job_scope_type = JobBizScopeType.BIZ.value
     client = settings.ESB_GET_CLIENT_BY_USER(settings.SYSTEM_USE_API_ACCOUNT)
-    runtime = BambooDjangoRuntime()
-    try:
-        execution_data = runtime.get_execution_data(node_id=node_id)
-    except bamboo_exceptions.NotFoundError:
-        node_logger.warning("execution data not found for node_id: %s", node_id)
-        return {
-            "result": False,
-            "message": "execution data not found for node_id: {}".format(node_id),
-            "logs": "",
-        }
+    if execution_data is None:
+        runtime = BambooDjangoRuntime()
+        try:
+            execution_data = runtime.get_execution_data(node_id=node_id)
+        except bamboo_exceptions.NotFoundError:
+            node_logger.warning("execution data not found for node_id: %s", node_id)
+            return {
+                "result": False,
+                "message": "execution data not found for node_id: {}".format(node_id),
+                "logs": "",
+            }
 
     if component_code and component_code in JOB_INST_ID_IN_LIST_MAP:
         job_instance_id_list = execution_data.outputs.get("job_inst_id_list") or []
@@ -115,19 +116,18 @@ def fetch_node_job_executed_log(node_id, bk_biz_id, target_ip=None, component_co
 @iam_intercept(TaskViewInterceptor())
 def get_node_job_executed_log(request, task_id, project_id):
     project = request.project
-    try:
-        TaskFlowInstance.objects.get(id=task_id, project_id=project.id)
-    except TaskFlowInstance.DoesNotExist:
-        message = (
-            "[API] get_node_job_executed_log task[id={task_id}] "
-            "of project[project_id={project_id}, biz_id={biz_id}] does not exist".format(
-                task_id=task_id, project_id=project.id, biz_id=project.bk_biz_id
-            )
-        )
-        logger.exception(message)
-        return Response({"result": False, "message": message, "code": err_code.CONTENT_NOT_EXIST.code})
+    taskflow, error_response = get_taskflow_for_log("get_node_job_executed_log", task_id, project)
+    if error_response is not None:
+        return error_response
 
     node_id = request.GET.get("node_id")
     target_ip = request.GET.get("target_ip")
+    error_response = validate_task_node("get_node_job_executed_log", taskflow, node_id)
+    if error_response is not None:
+        return error_response
 
-    return Response(fetch_node_job_executed_log(node_id, project.bk_biz_id, target_ip))
+    execution_data, error_response = get_execution_data_for_node("get_node_job_executed_log", node_id)
+    if error_response is not None:
+        return error_response
+
+    return Response(fetch_node_job_executed_log(node_id, project.bk_biz_id, target_ip, execution_data=execution_data))

--- a/gcloud/apigw/views/get_task_node_log.py
+++ b/gcloud/apigw/views/get_task_node_log.py
@@ -17,13 +17,11 @@ from django.conf import settings
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, mcp_apigw, project_inject
-from gcloud.apigw.views.utils import logger
+from gcloud.apigw.log_auth import get_taskflow_for_log, validate_task_node
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskViewInterceptor
 from gcloud.taskflow3.domains.node_log import NodeLogDataSourceFactory
-from gcloud.taskflow3.models import TaskFlowInstance
 from gcloud.utils.handlers import handle_plain_log
 
 DEFAULT_PAGE = 1
@@ -54,21 +52,16 @@ def fetch_task_node_log(node_id, version, page=DEFAULT_PAGE, page_size=DEFAULT_P
 @iam_intercept(TaskViewInterceptor())
 def get_task_node_log(request, task_id, project_id):
     project = request.project
-    try:
-        TaskFlowInstance.objects.get(id=task_id, project_id=project.id)
-    except TaskFlowInstance.DoesNotExist:
-        message = (
-            "[API] get_task_node_log task[id={task_id}] "
-            "of project[project_id={project_id}, biz_id={biz_id}] does not exist".format(
-                task_id=task_id, project_id=project.id, biz_id=project.bk_biz_id
-            )
-        )
-        logger.exception(message)
-        return Response({"result": False, "message": message, "code": err_code.CONTENT_NOT_EXIST.code})
+    taskflow, error_response = get_taskflow_for_log("get_task_node_log", task_id, project)
+    if error_response is not None:
+        return error_response
 
     node_id = request.GET.get("node_id")
     version = request.GET.get("version")
     page = request.GET.get("page", DEFAULT_PAGE)
     page_size = request.GET.get("page_size", DEFAULT_PAGE_SIZE)
+    error_response = validate_task_node("get_task_node_log", taskflow, node_id)
+    if error_response is not None:
+        return error_response
 
     return Response(fetch_task_node_log(node_id, version, page=page, page_size=page_size))

--- a/gcloud/apigw/views/get_task_plugin_log.py
+++ b/gcloud/apigw/views/get_task_plugin_log.py
@@ -16,12 +16,10 @@ from blueapps.account.decorators import login_exempt
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, mcp_apigw, project_inject
-from gcloud.apigw.views.utils import logger
+from gcloud.apigw.log_auth import get_taskflow_for_log, validate_node_plugin_trace, validate_task_node
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskViewInterceptor
-from gcloud.taskflow3.models import TaskFlowInstance
 from plugin_service.plugin_client import PluginServiceApiClient
 
 
@@ -47,20 +45,20 @@ def fetch_task_plugin_log(plugin_code, trace_id, scroll_id=None):
 @iam_intercept(TaskViewInterceptor())
 def get_task_plugin_log(request, task_id, project_id):
     project = request.project
-    try:
-        TaskFlowInstance.objects.get(id=task_id, project_id=project.id)
-    except TaskFlowInstance.DoesNotExist:
-        message = (
-            "[API] get_task_plugin_log task[id={task_id}] "
-            "of project[project_id={project_id}, biz_id={biz_id}] does not exist".format(
-                task_id=task_id, project_id=project.id, biz_id=project.bk_biz_id
-            )
-        )
-        logger.exception(message)
-        return Response({"result": False, "message": message, "code": err_code.CONTENT_NOT_EXIST.code})
+    taskflow, error_response = get_taskflow_for_log("get_task_plugin_log", task_id, project)
+    if error_response is not None:
+        return error_response
 
+    node_id = request.GET.get("node_id")
     trace_id = request.GET.get("trace_id")
     scroll_id = request.GET.get("scroll_id")
     plugin_code = request.GET.get("plugin_code")
+    error_response = validate_task_node("get_task_plugin_log", taskflow, node_id)
+    if error_response is not None:
+        return error_response
+
+    error_response = validate_node_plugin_trace("get_task_plugin_log", node_id, trace_id, plugin_code)
+    if error_response is not None:
+        return error_response
 
     return Response(fetch_task_plugin_log(plugin_code, trace_id, scroll_id))

--- a/gcloud/tests/apigw/views/test_get_task_log.py
+++ b/gcloud/tests/apigw/views/test_get_task_log.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import ujson as json
+from mock import MagicMock, patch
+
+from gcloud import err_code
+from gcloud.tests.mock import MockProject, MockTaskFlowInstance
+from gcloud.tests.mock_settings import PROJECT_GET, TASKINSTANCE_GET
+
+from .utils import APITest
+
+TEST_PROJECT_ID = "123"
+TEST_PROJECT_NAME = "biz name"
+TEST_BIZ_CC_ID = "123"
+TEST_TASKFLOW_ID = "2"
+TEST_NODE_ID = "node_id"
+TEST_TRACE_ID = "trace_id"
+TEST_PLUGIN_CODE = "plugin_code"
+
+
+class GetTaskNodeLogAPITest(APITest):
+    def url(self):
+        return "/apigw/get_task_node_log/{task_id}/{project_id}/"
+
+    @patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_get_task_node_log__node_not_in_task(self):
+        mock_taskflow = MockTaskFlowInstance(id=TEST_TASKFLOW_ID)
+        mock_taskflow.has_node = MagicMock(return_value=False)
+
+        with patch(TASKINSTANCE_GET, MagicMock(return_value=mock_taskflow)):
+            with patch(
+                "gcloud.apigw.views.get_task_node_log.fetch_task_node_log",
+                MagicMock(return_value={"result": True, "message": "success", "data": "log"}),
+            ) as mock_fetch_log:
+                response = self.client.get(
+                    path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                    data={"node_id": TEST_NODE_ID, "version": "legacy"},
+                )
+
+        data = json.loads(response.content)
+        self.assertFalse(data["result"])
+        self.assertEqual(data["code"], err_code.CONTENT_NOT_EXIST.code)
+        mock_taskflow.has_node.assert_called_once_with(TEST_NODE_ID)
+        mock_fetch_log.assert_not_called()
+
+
+class GetTaskPluginLogAPITest(APITest):
+    def url(self):
+        return "/apigw/get_task_plugin_log/{task_id}/{project_id}/"
+
+    @patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_get_task_plugin_log__node_not_in_task(self):
+        mock_taskflow = MockTaskFlowInstance(id=TEST_TASKFLOW_ID)
+        mock_taskflow.has_node = MagicMock(return_value=False)
+
+        with patch(TASKINSTANCE_GET, MagicMock(return_value=mock_taskflow)):
+            with patch(
+                "gcloud.apigw.views.get_task_plugin_log.fetch_task_plugin_log",
+                MagicMock(return_value={"result": True, "message": "success", "data": {"logs": "log"}}),
+            ) as mock_fetch_log:
+                response = self.client.get(
+                    path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                    data={"node_id": TEST_NODE_ID, "trace_id": TEST_TRACE_ID, "plugin_code": TEST_PLUGIN_CODE},
+                )
+
+        data = json.loads(response.content)
+        self.assertFalse(data["result"])
+        self.assertEqual(data["code"], err_code.CONTENT_NOT_EXIST.code)
+        mock_taskflow.has_node.assert_called_once_with(TEST_NODE_ID)
+        mock_fetch_log.assert_not_called()
+
+    @patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_get_task_plugin_log__trace_id_not_in_node(self):
+        mock_taskflow = MockTaskFlowInstance(id=TEST_TASKFLOW_ID)
+        mock_taskflow.has_node = MagicMock(return_value=True)
+        execution_data = MagicMock(outputs={"trace_id": "other_trace_id"}, inputs={"plugin_code": TEST_PLUGIN_CODE})
+
+        with patch(TASKINSTANCE_GET, MagicMock(return_value=mock_taskflow)):
+            with patch(
+                "gcloud.apigw.log_auth.get_execution_data_for_node",
+                MagicMock(return_value=(execution_data, None)),
+            ) as mock_get_execution_data:
+                with patch(
+                    "gcloud.apigw.views.get_task_plugin_log.fetch_task_plugin_log",
+                    MagicMock(return_value={"result": True, "message": "success", "data": {"logs": "log"}}),
+                ) as mock_fetch_log:
+                    response = self.client.get(
+                        path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                        data={"node_id": TEST_NODE_ID, "trace_id": TEST_TRACE_ID, "plugin_code": TEST_PLUGIN_CODE},
+                    )
+
+        data = json.loads(response.content)
+        self.assertFalse(data["result"])
+        self.assertEqual(data["code"], err_code.CONTENT_NOT_EXIST.code)
+        mock_taskflow.has_node.assert_called_once_with(TEST_NODE_ID)
+        mock_get_execution_data.assert_called_once_with("get_task_plugin_log", TEST_NODE_ID)
+        mock_fetch_log.assert_not_called()
+
+
+class GetNodeJobExecutedLogAPITest(APITest):
+    def url(self):
+        return "/apigw/get_node_job_executed_log/{task_id}/{project_id}/"
+
+    @patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_get_node_job_executed_log__node_not_in_task(self):
+        mock_taskflow = MockTaskFlowInstance(id=TEST_TASKFLOW_ID)
+        mock_taskflow.has_node = MagicMock(return_value=False)
+
+        with patch(TASKINSTANCE_GET, MagicMock(return_value=mock_taskflow)):
+            with patch(
+                "gcloud.apigw.views.get_node_job_executed_log.fetch_node_job_executed_log",
+                MagicMock(return_value={"result": True, "message": "success", "logs": "log"}),
+            ) as mock_fetch_log:
+                response = self.client.get(
+                    path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                    data={"node_id": TEST_NODE_ID},
+                )
+
+        data = json.loads(response.content)
+        self.assertFalse(data["result"])
+        self.assertEqual(data["code"], err_code.CONTENT_NOT_EXIST.code)
+        mock_taskflow.has_node.assert_called_once_with(TEST_NODE_ID)
+        mock_fetch_log.assert_not_called()


### PR DESCRIPTION
## 变更说明
- 外部网关日志接口在通过 `task_id` 完成任务鉴权后，补充校验 `node_id` 必须属于该任务，避免授权任务与实际查询日志节点不一致。
- `get_task_plugin_log` 增加 `node_id` 入参校验，并校验 `trace_id` / `plugin_code` 与节点执行数据绑定。
- 将日志对象绑定校验 helper 放在 `gcloud/apigw/log_auth.py`，避免在 `views` 目录新增非接口模块。
- 修正 `get_task_node_log` / `get_task_plugin_log` 网关资源路径，补充 `task_id` / `bk_biz_id` 路径参数，并要求用户认证。
- 增加 APIGW 单测覆盖跨任务 `node_id` 和插件日志 `trace_id` 不匹配场景。

## 验证
- `python -m compileall -q gcloud/apigw/log_auth.py gcloud/apigw/views/get_task_node_log.py gcloud/apigw/views/get_task_plugin_log.py gcloud/apigw/views/get_node_job_executed_log.py gcloud/tests/apigw/views/test_get_task_log.py`
- `uvx black==22.8.0 --check gcloud/apigw/log_auth.py gcloud/apigw/views/get_task_node_log.py gcloud/apigw/views/get_task_plugin_log.py gcloud/apigw/views/get_node_job_executed_log.py gcloud/tests/apigw/views/test_get_task_log.py`
- `uvx isort==5.6.4 --check-only --profile black --filter-files gcloud/apigw/log_auth.py gcloud/apigw/views/get_task_node_log.py gcloud/apigw/views/get_task_plugin_log.py gcloud/apigw/views/get_node_job_executed_log.py gcloud/tests/apigw/views/test_get_task_log.py`
- `uvx flake8==3.7.9 --max-line-length=120 gcloud/apigw/log_auth.py gcloud/apigw/views/get_task_node_log.py gcloud/apigw/views/get_task_plugin_log.py gcloud/apigw/views/get_node_job_executed_log.py gcloud/tests/apigw/views/test_get_task_log.py`

说明：本地 `python manage.py test gcloud.tests.apigw.views.test_get_task_log` 受当前环境缺少 Django 影响未能启动。