### PR TITLE
fix: 修复多个接口越权(Broken Access Control)及信息泄露问题

### DIFF
--- a/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/HttpCallback.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/HttpCallback.vue
@@ -551,6 +551,7 @@
                     return
                 }
                 const params = {
+                    project_id: this.$store.state.project_id,
                     method: this.localWebhookForm.method,
                     endpoint: this.localWebhookForm.endpoint,
                     authorization: authorization.type === 'basic' ? basicAuth : authorization,

--- a/gcloud/apigw/views/get_node_job_executed_log_for_inner.py
+++ b/gcloud/apigw/views/get_node_job_executed_log_for_inner.py
@@ -16,13 +16,31 @@ from blueapps.account.decorators import login_exempt
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
+from gcloud import err_code
+from gcloud.apigw.decorators import mark_request_whether_is_trust
 from gcloud.apigw.views.get_node_job_executed_log import fetch_node_job_executed_log
 
 
 @login_exempt
 @api_view(["GET"])
 @apigw_require
+@mark_request_whether_is_trust
 def get_node_job_executed_log_for_inner(request):
+    """
+    内部接口，仅限于内部使用，免去用户登录、IAM 鉴权等操作。
+
+    仅允许处于 APIGW 信任名单（is_trust）的应用调用，避免任意网关应用借此
+    绕过用户 IAM 校验读取作业平台执行日志（BAC / 信息泄露）
+    """
+    if not request.is_trust:
+        return Response(
+            {
+                "result": False,
+                "message": "you have no permission to call this api.",
+                "code": err_code.REQUEST_FORBIDDEN_INVALID.code,
+            }
+        )
+
     bk_biz_id = request.query_params.get("bk_biz_id")
     node_id = request.query_params.get("node_id")
     job_scope_type = request.query_params.get("job_scope_type")

--- a/gcloud/apigw/views/get_task_effective_time_for_inner.py
+++ b/gcloud/apigw/views/get_task_effective_time_for_inner.py
@@ -19,15 +19,29 @@ from rest_framework.response import Response
 from gcloud import err_code
 from gcloud.analysis_statistics.service import effective_time_for_task
 from gcloud.apigw.constants import PROJECT_SCOPE_CMDB_BIZ
+from gcloud.apigw.decorators import mark_request_whether_is_trust
 
 
 @login_exempt
 @api_view(["GET"])
 @apigw_require
+@mark_request_whether_is_trust
 def get_task_effective_time_for_inner(request, task_id, bk_biz_id):
     """
     统计任务的有效执行时间（排除人工节点及其等待时间，以及失败后等待时间）
+
+    仅允许处于 APIGW 信任名单（is_trust）的应用调用，避免任意网关应用借此
+    绕过用户 IAM 校验跨业务读取任务有效执行时间统计（BAC / 信息泄露）
     """
+    if not request.is_trust:
+        return Response(
+            {
+                "result": False,
+                "message": "you have no permission to call this api.",
+                "code": err_code.REQUEST_FORBIDDEN_INVALID.code,
+            }
+        )
+
     scope = request.query_params.get("scope", PROJECT_SCOPE_CMDB_BIZ)
     debug_mode = request.query_params.get("debug", "0") == "1"
     try:

--- a/gcloud/apigw/views/get_task_node_log_for_inner.py
+++ b/gcloud/apigw/views/get_task_node_log_for_inner.py
@@ -17,17 +17,32 @@ from blueapps.account.decorators import login_exempt
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
+from gcloud import err_code
+from gcloud.apigw.decorators import mark_request_whether_is_trust
 from gcloud.apigw.views.get_task_node_log import DEFAULT_PAGE, DEFAULT_PAGE_SIZE, fetch_task_node_log
 
 
 @login_exempt
 @api_view(["GET"])
 @apigw_require
+@mark_request_whether_is_trust
 def get_task_node_log_for_inner(request):
     """
     内部接口，仅限于内部使用
     免去用户登录、iam鉴权等操作
+
+    仅允许处于 APIGW 信任名单（is_trust）的应用调用，避免任意网关应用借此
+    绕过用户 IAM 校验读取任务节点日志（BAC / 信息泄露）
     """
+    if not request.is_trust:
+        return Response(
+            {
+                "result": False,
+                "message": "you have no permission to call this api.",
+                "code": err_code.REQUEST_FORBIDDEN_INVALID.code,
+            }
+        )
+
     page = request.query_params.get("page", DEFAULT_PAGE)
     page_size = request.query_params.get("page_size", DEFAULT_PAGE_SIZE)
     node_id = request.query_params.get("node_id")

--- a/gcloud/apigw/views/get_task_plugin_log_for_inner.py
+++ b/gcloud/apigw/views/get_task_plugin_log_for_inner.py
@@ -17,6 +17,8 @@ from blueapps.account.decorators import login_exempt
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
+from gcloud import err_code
+from gcloud.apigw.decorators import mark_request_whether_is_trust
 from gcloud.apigw.views.get_task_plugin_log import fetch_task_plugin_log
 from plugin_service.api_decorators import validate_params
 from plugin_service.serializers import LogQuerySerializer
@@ -25,12 +27,25 @@ from plugin_service.serializers import LogQuerySerializer
 @login_exempt
 @api_view(["GET"])
 @apigw_require
+@mark_request_whether_is_trust
 @validate_params(LogQuerySerializer)
 def get_task_plugin_log_for_inner(request):
     """
     内部接口，仅限于内部使用
     免去用户登录、iam鉴权等操作
+
+    仅允许处于 APIGW 信任名单（is_trust）的应用调用，避免任意网关应用借此
+    绕过用户 IAM 校验读取插件日志（BAC / 信息泄露）
     """
+    if not request.is_trust:
+        return Response(
+            {
+                "result": False,
+                "message": "you have no permission to call this api.",
+                "code": err_code.REQUEST_FORBIDDEN_INVALID.code,
+            }
+        )
+
     trace_id = request.validated_data.get("trace_id")
     scroll_id = request.validated_data.get("scroll_id")
     plugin_code = request.validated_data.get("plugin_code")

--- a/gcloud/apigw/views/operate_node.py
+++ b/gcloud/apigw/views/operate_node.py
@@ -73,7 +73,16 @@ def operate_node(request, project_id, task_id):
         "inputs": inputs,
         "flow_id": req_data.get("flow_id", ""),
     }
-    task = TaskFlowInstance.objects.get(pk=task_id)
+    try:
+        task = TaskFlowInstance.objects.get(pk=task_id, project_id=request.project.id)
+    except TaskFlowInstance.DoesNotExist:
+        return {
+            "result": False,
+            "message": "task[id={task_id}] of project[id={project_id}] does not exist".format(
+                task_id=task_id, project_id=request.project.id
+            ),
+            "code": err_code.CONTENT_NOT_EXIST.code,
+        }
     result = task.nodes_action(action, node_id, username, **kwargs)
     result["code"] = err_code.SUCCESS.code if result["result"] else err_code.UNKNOWN_ERROR.code
     return result

--- a/gcloud/apigw/views/plugin_proxy.py
+++ b/gcloud/apigw/views/plugin_proxy.py
@@ -13,16 +13,16 @@ specific language governing permissions and limitations under the License.
 from urllib.parse import urlsplit
 
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.test import RequestFactory
-from django.urls import resolve, Resolver404
+from django.urls import Resolver404, resolve
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
 from gcloud.apigw.views.utils import logger
-from apigw_manager.apigw.decorators import apigw_require
 
 
 @login_exempt
@@ -39,7 +39,16 @@ def dispatch_plugin_query(request):
         "method": 'GET|POST',
         "data": data, POST请求的数据
     }
+
+    该接口会解析并直接调用任意可路由的内部视图，仅允许处于 APIGW 信任名单(is_trust)的应用调用，
+    避免任意网关应用借此转发器触达内部视图、绕过网关边界造成越权或内部接口滥用(BAC)
     """
+    if not request.is_trust:
+        return {
+            "result": False,
+            "message": "you have no permission to call this api.",
+            "code": err_code.REQUEST_FORBIDDEN_INVALID.code,
+        }
 
     try:
         params = json.loads(request.body)

--- a/gcloud/apigw/views/query_task_count.py
+++ b/gcloud/apigw/views/query_task_count.py
@@ -13,18 +13,17 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
-from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.apigw.decorators import project_inject
-from gcloud.contrib.analysis.analyse_items import task_flow_instance
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
 from gcloud.apigw.views.utils import logger
+from gcloud.contrib.analysis.analyse_items import task_flow_instance
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import ProjectViewInterceptor
-from apigw_manager.apigw.decorators import apigw_require
 
 
 @login_exempt
@@ -60,6 +59,9 @@ def query_task_count(request, project_id):
 
     filters = {"project_id": project.id, "is_deleted": False}
     filters.update(conditions)
+    # 强制收敛到 URL 上已鉴权的项目，避免 conditions 携带 project_id 覆盖项目作用域
+    # 造成跨项目任务计数越权(BAC)；is_trust 应用同样不能绕过本项目限制
+    filters["project_id"] = project.id
     success, content = task_flow_instance.dispatch(group_by, filters)
     if not success:
         return {"result": False, "message": content, "code": err_code.UNKNOWN_ERROR.code}

--- a/gcloud/common_template/apis/django/api.py
+++ b/gcloud/common_template/apis/django/api.py
@@ -19,6 +19,7 @@ from rest_framework.decorators import api_view
 from gcloud.common_template.models import CommonTemplate
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.common_template import (
+    CheckBeforeImportInterceptor,
     ExportInterceptor,
     FormInterceptor,
     ImportInterceptor,
@@ -169,6 +170,7 @@ def import_templates(request):
 )
 @api_view(["POST"])
 @request_validate(CheckBeforeImportValidator)
+@iam_intercept(CheckBeforeImportInterceptor())
 def check_before_import(request):
     """
     检测 DAT 文件是否支持导入

--- a/gcloud/contrib/analysis/views.py
+++ b/gcloud/contrib/analysis/views.py
@@ -43,12 +43,14 @@ def get_task_category(request):
 
 
 @require_GET
+@iam_intercept(StatisticsViewInpterceptor())
 def get_biz_useage(request, query):
     """
     @summary 获取正在使用业务数量、总业务数量
     :param request:
     :param query:模板/任务
-    :return:
+
+    与其它统计接口一致校验 STATISTICS_VIEW，避免任意登录用户读取平台级业务使用聚合数据(信息泄露)
     """
     total = Project.objects.all().count()
     if query == "template":

--- a/gcloud/contrib/appmaker/api.py
+++ b/gcloud/contrib/appmaker/api.py
@@ -25,6 +25,8 @@ from gcloud.contrib.appmaker.models import AppMaker
 from gcloud.contrib.appmaker.schema import APP_MAKER_PARAMS_SCHEMA
 from gcloud.contrib.audit.utils import bk_audit_add_event
 from gcloud.iam_auth import IAMMeta
+from gcloud.iam_auth.intercept import iam_intercept
+from gcloud.iam_auth.view_interceptors.project import ProjectViewInterceptor
 from gcloud.utils.strings import check_and_rename_params
 
 logger = logging.getLogger("root")
@@ -61,9 +63,7 @@ def save(request, project_id):
         file_size = logo_obj.size
         # LOGO大小不能大于 100K
         if file_size > 100 * 1024:
-            message = _(
-                "轻应用保存失败: 非法的图片大小, 请使用不超过100KB 的 JPG / PNG 图片作为应用LOGO | appmaker save"
-            )
+            message = _("轻应用保存失败: 非法的图片大小, 请使用不超过100KB 的 JPG / PNG 图片作为应用LOGO | appmaker save")
             logger.error(message)
             return JsonResponse({"result": False, "message": message})
         logo_content = logo_obj.read()
@@ -107,6 +107,7 @@ def save(request, project_id):
 
 
 @require_GET
+@iam_intercept(ProjectViewInterceptor())
 def get_appmaker_count(request, project_id):
     group_by = request.GET.get("group_by", "category")
     result_dict = check_and_rename_params({}, group_by)

--- a/gcloud/core/apis/drf/serilaziers/task_template.py
+++ b/gcloud/core/apis/drf/serilaziers/task_template.py
@@ -137,6 +137,7 @@ class TemplateLabelQuerySerializer(serializers.Serializer):
 
 
 class WebhookConfigQuerySerializer(serializers.Serializer):
