### PR TITLE
refactor: 更新版本号至 3.34.11

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -6,7 +6,7 @@ is_use_celery: True
 author: 蓝鲸智云
 introduction: 标准运维是通过一套成熟稳定的任务调度引擎，把在多系统间的工作整合到一个流程，助力运维实现跨系统调度自动化的SaaS应用。
 introduction_en: SOPS is a SaaS application that utilizes a set of mature and stable task scheduling engines to help realize cross-system scheduling automation, and integrates the work among multiple systems into a single process.
-version: 3.34.10
+version: 3.34.11
 category: 运维工具
 language_support: 中文
 desktop:

--- a/app_desc.yaml
+++ b/app_desc.yaml
@@ -1,5 +1,5 @@
 spec_version: 2
-app_version: "3.34.10"
+app_version: "3.34.11"
 app:
     region: default
     bk_app_code: bk_sops

--- a/config/default.py
+++ b/config/default.py
@@ -213,7 +213,7 @@ LOGGING = get_logging_config_dict(locals())
 # mako模板中：<script src="/a.js?v=${ STATIC_VERSION }"></script>
 # 如果静态资源修改了以后，上线前改这个版本号即可
 
-STATIC_VERSION = "3.34.10"
+STATIC_VERSION = "3.34.11"
 DEPLOY_DATETIME = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]


### PR DESCRIPTION
## 变更说明

常规版本号升级：`3.34.10` → `3.34.11`。

涉及文件：
- `app.yml`：`version: 3.34.11`
- `app_desc.yaml`：`app_version: "3.34.11"`
- `config/default.py`：`STATIC_VERSION = "3.34.11"`

仅版本号变更，无业务逻辑改动。
