### PR TITLE
fix: 修复插件网关目录契约问题

### DIFF
--- a/gcloud/plugin_gateway/services/catalog.py
+++ b/gcloud/plugin_gateway/services/catalog.py
@@ -216,7 +216,8 @@ class PluginGatewayCatalogService:
         if not versions:
             return None
 
-        latest_version = versions[-1]
+        # bk-plugin-framework returns versions in descending order.
+        latest_version = versions[0]
         category = meta.get("group") or meta.get("category") or meta.get("tag") or PLUGIN_SOURCE_THIRD_PARTY
         return {
             "id": plugin["code"],

--- a/gcloud/tests/plugin_gateway/test_builtin_catalog.py
+++ b/gcloud/tests/plugin_gateway/test_builtin_catalog.py
@@ -12,6 +12,7 @@ from gcloud.plugin_gateway.constants import (
     encode_plugin_id,
 )
 from gcloud.plugin_gateway.services.builtin_catalog import BuiltinCatalogService
+from pipeline_plugins.components.collections.http.v1_0 import HttpComponent
 
 
 class TestPluginIdCodec(TestCase):
@@ -55,3 +56,13 @@ class TestBuiltinCatalog(TestCase):
         self.assertEqual(plugins[0]["category"], "JOB")
         self.assertEqual(plugins[0]["wrapper_version"], UNIFORM_API_WRAPPER_VERSION)
         self.assertIn("legacy", plugins[0]["versions"])
+
+    @patch("gcloud.plugin_gateway.services.builtin_catalog.ComponentLibrary")
+    def test_http_detail_exposes_runtime_timeout_input(self, mock_lib):
+        mock_lib.get_component_class.return_value = HttpComponent
+
+        detail = BuiltinCatalogService.get_plugin_detail("bk_http_request", "v1.0")
+
+        input_keys = [item["key"] for item in detail["inputs"]]
+        self.assertIn("bk_http_timeout", input_keys)
+        self.assertNotIn("bk_http_request_timeout", input_keys)

--- a/gcloud/tests/plugin_gateway/test_catalog.py
+++ b/gcloud/tests/plugin_gateway/test_catalog.py
@@ -232,7 +232,7 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         ]
         mock_get_plugin_meta.return_value = {
             "description": "remote plugin",
-            "versions": ["1.0.0", "1.1.0"],
+            "versions": ["1.1.0", "1.0.0"],
             "framework_version": "2.0.0",
             "runtime_version": "3.11",
             "group": "DEVOPS",
@@ -252,7 +252,7 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         self.assertEqual(third_party_plugin["category"], "DEVOPS")
         self.assertEqual(third_party_plugin["default_version"], "1.1.0")
         self.assertEqual(third_party_plugin["latest_version"], "1.1.0")
-        self.assertEqual(third_party_plugin["versions"], ["1.0.0", "1.1.0"])
+        self.assertEqual(third_party_plugin["versions"], ["1.1.0", "1.0.0"])
         self.assertEqual(third_party_plugin["wrapper_version"], UNIFORM_API_WRAPPER_VERSION)
         self.assertIn("/apigw/plugin-gateway/plugins/bk_plugin_demo/", third_party_plugin["meta_url_template"])
         self.assertEqual(builtin_plugin["plugin_source"], PLUGIN_SOURCE_BUILTIN)
@@ -277,7 +277,7 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
         mock_builtin_list.return_value = []
         mock_get_plugin_meta.return_value = {
             "description": "remote plugin",
-            "versions": ["1.0.0", "1.1.0"],
+            "versions": ["1.1.0", "1.0.0"],
             "framework_version": "2.0.0",
             "runtime_version": "3.11",
         }
@@ -356,6 +356,16 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
             detail["polling"]["url"],
             "https://bk-sops.apigw.example.com/stage/plugin-gateway/runs/status/",
         )
+
+    def test_build_third_party_plugin_reference_uses_first_framework_version_as_latest(self):
+        plugin = {"code": "bk_plugin_demo", "name": "Demo Plugin"}
+        meta = {"description": "remote plugin", "versions": ["1.2.0", "1.0.0"]}
+
+        reference = PluginGatewayCatalogService._build_third_party_plugin_reference(plugin, meta)
+
+        self.assertEqual(reference["default_version"], "1.2.0")
+        self.assertEqual(reference["latest_version"], "1.2.0")
+        self.assertEqual(reference["versions"], ["1.2.0", "1.0.0"])
 
     @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._get_plugin_meta")
     @patch("gcloud.plugin_gateway.services.catalog.PluginServiceApiClient")

--- a/pipeline_plugins/components/collections/http/v1_0.py
+++ b/pipeline_plugins/components/collections/http/v1_0.py
@@ -75,7 +75,7 @@ class HttpRequestService(BasePluginService):
             ),
             self.InputItem(
                 name=_("HTTP 请求超时时间"),
-                key="bk_http_request_timeout",
+                key="bk_http_timeout",
                 type="int",
                 schema=IntItemSchema(description=_("HTTP 请求超时时间")),
             ),


### PR DESCRIPTION
## 变更内容

- 按 bk-plugin-framework 的降序版本契约选择第三方插件 latest/default version
- 修正内置 HTTP 插件目录参数名，使其与运行时读取的 `bk_http_timeout` 一致
- 补充目录版本与 HTTP detail 回归测试

## 验证

- `python manage.py test gcloud.tests.plugin_gateway pipeline_plugins.tests.components.collections.http_test.test_v1_0 -v 0`（72 passed）
- Black / isort / Flake8 passed

关联需求：133649781