### PR TITLE
fix: 补全插件运行壳运行时日志上下文

### DIFF
--- a/gcloud/plugin_gateway/services/runner.py
+++ b/gcloud/plugin_gateway/services/runner.py
@@ -40,8 +40,11 @@ class PluginGatewayRunner:
             )
 
         service = component_cls.bound_service()
-        service.id = run.open_plugin_run_id
-        service.root_pipeline_id = run.open_plugin_run_id
+        service.setup_runtime_attrs(
+            id=run.open_plugin_run_id,
+            root_pipeline_id=run.open_plugin_run_id,
+            logger=logger,
+        )
         setattr(service, "version", run.plugin_version)
         return source, code, service
 

--- a/gcloud/tests/plugin_gateway/test_runner.py
+++ b/gcloud/tests/plugin_gateway/test_runner.py
@@ -19,7 +19,21 @@ from gcloud.plugin_gateway.models import PluginGatewayRun
 from gcloud.plugin_gateway.services.runner import PluginGatewayRunner
 
 
-class _SyncService:
+class _RuntimeService:
+    def __init__(self):
+        self._runtime_attrs = {}
+
+    def setup_runtime_attrs(self, **kwargs):
+        self._runtime_attrs.update(kwargs)
+
+    def __getattr__(self, name):
+        try:
+            return self._runtime_attrs[name]
+        except KeyError:
+            raise AttributeError()
+
+
+class _SyncService(_RuntimeService):
     interval = None
 
     def execute(self, data, parent_data):
@@ -37,7 +51,26 @@ class _SyncComponent:
     bound_service = _SyncService
 
 
-class _ThirdPartyShellService:
+class _RuntimeAwareService(_RuntimeService):
+    interval = None
+
+    def execute(self, data, parent_data):
+        self.logger.info("plugin gateway runtime logger is ready")
+        data.set_outputs("runtime_id", self.id)
+        data.set_outputs("runtime_root_pipeline_id", self.root_pipeline_id)
+        return True
+
+    def need_schedule(self):
+        return False
+
+
+class _RuntimeAwareComponent:
+    code = "runtime_aware"
+    version = "legacy"
+    bound_service = _RuntimeAwareService
+
+
+class _ThirdPartyShellService(_RuntimeService):
     interval = None
 
     def execute(self, data, parent_data):
@@ -59,7 +92,7 @@ class _ThirdPartyShellComponent:
     bound_service = _ThirdPartyShellService
 
 
-class _PollService:
+class _PollService(_RuntimeService):
     interval = object()
 
     def execute(self, data, parent_data):
@@ -70,6 +103,7 @@ class _PollService:
         return getattr(self, "__need_schedule__", False)
 
     def schedule(self, data, parent_data, callback_data=None):
+        self.logger.info("plugin gateway schedule runtime logger is ready")
         data.set_outputs("polled", True)
         data.set_outputs("trace_id_from_runtime", data.get_one_of_outputs("trace_id"))
         setattr(self, "__schedule_finish__", True)
@@ -117,6 +151,19 @@ class PluginGatewayRunnerExecuteTestCase(TestCase):
         self.assertFalse(result["finished"])
         self.assertEqual(result["outputs"]["echo_operator"], "zhangsan")
         self.assertTrue(result["outputs"]["done"])
+
+    @patch("gcloud.plugin_gateway.services.runner.ComponentLibrary")
+    def test_execute_injects_service_runtime_attrs(self, mock_lib):
+        mock_lib.get_component_class.return_value = _RuntimeAwareComponent
+
+        result = PluginGatewayRunner.run_execute(
+            self._run(plugin_id="builtin__runtime_aware"),
+            {"operator": "zhangsan", "project_id": 10, "bk_biz_id": 2},
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["outputs"]["runtime_id"], "a" * 32)
+        self.assertEqual(result["outputs"]["runtime_root_pipeline_id"], "a" * 32)
 
     @patch("gcloud.plugin_gateway.services.runner.ComponentLibrary")
     def test_execute_exception_maps_failed(self, mock_lib):


### PR DESCRIPTION
## 问题

stage 的内置 HTTP 轮询插件在 `schedule()` 首次访问 `self.logger` 时抛出空 `AttributeError`，运行 `165f91ca42bb4cc9b18a5dad9b434071` 最终失败。组件运行壳直接实例化 Service，但没有注入引擎正常执行时提供的运行时 logger。

## 修复

- 通过 `setup_runtime_attrs` 统一注入 `id`、`root_pipeline_id` 与 `logger`
- 补充 execute 和跨 tick schedule 重建场景的 logger 回归覆盖
- 测试桩对齐真实 pipeline Service 的运行时属性协议

## 验证

- `python manage.py test gcloud.tests.plugin_gateway gcloud.tests.apigw.views.test_plugin_gateway -v 1`：71 passed
- black / isort / flake8 / merge-conflict checks：passed
- 本地 commit hook 的 check-migrate、sensitive-info 脚本不在 upstream/master，commitlint 旧 hook 与 Node 18 ESM 不兼容；这些 hook 未形成有效检查结果

## 待部署后联调

- 重新验证内置 HTTP 轮询完整执行与回调
- `danny-test-plugi` 当前未出现在 stage 插件网关目录，第三方真实执行需目录可见后补验