### PR TITLE
fix: 插件网关返回全量第三方插件目录

### DIFF
--- a/gcloud/plugin_gateway/services/catalog.py
+++ b/gcloud/plugin_gateway/services/catalog.py
@@ -30,12 +30,14 @@ from gcloud.plugin_gateway.constants import (
 from gcloud.plugin_gateway.exceptions import PluginGatewaySourceUnavailableError, PluginGatewayVersionNotFoundError
 from gcloud.plugin_gateway.models import PluginGatewaySourceConfig
 from gcloud.plugin_gateway.services.builtin_catalog import BuiltinCatalogService
+from plugin_service.conf import PLUGIN_DISTRIBUTOR_NAME
 from plugin_service.exceptions import PluginServiceException
 from plugin_service.plugin_client import PluginServiceApiClient
 
 
 class PluginGatewayCatalogService:
     POLLING_STATUS_KEY = "data.status"
+    THIRD_PARTY_LIST_PAGE_SIZE = 200
     THIRD_PARTY_META_WORKERS = 8
     APIGW_BACKEND_PATH_PREFIX = "/apigw"
 
@@ -129,12 +131,43 @@ class PluginGatewayCatalogService:
 
         return sorted(plugins, key=lambda item: (item["name"], item["id"]))
 
-    @staticmethod
-    def _get_third_party_plugin_entries():
-        result = PluginServiceApiClient.get_plugin_list(limit=200, offset=0)
-        if not result.get("result"):
-            raise PluginGatewaySourceUnavailableError(result.get("message", "query plugin list failed"))
-        return result.get("data", {}).get("plugins", [])
+    @classmethod
+    def _get_third_party_plugin_entries(cls, search_term=None):
+        plugins = []
+        offset = 0
+        expected_total = None
+
+        while True:
+            request_kwargs = {
+                "limit": cls.THIRD_PARTY_LIST_PAGE_SIZE,
+                "offset": offset,
+                "distributor_code_name": PLUGIN_DISTRIBUTOR_NAME,
+            }
+            if search_term:
+                request_kwargs["search_term"] = search_term
+            result = PluginServiceApiClient.get_plugin_list(**request_kwargs)
+            if not result.get("result"):
+                raise PluginGatewaySourceUnavailableError(result.get("message", "query plugin list failed"))
+
+            data = result.get("data") or {}
+            page_plugins = data.get("plugins")
+            total = data.get("count")
+            if not isinstance(page_plugins, list) or type(total) is not int or total < 0:
+                raise PluginGatewaySourceUnavailableError("query plugin list returned invalid pagination data")
+            if expected_total is None:
+                expected_total = total
+            elif total != expected_total:
+                raise PluginGatewaySourceUnavailableError("plugin list count changed during pagination")
+
+            plugins.extend(page_plugins)
+            if len(plugins) == expected_total:
+                break
+            if len(plugins) > expected_total or len(page_plugins) != cls.THIRD_PARTY_LIST_PAGE_SIZE:
+                raise PluginGatewaySourceUnavailableError("query plugin list returned incomplete pagination data")
+
+            offset += cls.THIRD_PARTY_LIST_PAGE_SIZE
+
+        return plugins
 
     @staticmethod
     def _build_third_party_plugin_reference(plugin, meta):
@@ -174,7 +207,11 @@ class PluginGatewayCatalogService:
             return None
 
         plugin = next(
-            (item for item in cls._get_third_party_plugin_entries() if item["code"] == plugin_code),
+            (
+                item
+                for item in cls._get_third_party_plugin_entries(search_term=plugin_code)
+                if item["code"] == plugin_code
+            ),
             None,
         )
         if plugin is None:

--- a/gcloud/tests/plugin_gateway/test_catalog.py
+++ b/gcloud/tests/plugin_gateway/test_catalog.py
@@ -1,11 +1,13 @@
 from threading import Barrier
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from django.test import RequestFactory, TestCase, override_settings
 
 from gcloud.plugin_gateway.constants import PLUGIN_SOURCE_BUILTIN, PLUGIN_SOURCE_THIRD_PARTY
+from gcloud.plugin_gateway.exceptions import PluginGatewaySourceUnavailableError
 from gcloud.plugin_gateway.models import PluginGatewaySourceConfig
 from gcloud.plugin_gateway.services.catalog import PluginGatewayCatalogService
+from plugin_service.conf import PLUGIN_DISTRIBUTOR_NAME
 
 
 class PluginGatewayCatalogServiceTestCase(TestCase):
@@ -91,7 +93,7 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         }
         mock_client_cls.get_plugin_list.return_value = {
             "result": True,
-            "data": {"plugins": [{"code": "bk_plugin_demo", "name": "Demo Plugin"}]},
+            "data": {"count": 1, "plugins": [{"code": "bk_plugin_demo", "name": "Demo Plugin"}]},
         }
 
         meta = PluginGatewayCatalogService.get_plugin_list(request=self.request)
