### PR TITLE
fix: avoid full queryset evaluation in web APIs

### DIFF
--- a/gcloud/core/apis/drf/viewsets/base.py
+++ b/gcloud/core/apis/drf/viewsets/base.py
@@ -13,14 +13,14 @@ specific language governing permissions and limitations under the License.
 import logging
 from collections import Iterable
 
-from rest_framework import generics
-from rest_framework.response import Response
-from rest_framework.filters import SearchFilter, OrderingFilter
-from rest_framework.pagination import LimitOffsetPagination
-
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import generics
+from rest_framework.filters import OrderingFilter, SearchFilter
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.response import Response
+
+from gcloud.core.apis.drf.viewsets import ApiMixin, IAMMixin
 from gcloud.iam_auth import get_iam_client
-from gcloud.core.apis.drf.viewsets import IAMMixin, ApiMixin
 
 iam = get_iam_client()
 iam_logger = logging.getLogger("iam")
@@ -67,7 +67,7 @@ class GcloudListViewSet(GcloudCommonMixin):
         queryset = self.filter_queryset(self.get_queryset())
         # 支持使用方配置不分页
         page = self.paginate_queryset(queryset)
-        serializer = self.get_serializer(page if page else queryset, many=True)
+        serializer = self.get_serializer(page if page is not None else queryset, many=True)
         # 注入权限
         data = self.injection_auth_actions(request, serializer.data, serializer.instance)
         return self.get_paginated_response(data) if page is not None else Response(data)

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -641,7 +641,7 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
             .order_by("-archived_time")
             .values("archived_time", "elapsed_time")
         )
