### PR TITLE
fix: nodemgr plugin proxy install params lack of proxy_install_origin_unit_id. issue: #8338

### DIFF
--- a/pipeline_plugins/components/collections/sites/open/nodemgr/operate_node/v1_0.py
+++ b/pipeline_plugins/components/collections/sites/open/nodemgr/operate_node/v1_0.py
@@ -299,6 +299,7 @@ class NodemgrOperateNodeService(NodemgrBaseService):
 
             # proxy 节点额外的参数内容
             if node_role == "proxy":
+                install_host["proxy_install_origin_unit_id"] = host.get("bk_networkunit_id")
                 install_host["relay_callback_port"] = self.proxy_info.get("relay_callback_port", 28302)
                 install_host["relay_download_port"] = self.proxy_info.get("relay_download_port", 28303)
                 install_host["proxy_tags"] = self.proxy_info.get("proxy_tags", [


### PR DESCRIPTION
#8338