@@ -158,7 +160,7 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         }
         mock_client_cls.get_plugin_list.return_value = {
             "result": True,
-            "data": {"plugins": [{"code": "bk_plugin_demo", "name": "Demo Plugin"}]},
+            "data": {"count": 1, "plugins": [{"code": "bk_plugin_demo", "name": "Demo Plugin"}]},
         }
 
         detail = PluginGatewayCatalogService.get_plugin_detail(
@@ -219,16 +221,68 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         mock_client_cls.get_plugin_list.return_value = {
             "result": True,
             "data": {
+                "count": 2,
                 "plugins": [
                     {"code": "bk_plugin_demo_1", "name": "Demo Plugin 1"},
                     {"code": "bk_plugin_demo_2", "name": "Demo Plugin 2"},
-                ]
+                ],
             },
         }
 
         plugins = PluginGatewayCatalogService._list_third_party_plugins()
 
         self.assertEqual([plugin["id"] for plugin in plugins], ["bk_plugin_demo_1", "bk_plugin_demo_2"])
+
+    @patch("gcloud.plugin_gateway.services.catalog.PluginServiceApiClient")
+    def test_get_third_party_plugin_entries_loads_all_pages(self, mock_client_cls):
+        first_page = [
+            {"code": "plugin_{:03d}".format(index), "name": "Plugin {:03d}".format(index)} for index in range(200)
+        ]
+        second_page = [
+            {"code": "plugin_{:03d}".format(index), "name": "Plugin {:03d}".format(index)} for index in range(200, 400)
+        ]
+        third_page = [{"code": "plugin_400", "name": "Plugin 400"}]
+        mock_client_cls.get_plugin_list.side_effect = [
+            {"result": True, "data": {"count": 401, "plugins": first_page}},
+            {"result": True, "data": {"count": 401, "plugins": second_page}},
+            {"result": True, "data": {"count": 401, "plugins": third_page}},
+        ]
+
+        plugins = PluginGatewayCatalogService._get_third_party_plugin_entries()
+
+        self.assertEqual(len(plugins), 401)
+        self.assertEqual(plugins[-1]["code"], "plugin_400")
+        self.assertEqual(
+            mock_client_cls.get_plugin_list.call_args_list,
+            [
+                call(limit=200, offset=0, distributor_code_name=PLUGIN_DISTRIBUTOR_NAME),
+                call(limit=200, offset=200, distributor_code_name=PLUGIN_DISTRIBUTOR_NAME),
+                call(limit=200, offset=400, distributor_code_name=PLUGIN_DISTRIBUTOR_NAME),
+            ],
+        )
+
+    @patch("gcloud.plugin_gateway.services.catalog.PluginServiceApiClient")
+    def test_get_third_party_plugin_entries_rejects_incomplete_page(self, mock_client_cls):
+        first_page = [
+            {"code": "plugin_{:03d}".format(index), "name": "Plugin {:03d}".format(index)} for index in range(200)
+        ]
+        mock_client_cls.get_plugin_list.side_effect = [
+            {"result": True, "data": {"count": 401, "plugins": first_page}},
+            {"result": True, "data": {"count": 401, "plugins": []}},
+        ]
+
+        with self.assertRaises(PluginGatewaySourceUnavailableError):
+            PluginGatewayCatalogService._get_third_party_plugin_entries()
+
+    @patch("gcloud.plugin_gateway.services.catalog.PluginServiceApiClient")
+    def test_get_third_party_plugin_entries_rejects_boolean_count(self, mock_client_cls):
+        mock_client_cls.get_plugin_list.return_value = {
+            "result": True,
+            "data": {"count": True, "plugins": [{"code": "plugin_demo", "name": "Plugin Demo"}]},
+        }
+
+        with self.assertRaises(PluginGatewaySourceUnavailableError):
+            PluginGatewayCatalogService._get_third_party_plugin_entries()
 
     @patch("gcloud.plugin_gateway.services.catalog.BuiltinCatalogService.list_plugins")
     @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._get_plugin_detail_schema")
