### PR TITLE
fix: 自动跳过节点运行时允许跳过 --story=135095943

### DIFF
--- a/frontend/desktop/src/pages/task/TaskExecute/ExecuteInfo.vue
+++ b/frontend/desktop/src/pages/task/TaskExecute/ExecuteInfo.vue
@@ -444,7 +444,7 @@
                     if (type === 'tasknode') {
                         // 任务节点和独立子任务节点
                         const activity = this.pipelineData.activities[this.nodeDetailConfig.node_id]
-                        isShow = activity.skippable
+                        isShow = activity.skippable || activity.error_ignorable
                     } else if (type !== 'subflow') {
                         // 网关节点
                         isShow = true

--- a/pipeline_web/parser/format.py
+++ b/pipeline_web/parser/format.py
@@ -53,6 +53,8 @@ def format_web_data_to_pipeline(web_pipeline: dict, is_subprocess: bool = False)
                 act["skippable"] = act.get("isSkipped", True)
             if "retryable" not in act:
                 act["retryable"] = act.get("can_retry", True)
+            if act.get("error_ignorable") and not act.get("skippable"):
+                act["skippable"] = True
 
             # 检查节点配置冲突
             if act.get("timeout_config", {}).get("enable") and (

--- a/pipeline_web/tests/parser/format/test_format_web_data_to_pipeline.py
+++ b/pipeline_web/tests/parser/format/test_format_web_data_to_pipeline.py
@@ -2560,3 +2560,33 @@ class FormatWebDataToPipelineTestCase(TestCase):
         得到预渲染变量key列表
         """
         self.assertEqual(format_web_data_to_pipeline(web_tree), pipeline_tree)
+
+    def test_error_ignorable_node_is_skippable_for_legacy_pipeline_tree(self):
+        legacy_web_tree = {
+            "id": "pipeline",
+            "constants": {},
+            "outputs": [],
+            "activities": {
+                "node": {
+                    "id": "node",
+                    "type": "ServiceActivity",
+                    "component": {"code": "sleep_timer", "data": {}, "version": "legacy"},
+                    "error_ignorable": True,
+                    "skippable": False,
+                    "retryable": True,
+                    "incoming": "flow_start",
+                    "outgoing": "flow_end",
+                }
+            },
+            "gateways": {},
+            "flows": {
+                "flow_start": {"id": "flow_start", "source": "start", "target": "node"},
+                "flow_end": {"id": "flow_end", "source": "node", "target": "end"},
+            },
+            "start_event": {"id": "start", "type": "EmptyStartEvent", "incoming": "", "outgoing": "flow_start"},
+            "end_event": {"id": "end", "type": "EmptyEndEvent", "incoming": "flow_end", "outgoing": ""},
+        }
+
+        formatted_pipeline_tree = format_web_data_to_pipeline(legacy_web_tree)
+
+        self.assertTrue(formatted_pipeline_tree["activities"]["node"]["skippable"])


### PR DESCRIPTION
## 变更说明

- 在 `format_web_data_to_pipeline` 运行时转换阶段，将 `error_ignorable=True` 的服务节点推导为 `skippable=True`，不回写模板/流程定义的 `pipeline_tree`。
- 执行详情页跳过按钮展示条件同步支持 `error_ignorable`，与画布节点行为对齐。
- 补充最小 parser 测试，覆盖老流程 `error_ignorable=True && skippable=False` 时运行时可跳过。

## 背景

老流程中存在自动跳过节点被保存为 `skippable=False` 的情况。V2 引擎执行时会根据转换后的 `skippable` 固化 `can_skip`，导致用户强制终止后无法继续跳过。

## 验证

- 已确认新增测试在修复前失败：`AssertionError: False is not true`。
- `/tmp/bk-sops-parser-test-py37/bin/python` 运行新增单测通过。
- `python -m py_compile pipeline_web/parser/format.py pipeline_web/tests/parser/format/test_format_web_data_to_pipeline.py` 通过。
- pre-commit 中 black / isort / Flake8 通过；本地 pre-commit 的 `check-migrate` 和 `check-sensitive-info` 因当前 master 缺少引用脚本而无法执行。
