### PR TITLE
fix: 兼容执行方案数字字符串参数

### DIFF
--- a/gcloud/apigw/views/task_node_selector.py
+++ b/gcloud/apigw/views/task_node_selector.py
@@ -12,14 +12,22 @@ def _is_scheme_pk(value):
     return isinstance(value, int) and not isinstance(value, bool)
 
 
+def _normalize_scheme_id(value):
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return value
+
+
 def normalize_template_scheme_params(params):
     template_schemes_id = params.get("template_schemes_id", [])
 
     if isinstance(template_schemes_id, str) or _is_scheme_pk(template_schemes_id):
         template_schemes_id = [template_schemes_id]
-        params["template_schemes_id"] = template_schemes_id
-    else:
-        params.setdefault("template_schemes_id", template_schemes_id)
+
+    if isinstance(template_schemes_id, list):
+        template_schemes_id = [_normalize_scheme_id(scheme_id) for scheme_id in template_schemes_id]
+
+    params["template_schemes_id"] = template_schemes_id
 
     return template_schemes_id
 

--- a/gcloud/tests/apigw/views/test_task_node_selector.py
+++ b/gcloud/tests/apigw/views/test_task_node_selector.py
@@ -90,6 +90,27 @@ class TaskNodeSelectorTestCase(TestCase):
         self.assertEqual(params["template_schemes_id"], [243])
         self.assertEqual(result, ["node3"])
 
+    def test_resolve_with_template_schemes_id_numeric_string(self):
+        for template_schemes_id in ["243", ["243"]]:
+            template = SimpleNamespace(pipeline_template=SimpleNamespace(id=47))
+            pipeline_tree = {PE.activities: {"node1": {}, "node2": {}, "node3": {}}}
+            params = {"template_schemes_id": template_schemes_id}
+
+            with self.subTest(template_schemes_id=template_schemes_id):
+                with patch("gcloud.apigw.views.task_node_selector.TemplateScheme") as template_scheme:
+                    with patch("gcloud.apigw.views.task_node_selector.PipelineTemplateWebPreviewer") as previewer:
+                        template_scheme.objects.filter.return_value = [SimpleNamespace(id=243, unique_id="47-1")]
+                        previewer.get_template_exclude_task_nodes_with_schemes = MagicMock(return_value=["node3"])
+
+                        result = resolve_exclude_task_nodes_id(template, pipeline_tree, params)
+
+                template_scheme.objects.filter.assert_called_once_with(template_id=47, id__in=[243])
+                previewer.get_template_exclude_task_nodes_with_schemes.assert_called_once_with(
+                    pipeline_tree, [243], check_schemes_exist=True
+                )
+                self.assertEqual(params["template_schemes_id"], [243])
+                self.assertEqual(result, ["node3"])
+
     def test_reject_unknown_template_scheme(self):
         template = SimpleNamespace(pipeline_template=SimpleNamespace(id=47))
         pipeline_tree = {PE.activities: {}}


### PR DESCRIPTION
## Summary

- Normalize numeric string `template_schemes_id` values, such as `"243"` or `["243"]`, to integer `TemplateScheme.id` values before resolving execution schemes.
- Preserve existing string `TemplateScheme.unique_id` resolution for non-numeric IDs returned by `get_template_schemes`.
- Add APIGW node selector coverage for numeric string single-value and list-value inputs.

## Root Cause

After #8363, the schema accepted strings and integers, but the resolver still treated every string as `TemplateScheme.unique_id`. Therefore a request with `template_schemes_id: "243"` queried `unique_id="243"` and returned `unknown template_schemes_id: 243`, while `template_schemes_id: 243` correctly queried `id=243`.

## Validation

- `PYENV_VERSION=3.6.15 /Users/dengyh/.pyenv/versions/3.6.15/bin/python -m pytest gcloud/tests/apigw/views/test_task_node_selector.py gcloud/tests/apigw/views/test_create_task.py gcloud/tests/apigw/views/test_create_and_start_task.py -q --disable-warnings`
- `python3 -m py_compile gcloud/apigw/views/task_node_selector.py`
- `git diff --cached --check`