### PR TITLE
fix(ci): 加固可信贡献者自动代码审查

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -11,25 +11,55 @@ jobs:
   security-check:
     name: 安全检查
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       is_safe: ${{ steps.check.outputs.is_safe }}
       author_association: ${{ steps.check.outputs.author_association }}
+      author_permission: ${{ steps.check.outputs.author_permission }}
+      sender_permission: ${{ steps.check.outputs.sender_permission }}
     steps:
       - name: 检查贡献者身份
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EVENT_SENDER: ${{ github.event.sender.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
-          echo "作者关联: ${{ github.event.pull_request.author_association }}"
-          # 允许的身份：OWNER（所有者）、MEMBER（成员）、COLLABORATOR（协作者）
-          if [[ "${{ github.event.pull_request.author_association }}" == "OWNER" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "MEMBER" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]]; then
-            echo "✅ 可信任的贡献者，允许自动审查"
-            echo "is_safe=true" >> $GITHUB_OUTPUT
+          get_permission() {
+            local username="$1"
+            gh api "repos/${REPOSITORY}/collaborators/${username}/permission" \
+              --jq '.permission' 2>/dev/null || echo "none"
+          }
+
+          is_trusted_permission() {
+            # GitHub 的 permission 字段会把 maintain 映射为 write。
+            case "$1" in
+              admin|write) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          AUTHOR_PERMISSION="$(get_permission "$PR_AUTHOR")"
+          SENDER_PERMISSION="$(get_permission "$EVENT_SENDER")"
+
+          echo "作者关联: $AUTHOR_ASSOCIATION"
+          echo "PR 作者 $PR_AUTHOR 的仓库权限: $AUTHOR_PERMISSION"
+          echo "事件触发者 $EVENT_SENDER 的仓库权限: $SENDER_PERMISSION"
+
+          if is_trusted_permission "$AUTHOR_PERMISSION" && \
+            is_trusted_permission "$SENDER_PERMISSION"; then
+            echo "✅ PR 作者和事件触发者均具备写权限，允许自动审查"
+            echo "is_safe=true" >> "$GITHUB_OUTPUT"
           else
-            echo "⚠️ 外部贡献者，需要手动批准"
-            echo "is_safe=false" >> $GITHUB_OUTPUT
+            echo "⚠️ PR 作者或事件触发者不具备写权限，跳过自动审查"
+            echo "is_safe=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "author_association=${{ github.event.pull_request.author_association }}" >> $GITHUB_OUTPUT
+          echo "author_association=$AUTHOR_ASSOCIATION" >> "$GITHUB_OUTPUT"
+          echo "author_permission=$AUTHOR_PERMISSION" >> "$GITHUB_OUTPUT"
+          echo "sender_permission=$SENDER_PERMISSION" >> "$GITHUB_OUTPUT"
   # 第二步：代码审查（只对可信贡献者自动运行）
   code-review:
     name: 自动代码审查
@@ -47,6 +77,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          # 前置安全检查已确认 PR 作者与本次事件触发者均具备写权限。
+          # CodeBuddy 需要完整 PR 工作区进行跨文件审查，因此显式允许可信 fork 的 Head checkout。
+          allow-unsafe-pr-checkout: true
 
       - name: 设置 Node.js 环境
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 问题

bk-sops 的 CodeBuddy workflow 使用 `pull_request_target` 获取仓库 Secret，并显式检出 PR Head。新版 `actions/checkout@v4` 会默认拒绝在该事件中检出 fork PR 代码，因此可信贡献者的 fork PR 会在 CodeBuddy 启动前失败。

PR #8425 的失败日志已确认是该保护触发：安全检查通过，但 checkout 因 `allow-unsafe-pr-checkout: false` 退出。

## 修改

- 不再仅依赖 `author_association`，通过仓库 Collaborator Permission API 校验 PR 作者的真实权限。
- 同时校验本次事件触发者，只有两者都具备 `admin` 或 `write` 权限时才运行自动审查；权限查询失败时按不可信处理。
- 在上述门禁后显式设置 `allow-unsafe-pr-checkout: true`，恢复可信 fork PR 的 Head checkout。
- 保留现有 CodeBuddy 完整审查流程，包括全量工作区、PR diff、项目/API 规则、行内评论和总结。

## 安全边界与影响

- 外部贡献者、只读用户或无法确认权限的用户不会运行 CodeBuddy，也不会获得仓库 Secret。
- 已认可且具备写权限的 contributor 可以继续触发完整 CodeBuddy review。
- 安全检查 job 仅授予 `contents: read`；CodeBuddy job 原有 `contents: read`、`pull-requests: write` 权限不变。

## 验证

- `actionlint`：通过（仅忽略其尚未收录的 checkout 新输入定义，并已从 actions/checkout 官方 `action.yml` 确认该输入存在）。
- 权限门禁用例：`admin + write` 放行，`read + write` 拒绝，`admin + none` 拒绝。
- workflow 静态断言：完整 CodeBuddy review 能力标记均保留。
- `git diff --check`：通过；仅修改 `.github/workflows/code_review.yml`。

## CI 说明

本 PR 自身的 `pull_request_target` 会读取目标分支 `master` 上尚未修复的旧 workflow，因此“自动代码审查”仍可能以同一 checkout 错误失败。这是修复生效前的引导阶段现象；合入后，新触发的 PR 事件才会使用本次安全门禁和 checkout 配置。