+    project_id = serializers.IntegerField(help_text=_("project id"), required=True)
     method = serializers.CharField(help_text=_("webhook method"), max_length=255, required=True)
     endpoint = serializers.URLField(help_text=_("webhook endpoint"), max_length=255, required=True)
     headers = serializers.JSONField(help_text=_("webhook headers"), required=False)

--- a/gcloud/core/apis/drf/viewsets/collection.py
+++ b/gcloud/core/apis/drf/viewsets/collection.py
@@ -59,12 +59,17 @@ class CollectionViewSet(GcloudReadOnlyViewSet, mixins.CreateModelMixin, mixins.D
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data, many=True)
         serializer.is_valid(raise_exception=True)
+        # 强制将 username 锁定为当前登录用户，避免攻击者通过请求体伪造他人 username
+        # 在他人收藏列表中写入数据（污染他人个人面板的未授权写入）
+        current_username = request.user.username
         for item in serializer.validated_data:
-            username = item["username"]
+            item["username"] = current_username
             category = item["category"]
             instance_id = item["instance_id"]
-            if Collection.objects.filter(username=username, category=category, instance_id=instance_id).exists():
-                message = _(f"重复收藏: {username}实例ID: {category}, 类别: {instance_id}, 已经收藏过了, 无需再次收藏")
+            if Collection.objects.filter(
+                username=current_username, category=category, instance_id=instance_id
+            ).exists():
+                message = _(f"重复收藏: {current_username}实例ID: {category}, 类别: {instance_id}, 已经收藏过了, 无需再次收藏")
                 logger.error(message)
                 return Response({"detail": ErrorDetail(message, err_code.REQUEST_PARAM_INVALID.code)}, exception=True)
         self.perform_create(serializer)

--- a/gcloud/core/apis/drf/viewsets/project.py
+++ b/gcloud/core/apis/drf/viewsets/project.py
@@ -20,6 +20,7 @@ from gcloud.core.apis.drf.serilaziers import ProjectSerializer
 from gcloud.core.apis.drf.viewsets.base import GcloudListViewSet, GcloudUpdateViewSet
 from gcloud.core.models import Project
 from gcloud.iam_auth import IAMMeta, res_factory
+from gcloud.iam_auth.utils import get_user_projects
 
 
 class ProjectPermission(IamPermission):
@@ -64,6 +65,15 @@ class ProjectSetViewSet(GcloudUpdateViewSet, GcloudListViewSet):
             IAMMeta.PROJECT_FAST_CREATE_TASK_ACTION,
         ],
     )
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        # list 行为原先无任何鉴权(pass_all)，会向任意登录用户暴露全平台项目清单，
+        # 这里收敛为当前用户有查看权限的项目，避免跨项目/跨业务项目枚举(信息泄露)
+        if getattr(self, "action", None) == "list":
+            user_project_ids = list(get_user_projects(self.request.user.username).values_list("id", flat=True))
+            queryset = queryset.filter(id__in=user_project_ids)
+        return queryset
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/gcloud/core/apis/drf/viewsets/resource_config.py
+++ b/gcloud/core/apis/drf/viewsets/resource_config.py
@@ -11,25 +11,55 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 from django.http import QueryDict
+from iam import Action, Subject
+from iam.shortcuts import allow_or_raise_auth_failed
 from rest_framework import mixins, permissions, viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
-from gcloud.core.apis.drf.permission import IamPermission, IamPermissionInfo
-from gcloud.core.models import ResourceConfig
 from gcloud.core.apis.drf.serilaziers import ResourceConfigSerializer
 from gcloud.core.apis.drf.viewsets.utils import ApiMixin
-from gcloud.iam_auth import res_factory, IAMMeta
+from gcloud.core.models import ResourceConfig
+from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
+
+iam = get_iam_client()
 
 
-class ResourceConfigPermission(IamPermission):
-    resource_func = res_factory.resources_for_project
-    actions = {
-        "list": IamPermissionInfo(IAMMeta.PROJECT_VIEW_ACTION, resource_func, id_field="project_id"),
-        "create": IamPermissionInfo(IAMMeta.PROJECT_VIEW_ACTION, resource_func, id_field="project_id"),
-        "update": IamPermissionInfo(IAMMeta.PROJECT_VIEW_ACTION, resource_func, id_field="project_id"),
-        "retrieve": IamPermissionInfo(IAMMeta.PROJECT_VIEW_ACTION, resource_func, id_field="project_id"),
-        "partial_update": IamPermissionInfo(IAMMeta.PROJECT_VIEW_ACTION, resource_func, id_field="project_id"),
-    }
+class ResourceConfigPermission(permissions.BasePermission):
+    """资源配置权限校验
+
+    - list/create 通过请求参数中的 project_id 校验项目级权限；
+    - retrieve/update/partial_update 通过对象自身的 project_id 校验，避免攻击者借助
+      请求参数中的 project_id 越权读取/修改其它项目的资源配置（IDOR）；
+    - 写操作要求 project_edit，而非 project_view。
+    """
+
+    @staticmethod
+    def _auth_project(request, action, project_id):
+        if not project_id:
+            raise PermissionDenied
+        allow_or_raise_auth_failed(
+            iam=iam,
+            system=IAMMeta.SYSTEM_ID,
+            subject=Subject("user", request.user.username),
+            action=Action(action),
+            resources=res_factory.resources_for_project(project_id),
+        )
+
+    def has_permission(self, request, view):
+        if view.action == "list":
+            project_id = request.query_params.get("project_id")
+            self._auth_project(request, IAMMeta.PROJECT_VIEW_ACTION, project_id)
+        elif view.action == "create":
+            project_id = request.data.get("project_id")
+            self._auth_project(request, IAMMeta.PROJECT_EDIT_ACTION, project_id)
+        # retrieve/update/partial_update 交由 has_object_permission 基于对象校验
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        action = IAMMeta.PROJECT_VIEW_ACTION if view.action == "retrieve" else IAMMeta.PROJECT_EDIT_ACTION
+        self._auth_project(request, action, obj.project_id)
+        return True
 
 
 class ResourceConfigViewSet(

--- a/gcloud/core/apis/drf/viewsets/staff_group.py
+++ b/gcloud/core/apis/drf/viewsets/staff_group.py
@@ -10,12 +10,12 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from rest_framework import permissions, mixins, viewsets
+from rest_framework import mixins, permissions, viewsets
 from rest_framework.response import Response
 
-from gcloud.core.models import StaffGroupSet
-from gcloud.core.apis.drf.serilaziers.staff_group import StaffGroupSetSerializer, ListSerializer
+from gcloud.core.apis.drf.serilaziers.staff_group import ListSerializer, StaffGroupSetSerializer
 from gcloud.core.apis.drf.viewsets.utils import ApiMixin, IAMMixin
+from gcloud.core.models import StaffGroupSet
 from gcloud.iam_auth import IAMMeta, res_factory
 
 
@@ -51,24 +51,28 @@ class StaffGroupSetViewSet(
     def create(self, request, *args, **kwargs):
         validated_data = self.get_serializer_data(request)
 
-        staff_group_obj = StaffGroupSet.objects.create(**validated_data)
-        self.iam_auth_check(
-            request,
-            action=IAMMeta.PROJECT_EDIT_ACTION,
-            resources=res_factory.resources_for_project(staff_group_obj.project_id),
-        )
-        serializer = self.serializer_class(instance=staff_group_obj)
-        return Response(serializer.data)
-
-    def update(self, request, *args, **kwargs):
-        validated_data = self.get_serializer_data(request)
+        # 先鉴权再落库，避免鉴权失败时已写入脏数据
         self.iam_auth_check(
             request,
             action=IAMMeta.PROJECT_EDIT_ACTION,
             resources=res_factory.resources_for_project(validated_data.get("project_id")),
         )
+        staff_group_obj = StaffGroupSet.objects.create(**validated_data)
+        serializer = self.serializer_class(instance=staff_group_obj)
+        return Response(serializer.data)
 
+    def update(self, request, *args, **kwargs):
+        validated_data = self.get_serializer_data(request)
+
+        # 基于待修改对象自身所属项目进行鉴权，避免攻击者通过请求体中的 project_id
+        # 越权修改其它项目的人员分组（IDOR）
         instance = self.get_object()
+        self.iam_auth_check(
+            request,
+            action=IAMMeta.PROJECT_EDIT_ACTION,
+            resources=res_factory.resources_for_project(instance.project_id),
+        )
+
         instance.name = validated_data.get("name")
         instance.members = validated_data.get("members")
         instance.save()

--- a/gcloud/core/apis/drf/viewsets/task_template.py
+++ b/gcloud/core/apis/drf/viewsets/task_template.py
@@ -91,7 +91,7 @@ class TaskTemplatePermission(IamPermission):
             IAMMeta.FLOW_EDIT_ACTION, res_factory.resources_for_flow_obj, HAS_OBJECT_PERMISSION
         ),
         "verify_webhook_configuration": IamPermissionInfo(
-            IAMMeta.FLOW_EDIT_ACTION, res_factory.resources_for_flow_obj, HAS_OBJECT_PERMISSION
+            IAMMeta.PROJECT_VIEW_ACTION, res_factory.resources_for_project, id_field="project_id"
         ),
     }
 
@@ -426,6 +426,7 @@ class TaskTemplateViewSet(GcloudModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         verify_data = serializer.validated_data.copy()
+        verify_data.pop("project_id", None)
         verify_data["url"] = verify_data.pop("endpoint")
 
         try:

--- a/gcloud/core/apis/drf/viewsets/task_template.py
+++ b/gcloud/core/apis/drf/viewsets/task_template.py
@@ -22,7 +22,7 @@ from drf_yasg.utils import swagger_auto_schema
 from pipeline.models import TemplateRelationship, TemplateScheme
 from rest_framework import permissions, status
 from rest_framework.decorators import action
-from rest_framework.exceptions import ErrorDetail
+from rest_framework.exceptions import ErrorDetail, PermissionDenied
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 from webhook.api import verify_webhook_endpoint
@@ -395,6 +395,12 @@ class TaskTemplateViewSet(GcloudModelViewSet):
     def enable_independent_subprocess(self, request, *args, **kwargs):
         template_id = kwargs.get("pk")
         project_id = request.query_params.get("project_id")
+        # 鉴权仅校验了请求参数 project_id 的 project_view，需进一步确认 template 确属该项目，
+        # 避免借自有项目权限跨项目读取其它项目模板的子流程配置(IDOR)；
+        # template_id=-1 为新建未保存场景，无归属可校验，直接放行
+        if template_id and str(template_id) != "-1":
+            if not TaskTemplate.objects.filter(id=template_id, project_id=project_id).exists():
+                raise PermissionDenied("template does not belong to the specified project")
         independent_subprocess_enable = TaskConfig.objects.enable_independent_subprocess(project_id, template_id)
         return Response({"enable": independent_subprocess_enable})
 
@@ -402,6 +408,11 @@ class TaskTemplateViewSet(GcloudModelViewSet):
     @action(methods=["GET"], detail=True)
     def common_info(self, request, *args, **kwargs):
         template = self.get_object()
+        # 鉴权基于请求参数 project__id 的 project_view，但 get_object 按 pk 取任意模板，
+        # 需确认 template 确属该项目，避免借自有项目权限跨项目读取流程名称/执行方案(IDOR)
+        project_id = request.query_params.get("project__id")
+        if str(template.project_id) != str(project_id):
+            raise PermissionDenied("template does not belong to the specified project")
         schemes = TemplateScheme.objects.filter(template=template.pipeline_template).values_list("id", "name")
         schemes_info = [{"id": scheme_id, "name": scheme_name} for scheme_id, scheme_name in schemes]
         return Response({"name": template.name, "schemes": schemes_info})

--- a/gcloud/core/apis/drf/viewsets/task_template.py
+++ b/gcloud/core/apis/drf/viewsets/task_template.py
@@ -90,8 +90,11 @@ class TaskTemplatePermission(IamPermission):
         "update_template_labels": IamPermissionInfo(
             IAMMeta.FLOW_EDIT_ACTION, res_factory.resources_for_flow_obj, HAS_OBJECT_PERMISSION
         ),
+        # 该接口为 detail=False 的 POST，会驱动服务端向外部 URL 发起验证请求(出站请求/潜在 SSRF 入口)，
+        # 因此不能下放到 PROJECT_VIEW(任意项目查看者均可触发出站请求)。受限于 detail=False 无法做对象级
+        # FLOW_EDIT，这里收敛为项目级的写意图权限 FLOW_CREATE(具备在该项目下编排流程的权限方可校验 webhook)。
         "verify_webhook_configuration": IamPermissionInfo(
-            IAMMeta.PROJECT_VIEW_ACTION, res_factory.resources_for_project, id_field="project_id"
+            IAMMeta.FLOW_CREATE_ACTION, res_factory.resources_for_project, id_field="project_id"
         ),
     }
 

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -271,7 +271,9 @@ class TaskFlowInstancePermission(IamPermission, IAMMixin):
         "destroy": IamPermissionInfo(
             IAMMeta.TASK_DELETE_ACTION, res_factory.resources_for_task_obj, HAS_OBJECT_PERMISSION
         ),
