### PR TITLE
fix: 回滚 bamboo-pipeline 3.24.12 升级 #8374

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pyinstrument==3.1.3
 djangorestframework==3.11.2
 django-filter==2.4.0
 prometheus-client==0.9.0
-bamboo-pipeline==3.24.12
+bamboo-pipeline==3.24.11
 drf-yasg==1.20.0
 typing-extensions==3.7.4.3
 pyyaml==5.4.1


### PR DESCRIPTION
## 变更内容

- 将 `requirements.txt` 中 `bamboo-pipeline` 从 `3.24.12` 回滚到 `3.24.11`。

## 背景

- #8374 升级 `bamboo-pipeline` 后，引入 Mako 模板安全检查行为变化。
- 存量扫描结果显示部分项目流程模板存在 `_module` 私有属性访问、自定义 filter、`.format()` 等兼容风险。
- 为避免发布后影响存量流程参数渲染，先回滚依赖升级，后续再单独处理兼容治理方案。

## 发布影响

- 恢复到升级前依赖版本，降低存量流程模板渲染兼容风险。
- 本 PR 只回滚依赖版本，不包含其他代码逻辑变更。

## 验证

- `git diff --check`
- `/Users/dengyh/.pyenv/versions/3.11.4/bin/python -m pip download bamboo-pipeline==3.24.11 --no-deps --ignore-requires-python -d /tmp/bksops_revert_dep_check`
- pre-commit 中 `Check for merge conflicts` 通过；`black/isort/Flake8/check migrate` 无需检查文件。
- 本地 `check-sensitive-info` 钩子因当前基线缺少 `scripts/check_sensitive_info.sh` 跳过；`commitlint` 因本地 node hook 依赖 ESM 兼容问题跳过。

关联：#8374