### PR TITLE
fix: 规范化插件运行壳持久化输出

### DIFF
--- a/gcloud/plugin_gateway/services/runner.py
+++ b/gcloud/plugin_gateway/services/runner.py
@@ -11,8 +11,10 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import json
 import logging
 
+from django.core.serializers.json import DjangoJSONEncoder
 from pipeline.component_framework.library import ComponentLibrary
 from pipeline.core.data.base import DataObject
 from pipeline.utils.collections import FancyDict
@@ -123,9 +125,10 @@ class PluginGatewayRunner:
     @staticmethod
     def _outputs(data):
         try:
-            return dict(data.get_outputs())
+            outputs = dict(data.get_outputs())
         except Exception:
             return {}
+        return json.loads(json.dumps(outputs, cls=DjangoJSONEncoder))
 
     @staticmethod
     def _ex_data(data):

--- a/gcloud/tests/plugin_gateway/test_dispatch.py
+++ b/gcloud/tests/plugin_gateway/test_dispatch.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from django.test import TestCase
 from django.utils import timezone
+from django.utils.translation import ugettext_lazy
 
 from gcloud.plugin_gateway.exceptions import PluginGatewayContextResolveError
 from gcloud.plugin_gateway.models import PluginGatewayRun, PluginGatewaySourceConfig
@@ -12,6 +13,23 @@ from gcloud.plugin_gateway.tasks import (
     poll_plugin_gateway_run,
 )
 from gcloud.utils import crypto
+
+
+class _LazyOutputScheduleService:
+    def setup_runtime_attrs(self, **kwargs):
+        pass
+
+    def schedule(self, data, parent_data, callback_data=None):
+        data.set_outputs("ex_data", ugettext_lazy("请求响应数据格式非 JSON"))
+        data.set_outputs("details", {"messages": [ugettext_lazy("上游服务异常")]})
+        return False
+
+    def is_schedule_finished(self):
+        return False
+
+
+class _LazyOutputScheduleComponent:
+    bound_service = _LazyOutputScheduleService
 
 
 class PluginGatewayDispatchTaskTestCase(TestCase):
@@ -175,6 +193,36 @@ class PluginGatewayDispatchTaskTestCase(TestCase):
             kwargs={"open_plugin_run_id": run.open_plugin_run_id},
             countdown=10,
             queue="open_plugin_polling",
+        )
+
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayCallbackService.callback_run")
+    @patch("gcloud.plugin_gateway.services.runner.ComponentLibrary")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayContextService.resolve_run_context")
+    def test_poll_persists_lazy_translation_outputs(
+        self, mock_resolve_context, mock_component_library, mock_callback_run
+    ):
+        mock_resolve_context.return_value = {"operator": "bkflow-user", "project_id": 10, "bk_biz_id": 2}
+        mock_component_library.get_component_class.return_value = _LazyOutputScheduleComponent
+        run = self._create_run(
+            plugin_id="builtin__bk_http_request",
+            plugin_version="1.0",
+            run_status=PluginGatewayRun.Status.RUNNING,
+        )
+
+        poll_plugin_gateway_run(open_plugin_run_id=run.open_plugin_run_id)
+
+        run.refresh_from_db()
+        self.assertEqual(
+            run.runtime_outputs,
+            {
+                "ex_data": "请求响应数据格式非 JSON",
+                "details": {"messages": ["上游服务异常"]},
+            },
+        )
+        mock_callback_run.assert_called_once_with(
+            open_plugin_run_id=run.open_plugin_run_id,
+            run_status=PluginGatewayRun.Status.FAILED,
+            error_message="请求响应数据格式非 JSON",
         )
 
     @patch("gcloud.plugin_gateway.tasks.PluginGatewayCallbackService.callback_run")


### PR DESCRIPTION
## 变更内容

- 在插件运行壳输出边界使用 `DjangoJSONEncoder` 做 JSON 标准化，确保 Django 懒翻译对象以及日期、Decimal、UUID 等支持类型可写入 `runtime_outputs`。
- 新增轮询任务回归用例，覆盖组件返回嵌套 `ugettext_lazy` 输出、持久化运行时输出并触发失败回调的完整链路。

## 根因

组件可以把 `ugettext_lazy` 生成的 `__proxy__` 对象写入 outputs。此前运行壳直接返回原始对象，轮询任务在写入 `PluginGatewayRun.runtime_outputs` JSONField 时触发序列化异常，导致任务在执行失败回调前中断并停留在 RUNNING。

## 验证

```bash
python manage.py test gcloud.tests.plugin_gateway pipeline_plugins.tests.components.collections.http_test.test_v1_0 -v 1
```

共 70 条测试通过。Black、isort、Flake8 和冲突检查通过。

本次不涉及数据库迁移或 API 协议变更。