### PR TITLE
perf: 按插件来源提前加载插件目录

### DIFF
--- a/docs/plans/2026-07-20-plugin-gateway-catalog-source-filter.md
+++ b/docs/plans/2026-07-20-plugin-gateway-catalog-source-filter.md
@@ -1,0 +1,18 @@
+# Plugin Gateway Catalog Source Filter Plan
+
+Spec: `docs/specs/2026-07-20-plugin-gateway-catalog-source-filter-design.md`
+
+1. Add tests proving built-in requests do not load third-party metadata and
+   third-party requests do not load the built-in catalog.
+2. Pass `plugin_source` into the catalog builder and select the required source
+   before any source-specific loading begins.
+3. Run `gcloud.tests.plugin_gateway.test_catalog` and inspect the final diff.
+
+Test command:
+
+```bash
+set -a
+source /Users/dengyh/Projects/bk-sops/.env
+set +a
+PYENV_VERSION=3.6.15 python manage.py test gcloud.tests.plugin_gateway.test_catalog -v 2
+```

--- a/docs/specs/2026-07-20-plugin-gateway-catalog-source-filter-design.md
+++ b/docs/specs/2026-07-20-plugin-gateway-catalog-source-filter-design.md
@@ -1,0 +1,23 @@
+# Plugin Gateway Catalog Source Filter Design
+
+## Goal
+
+Reduce plugin list latency when a consumer requests only one plugin source.
+
+## Decision
+
+`GET plugin-gateway/plugins/` reads the optional `plugin_source` query parameter
+before building the catalog:
+
+- `builtin`: load only the built-in catalog.
+- `third_party`: load only the third-party catalog and metadata.
+- missing or unknown: preserve the existing behavior and load both catalogs.
+
+The existing category, keyword, blacklist, URL generation, and response shape
+remain unchanged. Plugin detail and execution behavior are outside this change.
+
+## Compatibility
+
+Requests without `plugin_source` still receive the full catalog. Unknown source
+values still produce an empty filtered result after loading the full catalog,
+matching the current API behavior.

--- a/gcloud/plugin_gateway/services/catalog.py
+++ b/gcloud/plugin_gateway/services/catalog.py
@@ -65,8 +65,8 @@ class PluginGatewayCatalogService:
     @classmethod
     def get_plugin_list(cls, request):
         meta = {"total": 0, "apis": []}
-        for item in cls._list_plugins():
-            plugin_source = request.GET.get("plugin_source")
+        plugin_source = request.GET.get("plugin_source")
+        for item in cls._list_plugins(plugin_source=plugin_source):
             if plugin_source and item.get("plugin_source") != plugin_source:
                 continue
 
@@ -139,10 +139,16 @@ class PluginGatewayCatalogService:
         detail["polling"]["url"] = cls._build_public_api_url(request, "apigw_plugin_gateway_run_status")
         return detail
 
-    @staticmethod
-    def _list_plugins():
-        plugins = BuiltinCatalogService.list_plugins() + PluginGatewayCatalogService._list_third_party_plugins()
-        plugins = PluginGatewayCatalogService._filter_do_not_open_plugins(plugins)
+    @classmethod
+    def _list_plugins(cls, plugin_source=None):
+        if plugin_source == PLUGIN_SOURCE_BUILTIN:
+            plugins = BuiltinCatalogService.list_plugins()
+        elif plugin_source == PLUGIN_SOURCE_THIRD_PARTY:
+            plugins = cls._list_third_party_plugins()
+        else:
+            plugins = BuiltinCatalogService.list_plugins() + cls._list_third_party_plugins()
+
+        plugins = cls._filter_do_not_open_plugins(plugins)
         return sorted(plugins, key=lambda item: (item["name"], item["id"]))
 
     @classmethod

--- a/gcloud/tests/plugin_gateway/test_catalog.py
+++ b/gcloud/tests/plugin_gateway/test_catalog.py
@@ -141,6 +141,45 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         self.assertEqual(meta["total"], 1)
         self.assertEqual([item["id"] for item in meta["apis"]], ["builtin__job_execute"])
 
+    @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._list_third_party_plugins")
+    @patch("gcloud.plugin_gateway.services.catalog.BuiltinCatalogService.list_plugins")
+    def test_get_plugin_list_loads_only_builtin_source(self, mock_builtin_list, mock_third_party_list):
+        request = RequestFactory().get(
+            "/apigw/plugin-gateway/plugins/",
+            {"plugin_source": PLUGIN_SOURCE_BUILTIN},
+        )
+        mock_builtin_list.return_value = []
+
+        PluginGatewayCatalogService.get_plugin_list(request=request)
+
+        mock_builtin_list.assert_called_once_with()
+        mock_third_party_list.assert_not_called()
+
+    @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._list_third_party_plugins")
+    @patch("gcloud.plugin_gateway.services.catalog.BuiltinCatalogService.list_plugins")
+    def test_get_plugin_list_loads_only_third_party_source(self, mock_builtin_list, mock_third_party_list):
+        request = RequestFactory().get(
+            "/apigw/plugin-gateway/plugins/",
+            {"plugin_source": PLUGIN_SOURCE_THIRD_PARTY},
+        )
+        mock_third_party_list.return_value = []
+
+        PluginGatewayCatalogService.get_plugin_list(request=request)
+
+        mock_builtin_list.assert_not_called()
+        mock_third_party_list.assert_called_once_with()
+
+    @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._list_third_party_plugins")
+    @patch("gcloud.plugin_gateway.services.catalog.BuiltinCatalogService.list_plugins")
+    def test_get_plugin_list_without_source_loads_all_sources(self, mock_builtin_list, mock_third_party_list):
+        mock_builtin_list.return_value = []
+        mock_third_party_list.return_value = []
+
+        PluginGatewayCatalogService.get_plugin_list(request=self.request)
+
+        mock_builtin_list.assert_called_once_with()
+        mock_third_party_list.assert_called_once_with()
+
     @override_settings(
         BK_API_URL_TMPL="https://{api_name}.apigw.example.com",
         BK_APIGW_NAME="bk-sops",


### PR DESCRIPTION
## 变更内容

- 在构建插件目录前读取 plugin_source，builtin 请求不再加载第三方插件元数据
- third_party 请求不再扫描内置组件目录
- 未传或传入未知来源时保留原有全量加载与过滤行为
- 补充设计、实施记录和来源级回归测试

## 验证

- python manage.py test gcloud.tests.plugin_gateway.test_catalog -v 1：17 passed
- black / isort / flake8：passed

关联需求：133649781