@@ -246,10 +300,11 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         mock_client_cls.get_plugin_list.return_value = {
             "result": True,
             "data": {
+                "count": 2,
                 "plugins": [
                     {"code": "bk_plugin_demo_1", "name": "Demo Plugin 1"},
                     {"code": "bk_plugin_demo_2", "name": "Demo Plugin 2"},
-                ]
+                ],
             },
         }
 
@@ -261,6 +316,12 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
 
         self.assertEqual(detail["id"], "bk_plugin_demo_1")
         mock_get_plugin_meta.assert_called_once_with("bk_plugin_demo_1")
+        mock_client_cls.get_plugin_list.assert_called_once_with(
+            search_term="bk_plugin_demo_1",
+            limit=200,
+            offset=0,
+            distributor_code_name=PLUGIN_DISTRIBUTOR_NAME,
+        )
 
     @patch("gcloud.plugin_gateway.services.catalog.BuiltinCatalogService.list_plugins")
     @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._get_plugin_meta")
@@ -288,7 +349,7 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         mock_get_plugin_meta.return_value = {"description": "remote plugin", "versions": ["1.0.0"]}
         mock_client_cls.get_plugin_list.return_value = {
             "result": True,
-            "data": {"plugins": [{"code": "bk_plugin_demo", "name": "Demo Plugin"}]},
+            "data": {"count": 1, "plugins": [{"code": "bk_plugin_demo", "name": "Demo Plugin"}]},
         }
 
         meta = PluginGatewayCatalogService.get_plugin_list(request=self.request)


### PR DESCRIPTION
## 变更说明

- 按 `PLUGIN_DISTRIBUTOR_NAME` 分页拉取标准运维获授权的全部第三方插件，不再固定只取前 200 条
- 严格校验分页 `count`，中途空页、短页、计数变化或非法计数整体返回来源异常，避免返回残缺目录
- detail/execute 查找单个第三方插件时使用 `search_term=plugin_code` 查询候选并精确匹配，避免每次执行扫描全量目录
- 对外响应结构不变，无需同步 APIGW 文档

## 验证

- `python manage.py test gcloud.tests.plugin_gateway -v 2`：57 passed
- `black --check gcloud/plugin_gateway/services/catalog.py gcloud/tests/plugin_gateway/test_catalog.py`
- `git diff --check`

## Stage 验证重点

1. 冷请求 `/stage/plugin-gateway/plugins/` 能返回超过单页上限的完整目录，并包含 `danny-test-plugi`
2. 记录首次全量请求耗时，确认 APIGW/Gunicorn 不会在响应完成前超时
3. 验证末页插件的 detail 和 execute 登记不再触发全量分页

首次全量目录仍需逐插件读取 meta，BKFlow 缓存只能降低后续刷新频率，不能消除第一次请求的超时风险；若 stage 出现 504，需要另行调整网关超时或引入异步快照。