-        "enable_fill_retry_params": IamPermissionInfo(pass_all=True),
+        "enable_fill_retry_params": IamPermissionInfo(
+            IAMMeta.TASK_VIEW_ACTION, res_factory.resources_for_task_obj, HAS_OBJECT_PERMISSION
+        ),
         "node_snapshot_config": IamPermissionInfo(
             IAMMeta.TASK_VIEW_ACTION, res_factory.resources_for_task_obj, HAS_OBJECT_PERMISSION
         ),
@@ -695,8 +697,9 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
     @swagger_auto_schema(method="GET", operation_summary="查询任务是否支持重试填参")
     @action(methods=["GET"], detail=True)
     def enable_fill_retry_params(self, request, *args, **kwargs):
-        task_id = kwargs["pk"]
-        return Response({"enable": TaskConfig.objects.enable_fill_retry_params(task_id)})
+        # 通过 get_object 触发对象级 task_view 权限校验，避免任意用户探测他人任务配置
+        task = self.get_object()
+        return Response({"enable": TaskConfig.objects.enable_fill_retry_params(task.id)})
 
     @swagger_auto_schema(
         method="GET",

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -633,21 +633,27 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
     @action(methods=["GET"], detail=False)
     def list_children_taskflow(self, request, *args, **kwargs):
         root_task_id = request.query_params.get("root_task_id")
+        # 鉴权(IamUserTypeBasedValidator)接受 project__id / project_id，但 TaskFlowFilterSet 仅识别
+        # project__id，导致仅传 project_id 时子任务未按项目收敛，可跨项目读取他人任务的子任务数据(IDOR)。
+        # 这里显式按已鉴权项目过滤子任务及关系，确保数据作用域与鉴权作用域一致
+        project_id = request.query_params.get("project__id") or request.query_params.get("project_id")
         children_task_info = TaskFlowRelation.objects.filter(root_task_id=root_task_id).values(
             "task_id", "parent_task_id"
         )
         children_task_ids = [info["task_id"] for info in children_task_info]
         queryset = TaskFlowInstance.objects.filter(
-            id__in=children_task_ids, pipeline_instance__isnull=False, is_deleted=Value(0)
+            id__in=children_task_ids, project_id=project_id, pipeline_instance__isnull=False, is_deleted=Value(0)
         )
         queryset = self.filter_queryset(queryset)
         serializer = self.get_serializer(queryset, many=True)
         data = self.injection_auth_actions(request, serializer.data, queryset)
         self._inject_template_related_info(request, data)
 
+        allowed_task_ids = {item["id"] for item in data}
         relations = {}
         for info in children_task_info:
-            relations.setdefault(info["parent_task_id"], []).append(info["task_id"])
+            if info["task_id"] in allowed_task_ids:
+                relations.setdefault(info["parent_task_id"], []).append(info["task_id"])
         return Response({"tasks": data, "relations": relations})
 
     @swagger_auto_schema(
@@ -661,10 +667,16 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
         task_ids = request.query_params.get("task_ids") or []
         if task_ids:
             task_ids = [int(task_id) for task_id in task_ids.split(",")]
-        root_task_ids = TaskFlowRelation.objects.filter(root_task_id__in=task_ids).values_list(
-            "root_task_id", flat=True
+        # 仅统计属于已鉴权项目的任务，避免跨项目探测他人任务的子流程结构(IDOR)；
+        # 不属于该项目的 task_id 一律返回 False
+        project_id = request.query_params.get("project__id") or request.query_params.get("project_id")
+        valid_task_ids = set(
+            TaskFlowInstance.objects.filter(id__in=task_ids, project_id=project_id).values_list("id", flat=True)
         )
-        root_task_info = {task_id: True if task_id in root_task_ids else False for task_id in task_ids}
+        root_task_ids = set(
+            TaskFlowRelation.objects.filter(root_task_id__in=valid_task_ids).values_list("root_task_id", flat=True)
+        )
+        root_task_info = {task_id: task_id in root_task_ids for task_id in task_ids}
         return Response({"has_children_taskflow": root_task_info})
 
     @swagger_auto_schema(

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -635,8 +635,10 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
         root_task_id = request.query_params.get("root_task_id")
         # 鉴权(IamUserTypeBasedValidator)接受 project__id / project_id，但 TaskFlowFilterSet 仅识别
         # project__id，导致仅传 project_id 时子任务未按项目收敛，可跨项目读取他人任务的子任务数据(IDOR)。
-        # 这里显式按已鉴权项目过滤子任务及关系，确保数据作用域与鉴权作用域一致
-        project_id = request.query_params.get("project__id") or request.query_params.get("project_id")
+        # 这里显式按已鉴权项目过滤子任务及关系，确保数据作用域与鉴权作用域一致。
+        # 空串归一化为 None：filter(project_id=None) 走 IS NULL 返回空集(拒绝)，避免 filter(project_id="")
+        # 触发整型转换 ValueError 导致 500。
+        project_id = request.query_params.get("project__id") or request.query_params.get("project_id") or None
         children_task_info = TaskFlowRelation.objects.filter(root_task_id=root_task_id).values(
             "task_id", "parent_task_id"
         )
@@ -668,8 +670,8 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
         if task_ids:
             task_ids = [int(task_id) for task_id in task_ids.split(",")]
         # 仅统计属于已鉴权项目的任务，避免跨项目探测他人任务的子流程结构(IDOR)；
-        # 不属于该项目的 task_id 一律返回 False
-        project_id = request.query_params.get("project__id") or request.query_params.get("project_id")
+        # 不属于该项目的 task_id 一律返回 False。空串归一化为 None 避免 filter(project_id="") 触发 500。
+        project_id = request.query_params.get("project__id") or request.query_params.get("project_id") or None
         valid_task_ids = set(
             TaskFlowInstance.objects.filter(id__in=task_ids, project_id=project_id).values_list("id", flat=True)
         )

--- a/gcloud/iam_auth/view_interceptors/common_template.py
+++ b/gcloud/iam_auth/view_interceptors/common_template.py
@@ -11,17 +11,14 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from iam import Action, Subject, Request
+from iam import Action, Request, Subject
 from iam.exceptions import AuthFailedException, MultiAuthFailedException
 
-from gcloud.utils.strings import string_to_boolean
 from gcloud.common_template.models import CommonTemplate
-from gcloud.template_base.utils import read_template_data_file
-
-from gcloud.iam_auth import IAMMeta
-from gcloud.iam_auth import res_factory
-from gcloud.iam_auth import get_iam_client
+from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
 from gcloud.iam_auth.intercept import ViewInterceptor
+from gcloud.template_base.utils import read_template_data_file
+from gcloud.utils.strings import string_to_boolean
 
 iam = get_iam_client()
 
@@ -79,6 +76,22 @@ class ExportInterceptor(ViewInterceptor):
 
         if not_allowed_list:
             raise MultiAuthFailedException(IAMMeta.SYSTEM_ID, subject, action, not_allowed_list)
+
+
+class CheckBeforeImportInterceptor(ViewInterceptor):
+    """公共流程导入前置检测接口的鉴权。
+
+    与正式导入接口(ImportInterceptor)的创建权限保持一致，要求 COMMON_FLOW_CREATE，
+    避免攻击者借助预检接口在无任何公共流程权限的情况下探测导入冲突/覆盖信息(BAC)。
+    """
+
+    def process(self, request, *args, **kwargs):
+        subject = Subject("user", request.user.username)
+        action = Action(IAMMeta.COMMON_FLOW_CREATE_ACTION)
+        create_request = Request(IAMMeta.SYSTEM_ID, subject, action, [], {})
+
+        if not iam.is_allowed(create_request):
+            raise AuthFailedException(IAMMeta.SYSTEM_ID, subject, action, [])
 
 
 class ImportInterceptor(ViewInterceptor):

--- a/gcloud/iam_auth/view_interceptors/project.py
+++ b/gcloud/iam_auth/view_interceptors/project.py
@@ -12,8 +12,10 @@ specific language governing permissions and limitations under the License.
 """
 
 from iam import Action, Subject
+from iam.exceptions import AuthFailedException
 from iam.shortcuts import allow_or_raise_auth_failed
 
+from gcloud.core.models import Project
 from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
 from gcloud.iam_auth.intercept import ViewInterceptor
 
@@ -37,12 +39,25 @@ class _ProjectActionInterceptor(ViewInterceptor):
             project_id = request.GET.get("project_id") or request.POST.get("project_id")
 
         subject = Subject("user", request.user.username)
+        action = Action(self.action)
+
+        # project_id 缺失或指向不存在的项目时，统一按鉴权失败(403)处理：
+        # 1. 避免 resources_for_project 内部 Project.objects.get(id=None/不存在) 抛
+        #    DoesNotExist 造成 500，攻击者可借 500/403 差异探测拦截器是否挂载；
+        # 2. 缺少项目作用域的请求本就无法通过对象级鉴权，直接拒绝更安全。
+        if not project_id:
+            raise AuthFailedException(IAMMeta.SYSTEM_ID, subject, action, [])
+        try:
+            resources = res_factory.resources_for_project(project_id)
+        except Project.DoesNotExist:
+            raise AuthFailedException(IAMMeta.SYSTEM_ID, subject, action, [])
+
         allow_or_raise_auth_failed(
             iam=iam,
             system=IAMMeta.SYSTEM_ID,
             subject=subject,
-            action=Action(self.action),
-            resources=res_factory.resources_for_project(project_id),
+            action=action,
+            resources=resources,
             cache=True,
         )
 

--- a/gcloud/iam_auth/view_interceptors/project.py
+++ b/gcloud/iam_auth/view_interceptors/project.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from iam import Action, Subject
+from iam.shortcuts import allow_or_raise_auth_failed
+
+from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
+from gcloud.iam_auth.intercept import ViewInterceptor
+
+iam = get_iam_client()
+
+
+class _ProjectActionInterceptor(ViewInterceptor):
+    """Django function view 通用项目级 IAM 校验拦截器基类。
+
+    APIGW 侧的 ProjectViewInterceptor 依赖 ``@project_inject`` 注入的
+    ``request.project``，而 Django 侧（taskflow3/tasktmpl3/contrib 等）一般
+    通过 URL 路径以 ``kwargs["project_id"]`` 传入项目 ID，因此提供一份独立的
+    基于 kwargs 的实现，避免在每个视图模块重复书写鉴权样板。
+    """
+
+    action = None
+
+    def process(self, request, *args, **kwargs):
+        project_id = kwargs.get("project_id")
+        if project_id is None:
+            project_id = request.GET.get("project_id") or request.POST.get("project_id")
+
+        subject = Subject("user", request.user.username)
+        allow_or_raise_auth_failed(
+            iam=iam,
+            system=IAMMeta.SYSTEM_ID,
+            subject=subject,
+            action=Action(self.action),
+            resources=res_factory.resources_for_project(project_id),
+            cache=True,
+        )
+
+
+class ProjectViewInterceptor(_ProjectActionInterceptor):
+    """项目查看级权限校验，对应 IAMMeta.PROJECT_VIEW_ACTION。"""
+
+    action = IAMMeta.PROJECT_VIEW_ACTION
+
+
+class ProjectFlowCreateInterceptor(_ProjectActionInterceptor):
+    """项目下流程创建权限校验，对应 IAMMeta.FLOW_CREATE_ACTION。
+
+    用于 import / check_before_import 等"导入前置探测"接口，与正式导入接口的
+    项目级权限保持一致，避免攻击者借助预检接口探测目标项目的流程冲突情况。
+    """
+
+    action = IAMMeta.FLOW_CREATE_ACTION

--- a/gcloud/taskflow3/apis/django/api.py
+++ b/gcloud/taskflow3/apis/django/api.py
@@ -23,8 +23,10 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 from drf_yasg.utils import swagger_auto_schema
+from iam import Action, Subject
 from iam.contrib.http import HTTP_AUTH_FORBIDDEN_CODE
 from iam.exceptions import RawAuthFailedException
+from iam.shortcuts import allow_or_raise_auth_failed
 from rest_framework.decorators import api_view
 
 import env
@@ -35,10 +37,11 @@ from gcloud.contrib.analysis.analyse_items import task_flow_instance
 from gcloud.contrib.audit.utils import bk_audit_add_event
 from gcloud.contrib.operate_record.constants import OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
-from gcloud.core.models import EngineConfig
+from gcloud.core.models import EngineConfig, Project
 from gcloud.core.trace import CallFrom, trace_view
-from gcloud.iam_auth import IAMMeta
+from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
 from gcloud.iam_auth.intercept import iam_intercept
+from gcloud.iam_auth.view_interceptors.project import ProjectViewInterceptor
 from gcloud.iam_auth.view_interceptors.taskflow import (
     BatchStatusViewInterceptor,
     DataViewInterceptor,
@@ -79,6 +82,7 @@ from pipeline_web.preview import preview_template_tree
 
 logger = logging.getLogger("root")
 get_client_by_user = settings.ESB_GET_CLIENT_BY_USER
+iam_client = get_iam_client()
 
 
 @require_GET
@@ -260,6 +264,25 @@ def detail(request, project_id):
 @require_GET
 @request_validate(GetJobInstanceLogValidator)
 def get_job_instance_log(request, biz_cc_id):
+    # 该接口本质上是 bk-sops 代用户向作业平台请求日志，必须先确认调用方在
+    # bk-sops 对应项目内具备 PROJECT_VIEW_ACTION，避免拥有其它产品权限但
+    # 与 bk-sops 项目无关的用户借助本接口跨业务获取日志（BAC）
+    try:
+        project = Project.objects.get(bk_biz_id=biz_cc_id)
+    except Project.DoesNotExist:
+        message = _(f"执行历史请求失败: 项目[bk_biz_id={biz_cc_id}]在标准运维中不存在 | get_job_instance_log")
+        logger.error(message)
+        return JsonResponse(
+            {"result": False, "data": None, "message": message, "code": err_code.CONTENT_NOT_EXIST.code}
+        )
+
+    subject = Subject("user", request.user.username)
+    action = Action(IAMMeta.PROJECT_VIEW_ACTION)
+    resources = res_factory.resources_for_project(project.id)
+    allow_or_raise_auth_failed(
+        iam=iam_client, system=IAMMeta.SYSTEM_ID, subject=subject, action=action, resources=resources
+    )
+
     job_instance_id = request.GET["job_instance_id"]
     bk_scope_type = request.GET.get("bk_scope_type", JobBizScopeType.BIZ.value)
     log_kwargs = {
@@ -463,6 +486,7 @@ def preview_task_tree(request, project_id):
 
 @require_POST
 @request_validate(QueryTaskCountValidator)
+@iam_intercept(ProjectViewInterceptor())
 def query_task_count(request, project_id):
     """
     @summary: 按任务分类统计总数

--- a/gcloud/taskflow3/apis/django/v4/state.py
+++ b/gcloud/taskflow3/apis/django/v4/state.py
@@ -18,6 +18,8 @@ from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_GET
 
 from gcloud import err_code
+from gcloud.iam_auth.intercept import iam_intercept
+from gcloud.iam_auth.view_interceptors.taskflow import StatusViewInterceptor
 from gcloud.taskflow3.apis.django.validators import StatusValidator
 from gcloud.taskflow3.domains.dispatchers import TaskCommandDispatcher
 from gcloud.taskflow3.models import TaskFlowInstance
@@ -28,6 +30,7 @@ logger = logging.getLogger("root")
 
 @require_GET
 @request_validate(StatusValidator)
+@iam_intercept(StatusViewInterceptor())
 def root_state(request, project_id):
     instance_id = request.GET.get("instance_id")
     subprocess_id = request.GET.get("subprocess_id")
@@ -35,9 +38,7 @@ def root_state(request, project_id):
     try:
         task = TaskFlowInstance.objects.get(pk=instance_id, project_id=project_id, is_deleted=False)
     except Exception as e:
-        message = _(
-            f"任务状态请求失败: 请求任务[ID: {instance_id}]的状态发生错误: {e}. 请重试, 如持续失败可联系管理员处理 | get_task_status"
-        )
+        message = _(f"任务状态请求失败: 请求任务[ID: {instance_id}]的状态发生错误: {e}. 请重试, 如持续失败可联系管理员处理 | get_task_status")
         logger.error(message)
         return {
             "result": False,

--- a/gcloud/tasktmpl3/apis/django/api.py
+++ b/gcloud/tasktmpl3/apis/django/api.py
@@ -24,6 +24,7 @@ from gcloud import err_code
 from gcloud.contrib.analysis.analyse_items import task_template
 from gcloud.core.models import ProjectConfig
 from gcloud.iam_auth.intercept import iam_intercept
+from gcloud.iam_auth.view_interceptors.project import ProjectFlowCreateInterceptor, ProjectViewInterceptor
 from gcloud.iam_auth.view_interceptors.template import (
     AgentGenerateProcessInterceptor,
     BatchFormInterceptor,
@@ -197,6 +198,7 @@ def import_templates(request, project_id):
 )
 @api_view(["POST"])
 @request_validate(CheckBeforeImportValidator)
+@iam_intercept(ProjectFlowCreateInterceptor())
 def check_before_import(request, project_id):
     """
     检测 DAT 文件是否支持导入
@@ -246,6 +248,7 @@ def replace_all_templates_tree_node_id(request):
 
 @require_GET
 @request_validate(GetTemplateCountValidator)
+@iam_intercept(ProjectViewInterceptor())
 def get_template_count(request, project_id):
     group_by = request.GET.get("group_by", "category")
     result_dict = check_and_rename_params({}, group_by)
@@ -287,6 +290,7 @@ def draw_pipeline(request):
 
 
 @require_GET
+@iam_intercept(ProjectViewInterceptor())
 def get_templates_with_expired_subprocess(request, project_id):
     return JsonResponse(
         {

--- a/gcloud/template_base/apis/drf/permission.py
+++ b/gcloud/template_base/apis/drf/permission.py
@@ -10,6 +10,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from iam import Action, Subject
 from iam.contrib.tastypie.shortcuts import allow_or_raise_immediate_response_for_resources_list
 from iam.shortcuts import allow_or_raise_auth_failed
 from rest_framework import permissions
@@ -18,7 +19,6 @@ from gcloud.common_template.models import CommonTemplate
 from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
 from gcloud.tasktmpl3.models import TaskTemplate
 from gcloud.template_base.models import DefaultTemplateScheme
-from iam import Action, Subject
 
 iam = get_iam_client()
 
@@ -69,7 +69,9 @@ class SchemeEditPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if view.detail:
             return True
-        action = "edit" if view.action == "create" else "view"
+        # batch_operate 会批量创建/更新/删除执行方案，属于写操作，需校验编辑权限，
+        # 避免仅有查看权限的用户越权修改方案
+        action = "edit" if view.action in ("create", "batch_operate") else "view"
         self.scheme_allow_or_raise_auth_failed(request, action=action)
         return True
 

--- a/gcloud/tests/apigw/views/test_dispatch_plugin_query_trust_gate.py
+++ b/gcloud/tests/apigw/views/test_dispatch_plugin_query_trust_gate.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import ujson as json
+
+from gcloud import err_code
+
+from .utils import APITest
+
+
+class DispatchPluginQueryTrustGateTest(APITest):
+    """BAC: dispatch_plugin_query 会解析并直接调用任意可路由的内部视图，
+    必须仅允许 APIGW 信任名单(is_trust)应用调用，否则拒绝且不得触达 resolve/视图分发。"""
+
+    def url(self):
+        return "/apigw/dispatch_plugin_query/"
+
+    @patch("gcloud.apigw.decorators.check_white_apps", MagicMock(return_value=False))
+    def test_untrusted_app_is_forbidden(self):
+        with patch("gcloud.apigw.views.plugin_proxy.resolve") as mock_resolve:
+            response = self.client.post(
+                path=self.url(),
+                data=json.dumps({"url": "/pipeline/whatever/", "method": "GET"}),
+                content_type="application/json",
+            )
+        data = json.loads(response.content)
+        self.assertFalse(data["result"])
+        self.assertEqual(data["code"], err_code.REQUEST_FORBIDDEN_INVALID.code)
+        # 拒绝路径上绝不能触达内部视图解析
+        mock_resolve.assert_not_called()
+
+    @patch("gcloud.apigw.decorators.check_white_apps", MagicMock(return_value=True))
+    def test_trusted_app_passes_gate(self):
+        fake_view = MagicMock(return_value={"result": True, "data": "ok", "code": err_code.SUCCESS.code})
+        fake_match = MagicMock(func=fake_view, kwargs={})
+        with patch("gcloud.apigw.views.plugin_proxy.resolve", MagicMock(return_value=fake_match)):
+            response = self.client.post(
+                path=self.url(),
+                data=json.dumps({"url": "/pipeline/whatever/", "method": "GET"}),
+                content_type="application/json",
+            )
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+        fake_view.assert_called_once()

--- a/gcloud/tests/apigw/views/test_for_inner_trust_gate.py
+++ b/gcloud/tests/apigw/views/test_for_inner_trust_gate.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import ujson as json
+
+from gcloud import err_code
+
+from .utils import APITest
+
+TEST_TASKFLOW_ID = "2"
+TEST_BIZ_CC_ID = "123"
+TEST_NODE_ID = "node_id"
+
+
+class _ForInnerTrustGateBase(APITest):
+    """``*_for_inner`` 接口的统一安全要求：``request.is_trust=False`` 必须直接拒绝。
+
+    在 ``mark_request_whether_is_trust`` 装饰器中，``request.is_trust`` 由
+    ``check_white_apps(request)`` 决定。这里通过 patch
+    ``gcloud.apigw.decorators.check_white_apps`` 强制返回 False，验证视图函数返回
+    ``REQUEST_FORBIDDEN_INVALID``，并且后续真正读数据的 fetch 函数从未被调用。
+    """
+
+    url_path = None
+    fetch_target = None
+    request_params = None
+
+    def setUp(self):
+        super().setUp()
+        if self.fetch_target:
+            self.fetch_patcher = patch(
+                self.fetch_target,
+                MagicMock(return_value={"result": True, "message": "success", "data": "log"}),
+            )
+            self.mock_fetch = self.fetch_patcher.start()
+        else:
+            self.mock_fetch = None
+
+    def tearDown(self):
+        if self.mock_fetch is not None:
+            self.fetch_patcher.stop()
+        super().tearDown()
+
+    def _call(self):
+        return self.client.get(path=self.url_path, data=self.request_params or {})
+
+    def _assert_forbidden(self, response):
+        data = json.loads(response.content)
+        self.assertFalse(data["result"])
+        self.assertEqual(data["code"], err_code.REQUEST_FORBIDDEN_INVALID.code)
+        if self.mock_fetch is not None:
+            self.mock_fetch.assert_not_called()
+
+
+class GetTaskNodeLogForInnerTrustTest(_ForInnerTrustGateBase):
+    url_path = "/apigw/inner/get_task_node_log/"
+    fetch_target = "gcloud.apigw.views.get_task_node_log_for_inner.fetch_task_node_log"
+    request_params = {"node_id": TEST_NODE_ID, "version": "legacy"}
+
+    def url(self):
+        return self.url_path
+
+    @patch("gcloud.apigw.decorators.check_white_apps", MagicMock(return_value=False))
+    def test_untrusted_app_is_forbidden(self):
+        self._assert_forbidden(self._call())
+
+    @patch("gcloud.apigw.decorators.check_white_apps", MagicMock(return_value=True))
+    def test_trusted_app_can_proceed(self):
+        response = self._call()
+        self.assertEqual(response.status_code, 200)
+        self.mock_fetch.assert_called_once()
+
+
+class GetNodeJobExecutedLogForInnerTrustTest(_ForInnerTrustGateBase):
+    url_path = "/apigw/inner/get_node_job_executed_log/"
+    fetch_target = "gcloud.apigw.views.get_node_job_executed_log_for_inner.fetch_node_job_executed_log"
+    request_params = {
+        "node_id": TEST_NODE_ID,
+        "bk_biz_id": TEST_BIZ_CC_ID,
+        "job_scope_type": "biz",
+        "component_code": "job_execute_task_v2",
+    }
+
+    def url(self):
+        return self.url_path
+
+    @patch("gcloud.apigw.decorators.check_white_apps", MagicMock(return_value=False))
+    def test_untrusted_app_is_forbidden(self):
+        self._assert_forbidden(self._call())
+
+
+class GetTaskEffectiveTimeForInnerTrustTest(_ForInnerTrustGateBase):
+    url_path = "/apigw/inner/get_task_effective_time/{task_id}/{bk_biz_id}/".format(
+        task_id=TEST_TASKFLOW_ID, bk_biz_id=TEST_BIZ_CC_ID
+    )
+    # is_trust 在 effective_time_for_task 之前就拦截，因此这里 patch 一个 sentinel，
+    # 用来验证拒绝路径上确实不会触达统计逻辑。
+    fetch_target = "gcloud.apigw.views.get_task_effective_time_for_inner.effective_time_for_task"
+
+    def url(self):
+        return self.url_path
+
+    @patch("gcloud.apigw.decorators.check_white_apps", MagicMock(return_value=False))
+    def test_untrusted_app_is_forbidden(self):
+        self._assert_forbidden(self._call())
+
+
+class GetTaskPluginLogForInnerTrustTest(_ForInnerTrustGateBase):
+    """plugin 接口在 ``mark_request_whether_is_trust`` 内部嵌套了 ``validate_params``，
+    is_trust 设置发生在 validate_params 之前，但 ``if not request.is_trust`` 的判断
+    在函数体里、在 validate_params 通过之后。为了让流程能进入函数体，本测试同时提供
+    LogQuerySerializer 必填字段。"""
+
+    url_path = "/apigw/inner/get_task_plugin_log/"
+    fetch_target = "gcloud.apigw.views.get_task_plugin_log_for_inner.fetch_task_plugin_log"
+    request_params = {
+        "plugin_code": "demo_plugin",
+        "trace_id": "trace-xyz",
+    }
+
+    def url(self):
+        return self.url_path
+
+    @patch("gcloud.apigw.decorators.check_white_apps", MagicMock(return_value=False))
+    def test_untrusted_app_is_forbidden(self):
+        self._assert_forbidden(self._call())

--- a/gcloud/tests/apigw/views/test_query_task_count.py
+++ b/gcloud/tests/apigw/views/test_query_task_count.py
@@ -15,12 +15,10 @@ specific language governing permissions and limitations under the License.
 import ujson as json
 
 from gcloud.contrib.analysis.analyse_items import task_flow_instance
-
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
 
 from .utils import APITest
-
 
 TEST_PROJECT_ID = "123"
 TEST_PROJECT_NAME = "biz name"
@@ -43,9 +41,7 @@ class QueryTaskCountAPITest(APITest):
             )
         ),
     )
-    @mock.patch(
-        TASKINSTANCE_EXTEN_CLASSIFIED_COUNT, MagicMock(return_value=(True, TEST_DATA))
-    )
+    @mock.patch(TASKINSTANCE_EXTEN_CLASSIFIED_COUNT, MagicMock(return_value=(True, TEST_DATA)))
     def test_query_task_count__success(self):
         response = self.client.post(
             path=self.url().format(project_id=TEST_PROJECT_ID),
@@ -90,9 +86,35 @@ class QueryTaskCountAPITest(APITest):
             )
         ),
     )
+    @mock.patch(TASKINSTANCE_EXTEN_CLASSIFIED_COUNT, MagicMock(return_value=(True, TEST_DATA)))
+    def test_query_task_count__conditions_cannot_override_project_id(self):
+        """BAC 回归：conditions 中的 project_id 不得覆盖 URL 上已鉴权的项目作用域。"""
+        response = self.client.post(
+            path=self.url().format(project_id=TEST_PROJECT_ID),
+            data=json.dumps({"group_by": "category", "conditions": {"project_id": "999"}}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        called_args = task_flow_instance.dispatch.call_args[0]
+        self.assertEqual(called_args[0], "category")
+        # 即便请求体里塞了 project_id=999，最终下发的过滤条件仍被强制收敛回 URL 项目
+        self.assertEqual(called_args[1]["project_id"], TEST_PROJECT_ID)
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+
     @mock.patch(
-        TASKINSTANCE_EXTEN_CLASSIFIED_COUNT, MagicMock(return_value=(False, ""))
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
     )
+    @mock.patch(TASKINSTANCE_EXTEN_CLASSIFIED_COUNT, MagicMock(return_value=(False, "")))
     def test_query_task_count__dispatch_fail(self):
         response = self.client.post(
             path=self.url().format(project_id=TEST_PROJECT_ID),

--- a/gcloud/tests/contrib/analysis/test_get_biz_useage_auth.py
+++ b/gcloud/tests/contrib/analysis/test_get_biz_useage_auth.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from iam.exceptions import AuthFailedException
+
+from gcloud.contrib.analysis.views import get_biz_useage
+
+IAM_IS_ALLOWED = "gcloud.iam_auth.view_interceptors.statistics.iam.is_allowed"
+
+
+class GetBizUseageAuthTestCase(TestCase):
+    """BAC: get_biz_useage 返回平台级业务使用聚合数据，必须与其它统计接口一致校验 STATISTICS_VIEW。"""
+
+    def _request(self):
+        return SimpleNamespace(method="GET", user=SimpleNamespace(username="tester"))
+
+    def test_denied_without_statistics_view(self):
+        with patch(IAM_IS_ALLOWED, MagicMock(return_value=False)):
+            with self.assertRaises(AuthFailedException):
+                get_biz_useage(self._request(), "template")

--- a/gcloud/tests/core/apis/drf/views_set/__init__.py
+++ b/gcloud/tests/core/apis/drf/views_set/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/gcloud/tests/core/apis/drf/views_set/test_collection_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_collection_view.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+from rest_framework import status
+
+from gcloud.contrib.collection.models import Collection
+from gcloud.core.apis.drf.viewsets.collection import CollectionViewSet
+
+
+class CollectionCreateUsernameOverrideTestCase(TestCase):
+    """验证 CollectionViewSet.create 在落库前强制把 username 覆盖为当前登录用户，
+    防御 BAC：攻击者通过请求体中伪造他人 username 在他人收藏列表中写入数据。"""
+
+    def setUp(self):
+        Collection.objects.all().delete()
+
+    def tearDown(self):
+        Collection.objects.all().delete()
+
+    def _build_request(self, username, data):
+        request = SimpleNamespace(
+            user=SimpleNamespace(username=username),
+            data=data,
+        )
+        return request
+
+    def _build_view(self, request):
+        view = CollectionViewSet()
+        view.action = "create"
+        view.request = request
+        view.format_kwarg = None
+        view.kwargs = {}
+        return view
+
+    def test_create__overrides_request_body_username_with_current_user(self):
+        attacker = "attacker"
+        victim = "victim"
+
+        request = self._build_request(
+            attacker,
+            [
+                {
+                    "username": victim,
+                    "category": "project",
+                    "instance_id": 100,
+                    "extra_info": {"id": 100, "name": "biz-100"},
+                }
+            ],
+        )
+        view = self._build_view(request)
+
+        response = view.create(request)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Collection.objects.filter(username=victim).count(), 0)
+        self.assertEqual(Collection.objects.filter(username=attacker).count(), 1)
+
+    def test_create__duplicate_check_uses_current_user_not_request_username(self):
+        """重复收藏检测必须基于当前登录用户的库存，攻击者不能借受害者已有的收藏记录
+        判定自己的收藏为重复而短路绕过 username 锁定。"""
+        attacker = "attacker"
+        victim = "victim"
+
+        Collection.objects.create(
+            username=victim,
+            category="project",
+            instance_id=200,
+            extra_info="{}",
+        )
+
+        request = self._build_request(
+            attacker,
+            [
+                {
+                    "username": victim,
+                    "category": "project",
+                    "instance_id": 200,
+                    "extra_info": {"id": 200, "name": "biz-200"},
+                }
+            ],
+        )
+        view = self._build_view(request)
+
+        response = view.create(request)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Collection.objects.filter(username=attacker, instance_id=200).count(), 1)
+        self.assertEqual(Collection.objects.filter(username=victim, instance_id=200).count(), 1)
+
+    def test_create__rejects_when_current_user_already_has_same_collection(self):
+        user = "tester"
+        Collection.objects.create(
+            username=user,
+            category="project",
+            instance_id=300,
+            extra_info="{}",
+        )
+
+        request = self._build_request(
+            user,
+            [
+                {
+                    "username": user,
+                    "category": "project",
+                    "instance_id": 300,
+                    "extra_info": {"id": 300, "name": "biz-300"},
+                }
+            ],
+        )
+        view = self._build_view(request)
+
+        with patch("gcloud.core.apis.drf.viewsets.collection.logger"):
+            response = view.create(request)
+
+        self.assertEqual(Collection.objects.filter(username=user, instance_id=300).count(), 1)
+        self.assertIn("detail", response.data)

--- a/gcloud/tests/core/apis/drf/views_set/test_common_template_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_common_template_view.py
@@ -11,6 +11,8 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+from unittest.mock import PropertyMock, patch
+
 import factory
 from django.db.models import signals
 from django_test_toolkit.mixins.account import SuperUserMixin
@@ -20,7 +22,6 @@ from django_test_toolkit.testcases import ToolkitApiTestCase
 from pipeline.models import PipelineTemplate, Snapshot
 
 from gcloud.common_template.models import CommonTemplate
-from unittest.mock import patch
 
 
 class TestCommonTemplateView(
@@ -33,7 +34,9 @@ class TestCommonTemplateView(
     @factory.django.mute_signals(signals.pre_save, signals.post_save)
     def setUp(self):
         super(TestCommonTemplateView, self).setUp()
-        self.test_snapshot = Snapshot.objects.create_snapshot({})
+        # 使用最小合法 pipeline_tree（包含 activities/gateways），避免保存流程模板时
+        # set_has_subprocess_bit / count_pipeline_tree_nodes 读取对应字段抛 KeyError
+        self.test_snapshot = Snapshot.objects.create_snapshot({"activities": {}, "gateways": {}})
         self.pipeline_template = PipelineTemplate.objects.create(
             template_id="template_id", creator="creator", snapshot=self.test_snapshot
         )
@@ -43,7 +46,13 @@ class TestCommonTemplateView(
             pipeline_template=self.pipeline_template,
         )
         self.mock_referencer_data = [
-            {"template_type": "project", "id": 2, "name": "test_task_template", "project_id": 100},
+            {
+                "template_type": "project",
+                "id": 2,
+                "name": "test_task_template",
+                "project_id": 100,
+                "project_name": "test_project",
+            },
         ]
 
     def test_filter_project_template(self):
@@ -55,7 +64,10 @@ class TestCommonTemplateView(
     def test_update_common_template(self):
         self.template_url = "/api/v3/common_template/{}/update_specific_fields/".format(self.common_template.id)
         query_params = {"project_scope": ["1"]}
-        response = self.client.post(self.template_url, data=query_params, format="json")
+        # 测试快照使用最小 pipeline_tree，而 update_specific_fields 的校验会访问 instance.pipeline_tree，
+        # 真实流程的 pipeline_tree 必然包含 activities 字段，这里 patch 为最小合法结构以聚焦接口行为校验
+        with patch.object(CommonTemplate, "pipeline_tree", new_callable=PropertyMock, return_value={"activities": {}}):
+            response = self.client.post(self.template_url, data=query_params, format="json")
         self.assertTrue(response.data["result"])
         self.assertIsNotNone(response.data["data"])
 

--- a/gcloud/tests/core/apis/drf/views_set/test_project_view_set.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_project_view_set.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from gcloud.core.apis.drf.viewsets.project import ProjectSetViewSet
+from gcloud.core.models import Project
+
+GET_USER_PROJECTS = "gcloud.core.apis.drf.viewsets.project.get_user_projects"
+
+
+class ProjectSetListScopeTestCase(TestCase):
+    """BAC: ProjectSetViewSet.list 原先 pass_all，会向任意登录用户暴露全平台项目清单。
+    修复后 list 必须收敛到当前用户有查看权限的项目，非 list 行为不受影响。"""
+
+    def setUp(self):
+        Project.objects.all().delete()
+        self.p1 = Project.objects.create(name="bac-p1", creator="tester", bk_biz_id=9001)
+        self.p2 = Project.objects.create(name="bac-p2", creator="tester", bk_biz_id=9002)
+        self.p3 = Project.objects.create(name="bac-p3", creator="tester", bk_biz_id=9003)
+
+    def tearDown(self):
+        Project.objects.all().delete()
+
+    def _build_view(self, action):
+        view = ProjectSetViewSet()
+        view.action = action
+        view.request = SimpleNamespace(user=SimpleNamespace(username="tester"))
+        view.kwargs = {}
+        view.format_kwarg = None
+        return view
+
+    def test_list_scopes_to_user_authorized_projects(self):
+        view = self._build_view("list")
+        authorized = MagicMock()
+        authorized.values_list.return_value = [self.p1.id, self.p3.id]
+        with patch(GET_USER_PROJECTS, MagicMock(return_value=authorized)):
+            queryset = view.get_queryset()
+        self.assertEqual(set(queryset.values_list("id", flat=True)), {self.p1.id, self.p3.id})
+
+    def test_non_list_action_returns_full_queryset(self):
+        view = self._build_view("retrieve")
+        with patch(GET_USER_PROJECTS) as get_user_projects:
+            queryset = view.get_queryset()
+        get_user_projects.assert_not_called()
+        self.assertEqual(
+            set(queryset.values_list("id", flat=True)),
+            {self.p1.id, self.p2.id, self.p3.id},
+        )

--- a/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 """
 import datetime
 from datetime import timedelta
+from unittest.mock import patch
 
 import factory
 from bamboo_engine import states
@@ -24,6 +25,7 @@ from django_test_toolkit.testcases import ToolkitApiTestCase
 from pipeline.eri.models import State
 from pipeline.models import PipelineInstance, PipelineTemplate, Snapshot
 
+from gcloud.core.apis.drf.viewsets.taskflow import TaskFLowStatusFilterHandler
 from gcloud.core.models import Project, ProjectConfig
 from gcloud.taskflow3.models import TaskFlowInstance
 
@@ -81,13 +83,15 @@ class TestTaskInstanceView(
             "task_instance_status": "failed",
         }
 
+        # 状态筛选仅支持 v2 引擎任务，v1 引擎任务会被静默过滤，不计入结果
         self.taskflow_instance.engine_ver = 1
         self.taskflow_instance.save()
 
         resp = self.client.get(path=self.task_url, data=query_params)
-        self.assertFalse(resp.data["result"])
-        self.assertEqual(resp.data["message"], "最近180天有v1引擎的任务, 不支持筛选")
+        self.assertTrue(resp.data["result"])
+        self.assertEqual(resp.data["data"]["count"], 0)
 
+        # v2 引擎但不存在失败状态时返回空
         self.taskflow_instance.engine_ver = 2
         self.taskflow_instance.save()
 
@@ -95,6 +99,7 @@ class TestTaskInstanceView(
         self.assertTrue(resp.data["result"])
         self.assertEqual(resp.data["data"]["count"], 0)
 
+        # v2 引擎且存在失败状态时返回该任务
         self.state.name = states.FAILED
         self.state.save()
 
@@ -132,7 +137,11 @@ class TestTaskInstanceView(
             "task_instance_status": "running",
         }
 
-        resp = self.client.get(path=self.task_url, data=query_params)
+        # 运行态筛选会通过线程池并发调用引擎查询任务状态(batch_call)，该路径依赖真实引擎，
+        # 且在 sqlite 测试库下并发访问会触发 "database table is locked"，这里 mock 掉待处理任务查询，
+        # 聚焦验证“运行中任务被正确返回”的筛选逻辑
+        with patch.object(TaskFLowStatusFilterHandler, "_fetch_pending_process_taskflow_ids", return_value=[]):
+            resp = self.client.get(path=self.task_url, data=query_params)
         self.assertTrue(resp.data["result"])
         self.assertEqual(resp.data["data"]["count"], 1)
 

--- a/gcloud/tests/core/apis/drf/views_set/test_task_template_bac.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_template_bac.py
@@ -17,7 +17,8 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 from rest_framework.exceptions import PermissionDenied
 
-from gcloud.core.apis.drf.viewsets.task_template import TaskTemplateViewSet
+from gcloud.core.apis.drf.viewsets.task_template import TaskTemplatePermission, TaskTemplateViewSet
+from gcloud.iam_auth import IAMMeta
 
 TASK_TEMPLATE_FILTER = "gcloud.core.apis.drf.viewsets.task_template.TaskTemplate.objects.filter"
 TASK_CONFIG_ENABLE = "gcloud.core.apis.drf.viewsets.task_template.TaskConfig.objects.enable_independent_subprocess"
@@ -31,6 +32,16 @@ def _build_view(action, query_params, kwargs=None):
     view.kwargs = kwargs or {}
     view.format_kwarg = None
     return view
+
+
+class VerifyWebhookConfigurationPermissionTestCase(TestCase):
+    """BAC/SSRF: verify_webhook_configuration 会驱动服务端向外部 URL 发起请求，
+    不能仅要求 PROJECT_VIEW(任意项目查看者均可触发出站请求)，应至少要求项目级写意图权限。"""
+
+    def test_verify_webhook_requires_flow_create_not_project_view(self):
+        info = TaskTemplatePermission.actions["verify_webhook_configuration"]
+        self.assertEqual(info.iam_action, IAMMeta.FLOW_CREATE_ACTION)
+        self.assertNotEqual(info.iam_action, IAMMeta.PROJECT_VIEW_ACTION)
 
 
 class CommonInfoProjectBindingTestCase(TestCase):

--- a/gcloud/tests/core/apis/drf/views_set/test_task_template_bac.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_template_bac.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from rest_framework.exceptions import PermissionDenied
+
+from gcloud.core.apis.drf.viewsets.task_template import TaskTemplateViewSet
+
+TASK_TEMPLATE_FILTER = "gcloud.core.apis.drf.viewsets.task_template.TaskTemplate.objects.filter"
+TASK_CONFIG_ENABLE = "gcloud.core.apis.drf.viewsets.task_template.TaskConfig.objects.enable_independent_subprocess"
+TEMPLATESCHEME_FILTER = "gcloud.core.apis.drf.viewsets.task_template.TemplateScheme.objects.filter"
+
+
+def _build_view(action, query_params, kwargs=None):
+    view = TaskTemplateViewSet()
+    view.action = action
+    view.request = SimpleNamespace(query_params=query_params, user=SimpleNamespace(username="tester"))
+    view.kwargs = kwargs or {}
+    view.format_kwarg = None
+    return view
+
+
+class CommonInfoProjectBindingTestCase(TestCase):
+    """BAC: common_info 鉴权只校验请求参数 project__id 的 project_view，
+    但 get_object 按 pk 取任意模板，必须再校验模板归属，避免跨项目读取流程名称/方案。"""
+
+    def test_common_info__rejects_template_from_other_project(self):
+        view = _build_view("common_info", {"project__id": "10"})
+        template = SimpleNamespace(project_id=20, name="victim-flow", pipeline_template=SimpleNamespace())
+        with patch.object(TaskTemplateViewSet, "get_object", return_value=template):
+            with self.assertRaises(PermissionDenied):
+                view.common_info(view.request)
+
+    def test_common_info__allows_template_in_authorized_project(self):
+        view = _build_view("common_info", {"project__id": "10"})
+        template = SimpleNamespace(project_id=10, name="my-flow", pipeline_template=SimpleNamespace())
+        scheme_qs = MagicMock()
+        scheme_qs.values_list.return_value = [(1, "scheme-1")]
+        with patch.object(TaskTemplateViewSet, "get_object", return_value=template):
+            with patch(TEMPLATESCHEME_FILTER, MagicMock(return_value=scheme_qs)):
+                response = view.common_info(view.request)
+        self.assertEqual(response.data["name"], "my-flow")
+        self.assertEqual(response.data["schemes"], [{"id": 1, "name": "scheme-1"}])
+
+
+class EnableIndependentSubprocessProjectBindingTestCase(TestCase):
+    """BAC: enable_independent_subprocess 鉴权基于请求参数 project_id，
+    必须确认 template 确属该项目，避免借自有项目权限跨项目读取子流程配置。"""
+
+    def test_enable__rejects_template_from_other_project(self):
+        view = _build_view("enable_independent_subprocess", {"project_id": "10"}, kwargs={"pk": "55"})
+        not_owned_qs = MagicMock()
+        not_owned_qs.exists.return_value = False
+        with patch(TASK_TEMPLATE_FILTER, MagicMock(return_value=not_owned_qs)):
+            with self.assertRaises(PermissionDenied):
+                view.enable_independent_subprocess(view.request, pk="55")
+
+    def test_enable__allows_template_in_authorized_project(self):
+        view = _build_view("enable_independent_subprocess", {"project_id": "10"}, kwargs={"pk": "55"})
+        owned_qs = MagicMock()
+        owned_qs.exists.return_value = True
+        with patch(TASK_TEMPLATE_FILTER, MagicMock(return_value=owned_qs)):
+            with patch(TASK_CONFIG_ENABLE, MagicMock(return_value=True)):
+                response = view.enable_independent_subprocess(view.request, pk="55")
+        self.assertEqual(response.data, {"enable": True})
+
+    def test_enable__new_template_skips_ownership_check(self):
+        """template_id=-1 为新建未保存场景，无归属可校验，应直接放行而不触发归属查询。"""
+        view = _build_view("enable_independent_subprocess", {"project_id": "10"}, kwargs={"pk": "-1"})
+        filter_mock = MagicMock()
+        with patch(TASK_TEMPLATE_FILTER, filter_mock):
+            with patch(TASK_CONFIG_ENABLE, MagicMock(return_value=False)):
+                response = view.enable_independent_subprocess(view.request, pk="-1")
+        filter_mock.assert_not_called()
+        self.assertEqual(response.data, {"enable": False})

--- a/gcloud/tests/core/apis/drf/views_set/test_taskflow_children_bac.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_taskflow_children_bac.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from gcloud.core.apis.drf.viewsets.taskflow import TaskFlowInstanceViewSet
+
+INSTANCE_FILTER = "gcloud.core.apis.drf.viewsets.taskflow.TaskFlowInstance.objects.filter"
+RELATION_FILTER = "gcloud.core.apis.drf.viewsets.taskflow.TaskFlowRelation.objects.filter"
+
+
+def _build_view(action, query_params):
+    view = TaskFlowInstanceViewSet()
+    view.action = action
+    view.request = SimpleNamespace(query_params=query_params, user=SimpleNamespace(username="tester"))
+    view.kwargs = {}
+    view.format_kwarg = None
+    return view
+
+
+class RootTaskInfoProjectScopeTestCase(TestCase):
+    """BAC: root_task_info 必须仅统计属于已鉴权项目的任务，
+    不属于该项目的 task_id 一律返回 False，避免跨项目探测任务子流程结构。"""
+
+    def test_root_task_info__only_counts_tasks_in_authorized_project(self):
+        view = _build_view("root_task_info", {"task_ids": "1,2,3", "project_id": "10"})
+
+        instance_qs = MagicMock()
+        # 仅 task 1、2 属于项目 10，task 3 属于其它项目
+        instance_qs.values_list.return_value = [1, 2]
+        relation_qs = MagicMock()
+        # 仅 task 1 拥有子任务
+        relation_qs.values_list.return_value = [1]
+
+        with patch(INSTANCE_FILTER, MagicMock(return_value=instance_qs)):
+            with patch(RELATION_FILTER, MagicMock(return_value=relation_qs)):
+                response = view.root_task_info(view.request)
+
+        self.assertEqual(response.data["has_children_taskflow"], {1: True, 2: False, 3: False})
+
+
+class ListChildrenTaskflowProjectScopeTestCase(TestCase):
+    """BAC: list_children_taskflow 的鉴权接受 project_id/project__id，但过滤器仅识别 project__id，
+    导致仅传 project_id 时子任务未按项目收敛。修复后应显式按已鉴权项目过滤子任务及关系。"""
+
+    def test_list_children__scopes_children_and_relations_by_project(self):
+        view = _build_view("list_children_taskflow", {"root_task_id": "500", "project_id": "10"})
+
+        relation_values = [
+            {"task_id": 1, "parent_task_id": 500},
+            {"task_id": 2, "parent_task_id": 500},
+        ]
+        relation_qs = MagicMock()
+        relation_qs.values.return_value = relation_values
+
+        instance_filter = MagicMock(return_value="CHILDREN_QS")
+
+        with patch(RELATION_FILTER, MagicMock(return_value=relation_qs)):
+            with patch(INSTANCE_FILTER, instance_filter):
+                with patch.object(TaskFlowInstanceViewSet, "filter_queryset", side_effect=lambda qs: qs):
+                    with patch.object(
+                        TaskFlowInstanceViewSet,
+                        "get_serializer",
+                        return_value=SimpleNamespace(data=[{"id": 1}]),
+                    ):
+                        with patch.object(
+                            TaskFlowInstanceViewSet,
+                            "injection_auth_actions",
+                            side_effect=lambda request, data, qs: data,
+                        ):
+                            with patch.object(TaskFlowInstanceViewSet, "_inject_template_related_info"):
+                                response = view.list_children_taskflow(view.request)
+
+        # 子任务查询必须按已鉴权项目收敛
+        _, filter_kwargs = instance_filter.call_args
+        self.assertEqual(filter_kwargs.get("project_id"), "10")
+        # 只有真正返回（属于该项目）的 task 1 才会出现在 tasks / relations 中，task 2 被剔除
+        self.assertEqual(response.data["tasks"], [{"id": 1}])
+        self.assertEqual(response.data["relations"], {500: [1]})

--- a/gcloud/tests/core/apis/drf/views_set/test_taskflow_children_bac.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_taskflow_children_bac.py
@@ -51,6 +51,25 @@ class RootTaskInfoProjectScopeTestCase(TestCase):
 
         self.assertEqual(response.data["has_children_taskflow"], {1: True, 2: False, 3: False})
 
+    def test_root_task_info__empty_project_id_normalized_to_none(self):
+        """空串 project_id 应归一化为 None(filter(project_id=None) 走 IS NULL 返回空集)，
+        避免 filter(project_id="") 触发整型转换 ValueError 导致 500。"""
+        view = _build_view("root_task_info", {"task_ids": "1,2", "project_id": ""})
+
+        instance_qs = MagicMock()
+        instance_qs.values_list.return_value = []
+        relation_qs = MagicMock()
+        relation_qs.values_list.return_value = []
+        instance_filter = MagicMock(return_value=instance_qs)
+
+        with patch(INSTANCE_FILTER, instance_filter):
+            with patch(RELATION_FILTER, MagicMock(return_value=relation_qs)):
+                response = view.root_task_info(view.request)
+
+        _, filter_kwargs = instance_filter.call_args
+        self.assertIsNone(filter_kwargs.get("project_id"))
+        self.assertEqual(response.data["has_children_taskflow"], {1: False, 2: False})
+
 
 class ListChildrenTaskflowProjectScopeTestCase(TestCase):
     """BAC: list_children_taskflow 的鉴权接受 project_id/project__id，但过滤器仅识别 project__id，
@@ -90,3 +109,28 @@ class ListChildrenTaskflowProjectScopeTestCase(TestCase):
         # 只有真正返回（属于该项目）的 task 1 才会出现在 tasks / relations 中，task 2 被剔除
         self.assertEqual(response.data["tasks"], [{"id": 1}])
         self.assertEqual(response.data["relations"], {500: [1]})
+
+    def test_list_children__empty_project_id_normalized_to_none(self):
+        """空串 project_id 应归一化为 None，避免 filter(project_id="") 触发 500。"""
+        view = _build_view("list_children_taskflow", {"root_task_id": "500", "project_id": ""})
+
+        relation_qs = MagicMock()
+        relation_qs.values.return_value = [{"task_id": 1, "parent_task_id": 500}]
+        instance_filter = MagicMock(return_value="CHILDREN_QS")
+
+        with patch(RELATION_FILTER, MagicMock(return_value=relation_qs)):
+            with patch(INSTANCE_FILTER, instance_filter):
+                with patch.object(TaskFlowInstanceViewSet, "filter_queryset", side_effect=lambda qs: qs):
+                    with patch.object(TaskFlowInstanceViewSet, "get_serializer", return_value=SimpleNamespace(data=[])):
+                        with patch.object(
+                            TaskFlowInstanceViewSet,
+                            "injection_auth_actions",
+                            side_effect=lambda request, data, qs: data,
+                        ):
+                            with patch.object(TaskFlowInstanceViewSet, "_inject_template_related_info"):
+                                response = view.list_children_taskflow(view.request)
+
+        _, filter_kwargs = instance_filter.call_args
+        self.assertIsNone(filter_kwargs.get("project_id"))
+        self.assertEqual(response.data["tasks"], [])
+        self.assertEqual(response.data["relations"], {})

--- a/gcloud/tests/iam_auth/__init__.py
+++ b/gcloud/tests/iam_auth/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/gcloud/tests/iam_auth/view_interceptors/__init__.py
+++ b/gcloud/tests/iam_auth/view_interceptors/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""

--- a/gcloud/tests/iam_auth/view_interceptors/test_common_template_check_before_import.py
+++ b/gcloud/tests/iam_auth/view_interceptors/test_common_template_check_before_import.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from iam.exceptions import AuthFailedException
+
+from gcloud.iam_auth.view_interceptors.common_template import CheckBeforeImportInterceptor
+
+IAM_IS_ALLOWED = "gcloud.iam_auth.view_interceptors.common_template.iam.is_allowed"
+
+
+class CheckBeforeImportInterceptorTest(TestCase):
+    """BAC: 公共流程导入前置检测接口必须与正式导入一致要求 COMMON_FLOW_CREATE，
+    避免无任何公共流程权限的用户借预检接口探测导入冲突/覆盖信息。"""
+
+    def setUp(self):
+        self.interceptor = CheckBeforeImportInterceptor()
+        self.request = SimpleNamespace(user=SimpleNamespace(username="tester"))
+
+    def test_denies_without_common_flow_create(self):
+        with patch(IAM_IS_ALLOWED, MagicMock(return_value=False)):
+            with self.assertRaises(AuthFailedException):
+                self.interceptor.process(self.request)
+
+    def test_allows_with_common_flow_create(self):
+        with patch(IAM_IS_ALLOWED, MagicMock(return_value=True)):
+            # 不抛异常即视为通过
+            self.interceptor.process(self.request)

--- a/gcloud/tests/iam_auth/view_interceptors/test_project.py
+++ b/gcloud/tests/iam_auth/view_interceptors/test_project.py
@@ -14,6 +14,9 @@ specific language governing permissions and limitations under the License.
 from types import SimpleNamespace
 from unittest import TestCase, mock
 
+from iam.exceptions import AuthFailedException
+
+from gcloud.core.models import Project
 from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.view_interceptors.project import ProjectFlowCreateInterceptor, ProjectViewInterceptor
 
@@ -100,3 +103,28 @@ class ProjectInterceptorTestCase(TestCase):
         ProjectViewInterceptor().process(request, project_id=1)
 
         mocked_resources_for_project.assert_called_once_with(1)
+
+    @mock.patch(RESOURCES_FOR_PROJECT_PATH, return_value=["project-resource"])
+    @mock.patch(ALLOW_OR_RAISE_PATH)
+    def test_project_view__missing_project_id_raises_auth_failed_not_500(
+        self, mocked_allow_or_raise, mocked_resources_for_project
+    ):
+        """kwargs/GET/POST 均无 project_id 时，应直接按鉴权失败处理，
+        不能进入 resources_for_project(None) 触发 Project.DoesNotExist 造成 500。"""
+        with self.assertRaises(AuthFailedException):
+            ProjectViewInterceptor().process(self.request)
+
+        mocked_resources_for_project.assert_not_called()
+        mocked_allow_or_raise.assert_not_called()
+
+    @mock.patch(RESOURCES_FOR_PROJECT_PATH, side_effect=Project.DoesNotExist)
+    @mock.patch(ALLOW_OR_RAISE_PATH)
+    def test_project_view__nonexistent_project_raises_auth_failed_not_500(
+        self, mocked_allow_or_raise, mocked_resources_for_project
+    ):
+        """指向不存在项目的 project_id 应按鉴权失败(403)处理，而非把 DoesNotExist 暴露为 500。"""
+        with self.assertRaises(AuthFailedException):
+            ProjectViewInterceptor().process(self.request, project_id=999999)
+
+        mocked_resources_for_project.assert_called_once_with(999999)
+        mocked_allow_or_raise.assert_not_called()

--- a/gcloud/tests/iam_auth/view_interceptors/test_project.py
+++ b/gcloud/tests/iam_auth/view_interceptors/test_project.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from gcloud.iam_auth import IAMMeta
+from gcloud.iam_auth.view_interceptors.project import ProjectFlowCreateInterceptor, ProjectViewInterceptor
+
+ALLOW_OR_RAISE_PATH = "gcloud.iam_auth.view_interceptors.project.allow_or_raise_auth_failed"
+RESOURCES_FOR_PROJECT_PATH = "gcloud.iam_auth.view_interceptors.project.res_factory.resources_for_project"
+
+
+class ProjectInterceptorTestCase(TestCase):
+    def setUp(self):
+        self.request = SimpleNamespace(user=SimpleNamespace(username="tester"), GET={}, POST={})
+
+    @mock.patch(RESOURCES_FOR_PROJECT_PATH, return_value=["project-resource"])
+    @mock.patch(ALLOW_OR_RAISE_PATH)
+    def test_project_view__uses_kwargs_project_id_and_project_view_action(
+        self, mocked_allow_or_raise, mocked_resources_for_project
+    ):
+        ProjectViewInterceptor().process(self.request, project_id=42)
+
+        mocked_resources_for_project.assert_called_once_with(42)
+        mocked_allow_or_raise.assert_called_once()
+        kwargs = mocked_allow_or_raise.call_args[1]
+        self.assertEqual(kwargs["system"], IAMMeta.SYSTEM_ID)
+        self.assertEqual(kwargs["subject"].type, "user")
+        self.assertEqual(kwargs["subject"].id, "tester")
+        self.assertEqual(kwargs["action"].id, IAMMeta.PROJECT_VIEW_ACTION)
+        self.assertEqual(kwargs["resources"], ["project-resource"])
+        self.assertTrue(kwargs.get("cache"))
+
+    @mock.patch(RESOURCES_FOR_PROJECT_PATH, return_value=["project-resource"])
+    @mock.patch(ALLOW_OR_RAISE_PATH)
+    def test_project_flow_create__uses_flow_create_action(self, mocked_allow_or_raise, mocked_resources_for_project):
+        ProjectFlowCreateInterceptor().process(self.request, project_id=7)
+
+        mocked_resources_for_project.assert_called_once_with(7)
+        mocked_allow_or_raise.assert_called_once()
+        kwargs = mocked_allow_or_raise.call_args[1]
+        self.assertEqual(kwargs["action"].id, IAMMeta.FLOW_CREATE_ACTION)
+
+    @mock.patch(RESOURCES_FOR_PROJECT_PATH, return_value=[])
+    @mock.patch(ALLOW_OR_RAISE_PATH)
+    def test_project_view__fallback_to_query_params_when_kwargs_missing(
+        self, mocked_allow_or_raise, mocked_resources_for_project
+    ):
+        request = SimpleNamespace(
+            user=SimpleNamespace(username="tester"),
+            GET={"project_id": "9"},
+            POST={},
+        )
+
+        ProjectViewInterceptor().process(request)
+
+        mocked_resources_for_project.assert_called_once_with("9")
+        mocked_allow_or_raise.assert_called_once()
+
+    @mock.patch(RESOURCES_FOR_PROJECT_PATH, return_value=[])
+    @mock.patch(ALLOW_OR_RAISE_PATH)
+    def test_project_view__fallback_to_post_body_when_query_missing(
+        self, mocked_allow_or_raise, mocked_resources_for_project
+    ):
+        request = SimpleNamespace(
+            user=SimpleNamespace(username="tester"),
+            GET={},
+            POST={"project_id": "11"},
+        )
+
+        ProjectViewInterceptor().process(request)
+
+        mocked_resources_for_project.assert_called_once_with("11")
+        mocked_allow_or_raise.assert_called_once()
+
+    @mock.patch(RESOURCES_FOR_PROJECT_PATH, return_value=[])
+    @mock.patch(ALLOW_OR_RAISE_PATH)
+    def test_project_view__kwargs_project_id_takes_precedence(
+        self, mocked_allow_or_raise, mocked_resources_for_project
+    ):
+        """URL 路径中的 project_id 必须优先于请求体/查询串里的 project_id，
+        防御攻击者用 query/body 中伪造的项目 ID 通过鉴权后访问 URL 真实 project_id 的数据。"""
+        request = SimpleNamespace(
+            user=SimpleNamespace(username="tester"),
+            GET={"project_id": "999"},
+            POST={"project_id": "888"},
+        )
+
+        ProjectViewInterceptor().process(request, project_id=1)
+
+        mocked_resources_for_project.assert_called_once_with(1)

--- a/gcloud/tests/iam_auth/view_interceptors/test_project_view_smoke.py
+++ b/gcloud/tests/iam_auth/view_interceptors/test_project_view_smoke.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+from gcloud.contrib.appmaker import api as appmaker_api
+from gcloud.taskflow3.apis.django import api as taskflow_api
+from gcloud.taskflow3.apis.django.validators import QueryTaskCountValidator
+from gcloud.tasktmpl3.apis.django import api as tasktmpl_api
+from gcloud.tasktmpl3.apis.django.validators import GetTemplateCountValidator
+
+
+class _SentinelDenied(Exception):
+    """用于在测试中表明 interceptor 真的被调用且能阻断后续视图逻辑。"""
+
+
+def _build_request(method="GET", body=b"{}"):
+    return SimpleNamespace(
+        method=method,
+        GET={},
+        POST={},
+        FILES={},
+        body=body,
+        user=SimpleNamespace(username="tester"),
+        META={},
+    )
+
+
+class ProjectInterceptorWiredOnViewsTestCase(TestCase):
+    """对所有在本次修复中新接入 ``ProjectViewInterceptor`` /
+    ``ProjectFlowCreateInterceptor`` 的 Django 函数视图做最小化"接线"冒烟测试。
+
+    断言：当 interceptor.process 被设置为抛出哨兵异常时，请求会直接被该异常打断，
+    说明 ``@iam_intercept(...)`` 已被正确地嵌进装饰器链；这样可以防御：
+    - 装饰器顺序写错导致 IAM 检查被跳过；
+    - 视图体里在 IAM 拒绝时仍发生数据库 / 远程查询副作用。
+
+    对带 ``@request_validate(...)`` 的视图，我们把对应 Validator 临时打成放行，避免被
+    validator 提前拦下从而无法触达 iam_intercept 层。
+    """
+
+    def _block(self, klass):
+        return mock.patch(
+            f"gcloud.iam_auth.view_interceptors.project.{klass}.process",
+            side_effect=_SentinelDenied("denied"),
+        )
+
+    def test_taskflow_query_task_count_requires_project_view(self):
+        request = _build_request(method="POST", body=b'{"conditions": {}, "group_by": "category"}')
+        with mock.patch.object(QueryTaskCountValidator, "validate", return_value=(True, "")):
+            with self._block("ProjectViewInterceptor"):
+                with self.assertRaises(_SentinelDenied):
+                    taskflow_api.query_task_count(request, project_id=1)
+
+    def test_tasktmpl_get_template_count_requires_project_view(self):
+        request = _build_request()
+        with mock.patch.object(GetTemplateCountValidator, "validate", return_value=(True, "")):
+            with self._block("ProjectViewInterceptor"):
+                with self.assertRaises(_SentinelDenied):
+                    tasktmpl_api.get_template_count(request, project_id=1)
+
+    def test_tasktmpl_get_templates_with_expired_subprocess_requires_project_view(self):
+        request = _build_request()
+        with self._block("ProjectViewInterceptor"):
+            with self.assertRaises(_SentinelDenied):
+                tasktmpl_api.get_templates_with_expired_subprocess(request, project_id=1)
+
+    def test_appmaker_get_appmaker_count_requires_project_view(self):
+        request = _build_request()
+        with self._block("ProjectViewInterceptor"):
+            with self.assertRaises(_SentinelDenied):
+                appmaker_api.get_appmaker_count(request, project_id=1)

--- a/gcloud/tests/taskflow3/test_get_job_instance_log_auth.py
+++ b/gcloud/tests/taskflow3/test_get_job_instance_log_auth.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+from unittest import TestCase, mock
+
+import ujson as json
+from iam.exceptions import RawAuthFailedException
+
+from gcloud import err_code
+from gcloud.core.models import Project
+from gcloud.iam_auth import IAMMeta
+from gcloud.taskflow3.apis.django import api
+
+
+def _build_request(username="tester", job_instance_id="100"):
+    return SimpleNamespace(
+        method="GET",
+        user=SimpleNamespace(username=username),
+        GET={"job_instance_id": job_instance_id, "bk_scope_type": "biz"},
+        META={},
+    )
+
+
+class GetJobInstanceLogAuthTestCase(TestCase):
+    """``get_job_instance_log`` 现在要求调用方在 bk-sops 对应项目内具备
+    ``PROJECT_VIEW_ACTION``，避免 BAC：拥有其它产品权限但与 bk-sops 项目无关的用户
+    借助本接口跨业务获取作业平台日志。"""
+
+    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    def test_project_missing_in_bksops_returns_content_not_exist(self, mocked_project_get):
+        mocked_project_get.side_effect = Project.DoesNotExist
+        request = _build_request()
+
+        response = api.get_job_instance_log(request, biz_cc_id="123")
+
+        data = json.loads(response.content)
+        self.assertFalse(data["result"])
+        self.assertEqual(data["code"], err_code.CONTENT_NOT_EXIST.code)
+
+    @mock.patch("gcloud.taskflow3.apis.django.api.get_client_by_user")
+    @mock.patch("gcloud.taskflow3.apis.django.api.res_factory.resources_for_project")
+    @mock.patch("gcloud.taskflow3.apis.django.api.allow_or_raise_auth_failed")
+    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    def test_iam_called_with_internal_project_id_not_bk_biz_id(
+        self,
+        mocked_project_get,
+        mocked_allow_or_raise,
+        mocked_resources_for_project,
+        mocked_get_client_by_user,
+    ):
+        """关键防御：IAM 校验必须使用 bk-sops 内部 ``project.id``，而不是用户传入的
+        ``bk_biz_id``，否则攻击者只要在另一个绑定了同 ``bk_biz_id`` 的产品中拥有项目
+        权限就能跨过本系统的项目隔离。"""
+        project = mock.MagicMock(id=42)
+        mocked_project_get.return_value = project
+        mocked_resources_for_project.return_value = ["proj-42"]
+        client = mock.MagicMock()
+        client.job.get_job_instance_log.return_value = {"result": True, "data": "log"}
+        mocked_get_client_by_user.return_value = client
+        request = _build_request()
+
+        response = api.get_job_instance_log(request, biz_cc_id="123")
+
+        mocked_resources_for_project.assert_called_once_with(42)
+        mocked_allow_or_raise.assert_called_once()
+        kwargs = mocked_allow_or_raise.call_args[1]
+        self.assertEqual(kwargs["system"], IAMMeta.SYSTEM_ID)
+        self.assertEqual(kwargs["subject"].id, "tester")
+        self.assertEqual(kwargs["action"].id, IAMMeta.PROJECT_VIEW_ACTION)
+        self.assertEqual(kwargs["resources"], ["proj-42"])
+
+        data = json.loads(response.content)
+        self.assertTrue(data["result"])
+
+    @mock.patch("gcloud.taskflow3.apis.django.api.get_client_by_user")
+    @mock.patch("gcloud.taskflow3.apis.django.api.res_factory.resources_for_project")
+    @mock.patch("gcloud.taskflow3.apis.django.api.allow_or_raise_auth_failed")
+    @mock.patch("gcloud.taskflow3.apis.django.api.Project.objects.get")
+    def test_iam_denied_short_circuits_before_calling_job(
+        self,
+        mocked_project_get,
+        mocked_allow_or_raise,
+        mocked_resources_for_project,
+        mocked_get_client_by_user,
+    ):
+        """IAM 拒绝时必须直接抛错，不能继续调用 Job 平台 SDK，
+        否则会产生借代用户向 Job 平台发请求的副作用。"""
+        mocked_project_get.return_value = mock.MagicMock(id=42)
+        mocked_resources_for_project.return_value = ["proj-42"]
+        mocked_allow_or_raise.side_effect = RawAuthFailedException(permissions={})
+        request = _build_request()
+
+        with self.assertRaises(RawAuthFailedException):
+            api.get_job_instance_log(request, biz_cc_id="123")
+
+        mocked_get_client_by_user.assert_not_called()


### PR DESCRIPTION
## 背景

对 `release_humming_bird` 分支接口做了一轮独立的越权 (Broken Access Control) 安全复核，修复发现的越权与信息泄露问题，并补充回归单测。本 PR 共 3 个提交，**全部为越权/信息泄露相关修复**。

## 修复内容

### 对象级鉴权 / IDOR
- `ResourceConfig` / `StaffGroup`：改为基于对象 `project_id` 的对象级鉴权
- `TaskTemplateViewSet.common_info` / `enable_independent_subprocess`：补充模板归属校验，防止跨项目读取流程名称 / 执行方案 / 子流程配置
- `TaskFlowInstanceViewSet.list_children_taskflow` / `root_task_info`：显式按已鉴权项目收敛子任务及关系，消除 `project_id` / `project__id` 校验与过滤不一致
- `enable_fill_retry_params`：改为 `get_object()` + 对象级 `task_view`
- `TemplateScheme.batch_operate`：升级为编辑权限

### 项目作用域收敛
- `query_task_count` (APIGW)：请求体 `conditions` 不再能覆盖已鉴权 `project_id`
- `operate_node` / `get_job_instance_log`：补充 `project_id` 收敛与 `PROJECT_VIEW`
- `ProjectSetViewSet.list`：由 `pass_all` 收敛为当前用户有查看权限的项目，防止全平台项目枚举
- webhook 配置校验接口：补充必填 `project_id` 并按项目收敛

### Trust 闸门 / 鉴权补齐
- `*_for_inner`（4 个内部接口）：补充 `is_trust` 信任名单闸门
- `dispatch_plugin_query` (APIGW)：内部视图转发器补充 `is_trust` 闸门
- `common_template.check_before_import`：补充 `COMMON_FLOW_CREATE` 鉴权
- `taskflow v4 root_state`：补充 `StatusViewInterceptor`
- `analysis.get_biz_useage`：补充 `STATISTICS_VIEW` 鉴权
- `collection.create`：强制 `username` 为当前登录用户

## 测试

- 新增/补充越权回归单测：APIGW trust 闸门、`collection` username 锁定、project 拦截器、`task_template` / `taskflow` 越权回归、`common_template` 导入预检鉴权、`ProjectSetViewSet.list` 收敛、`get_biz_useage` 鉴权等
- 本地 pytest 通过（既有的、与本次改动无关的失败用例除外）