-        execution_total_time = len(execution_data)
+        execution_total_time = execution_data.count()
         execution_time_data = execution_data[: settings.MAX_RECORDED_NODE_EXECUTION_TIMES]
         node_execution_record_serializer = NodeExecutionRecordResponseSerializer(
             data={"execution_time": execution_time_data, "total": execution_total_time}

--- a/gcloud/tests/core/apis/drf/views_set/test_base_viewset.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_base_viewset.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+from rest_framework.response import Response
+
+from gcloud.core.apis.drf.viewsets.base import GcloudListViewSet
+
+
+class _Serializer(object):
+    def __init__(self, instance):
+        self.instance = instance
+        self.data = []
+
+
+class _EmptyPageViewSet(GcloudListViewSet):
+    def __init__(self):
+        super(_EmptyPageViewSet, self).__init__()
+        self.queryset = object()
+        self.serialized_instance = None
+
+    def get_queryset(self):
+        return self.queryset
+
+    def filter_queryset(self, queryset):
+        return queryset
+
+    def paginate_queryset(self, queryset):
+        return []
+
+    def get_serializer(self, instance, many=False):
+        self.serialized_instance = instance
+        return _Serializer(instance)
+
+    def injection_auth_actions(self, request, serializer_data, queryset_data):
+        return serializer_data
+
+    def get_paginated_response(self, data):
+        return Response({"results": data})
+
+
+class TestGcloudListViewSet(SimpleTestCase):
+    def test_empty_page_does_not_fall_back_to_full_queryset(self):
+        view = _EmptyPageViewSet()
+
+        view.list(SimpleNamespace())
+
+        self.assertEqual(view.serialized_instance, [])

--- a/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
@@ -12,11 +12,13 @@ specific language governing permissions and limitations under the License.
 """
 import datetime
 from datetime import timedelta
+from types import SimpleNamespace
 
 import factory
 from bamboo_engine import states
 from django.conf import settings
 from django.db.models import signals
+from django.test import SimpleTestCase
 from django_test_toolkit.mixins.account import SuperUserMixin
 from django_test_toolkit.mixins.blueking import LoginExemptMixin, StandardResponseAssertionMixin
 from django_test_toolkit.mixins.drf import DrfPermissionExemptMixin
@@ -25,6 +27,7 @@ from mock import patch
 from pipeline.eri.models import State
 from pipeline.models import PipelineInstance, PipelineTemplate, Snapshot
 
+from gcloud.core.apis.drf.viewsets.taskflow import TaskFlowInstanceViewSet
 from gcloud.core.models import Project, ProjectConfig
 from gcloud.taskflow3.models import TaskFlowInstance
 
@@ -318,3 +321,50 @@ class TestTaskInstanceView(
         task_ids = [task["id"] for task in resp.data["data"]["results"]]
         # 应该过滤掉旧任务
         self.assertNotIn(old_taskflow_instance.id, task_ids)
+
+
+class _NodeExecutionRecordQuerySet(object):
+    def __init__(self, rows):
+        self.rows = rows
+        self.count_called = False
+        self.sliced_limits = []
+
+    def order_by(self, *args):
+        return self
+
+    def values(self, *args):
+        return self
+
+    def count(self):
+        self.count_called = True
+        return 100
+
+    def __len__(self):
+        raise AssertionError("node_execution_record should not evaluate the full queryset")
+
+    def __getitem__(self, item):
+        self.sliced_limits.append((item.start, item.stop))
+        return self.rows[item]
+
+
+class TestTaskInstanceNodeExecutionRecord(SimpleTestCase):
+    def test_node_execution_record_counts_without_evaluating_queryset(self):
+        rows = [
+            {"archived_time": datetime.datetime(2026, 1, 1, 10, 0, 0), "elapsed_time": 10},
+            {"archived_time": datetime.datetime(2026, 1, 1, 10, 1, 0), "elapsed_time": 12},
+        ]
+        queryset = _NodeExecutionRecordQuerySet(rows)
+        request = SimpleNamespace(query_params={"template_node_id": "node-id"})
+        view = TaskFlowInstanceViewSet()
+
+        with patch.object(TaskFlowInstanceViewSet, "get_object", return_value=SimpleNamespace(template_id=1)):
+            with patch(
+                "gcloud.core.apis.drf.viewsets.taskflow.TaskflowExecutedNodeStatistics.objects.filter",
+                return_value=queryset,
+            ):
+                response = view.node_execution_record(request)
+
+        self.assertTrue(queryset.count_called)
+        self.assertEqual(queryset.sliced_limits, [(None, settings.MAX_RECORDED_NODE_EXECUTION_TIMES)])
+        self.assertEqual(response.data["total"], 100)
+        self.assertEqual(len(response.data["execution_time"]), 2)


### PR DESCRIPTION
## Summary
- Use `QuerySet.count()` in `node_execution_record` so the total no longer forces full result materialization before slicing.
- Preserve empty paginated pages in `GcloudListViewSet.list` instead of falling back to the full queryset.
- Add regression tests for both queryset-evaluation cases.

## Tests
- `PYENV_VERSION=3.6.15 python -m py_compile gcloud/core/apis/drf/viewsets/base.py gcloud/core/apis/drf/viewsets/taskflow.py gcloud/tests/core/apis/drf/views_set/test_base_viewset.py gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py`
- `git diff --check`
- `PYENV_VERSION=3.6.15 PYTHONPATH=/tmp/bksops_test_settings:$PYTHONPATH DJANGO_SETTINGS_MODULE=test_settings BKPAAS_ENVIRONMENT=stag BKPAAS_MAJOR_VERSION=3 BKPAAS_APP_ID=bk_sops BKPAAS_APP_SECRET=test BKPAAS_DEFAULT_PREALLOCATED_URLS=http://bk-sops.example.com BKPAAS_ENGINE_REGION=default BKPAAS_PROCESS_TYPE=web BKAPP_IAM_SKIP=1 BKAPP_BK_API_URL_TMPL=http://bkapi.example.com/api/{api_name} BKAPP_PAASV3_APIGW_API_TOKEN=dummy BK_IAM_V3_INNER_HOST=http://iam.example.com BKAPP_SOPS_PAAS_ESB_HOST=http://esb.example.com APP_CODE=bk_sops python manage.py test gcloud.tests.core.apis.drf.views_set.test_base_viewset.TestGcloudListViewSet gcloud.tests.core.apis.drf.views_set.test_task_instance_view.TestTaskInstanceNodeExecutionRecord --verbosity=2`

## Local Hook Notes
- `black`, `isort`, and `Flake8` passed.
- Commit skipped `check-migrate` and `check-sensitive-info` because the referenced scripts are missing in this checkout.
- Commit skipped `commitlint` because the local hook failed before checking the message with a Node ESM compatibility error; the commit message is still conventional-format.