### PR TITLE
fix(ci): 修复默认分支可信贡献者代码审查

### DIFF
--- a/.github/workflows/code_review.yml
+++ b/.github/workflows/code_review.yml
@@ -11,25 +11,55 @@ jobs:
   security-check:
     name: 安全检查
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       is_safe: ${{ steps.check.outputs.is_safe }}
       author_association: ${{ steps.check.outputs.author_association }}
+      author_permission: ${{ steps.check.outputs.author_permission }}
+      sender_permission: ${{ steps.check.outputs.sender_permission }}
     steps:
       - name: 检查贡献者身份
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          EVENT_SENDER: ${{ github.event.sender.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.pull_request.author_association }}
         run: |
-          echo "作者关联: ${{ github.event.pull_request.author_association }}"
-          # 允许的身份：OWNER（所有者）、MEMBER（成员）、COLLABORATOR（协作者）
-          if [[ "${{ github.event.pull_request.author_association }}" == "OWNER" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "MEMBER" ]] || \
-             [[ "${{ github.event.pull_request.author_association }}" == "COLLABORATOR" ]]; then
-            echo "✅ 可信任的贡献者，允许自动审查"
-            echo "is_safe=true" >> $GITHUB_OUTPUT
+          get_permission() {
+            local username="$1"
+            gh api "repos/${REPOSITORY}/collaborators/${username}/permission" \
+              --jq '.permission' 2>/dev/null || echo "none"
+          }
+
+          is_trusted_permission() {
+            # GitHub 的 permission 字段会把 maintain 映射为 write。
+            case "$1" in
+              admin|write) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          AUTHOR_PERMISSION="$(get_permission "$PR_AUTHOR")"
+          SENDER_PERMISSION="$(get_permission "$EVENT_SENDER")"
+
+          echo "作者关联: $AUTHOR_ASSOCIATION"
+          echo "PR 作者 $PR_AUTHOR 的仓库权限: $AUTHOR_PERMISSION"
+          echo "事件触发者 $EVENT_SENDER 的仓库权限: $SENDER_PERMISSION"
+
+          if is_trusted_permission "$AUTHOR_PERMISSION" && \
+            is_trusted_permission "$SENDER_PERMISSION"; then
+            echo "✅ PR 作者和事件触发者均具备写权限，允许自动审查"
+            echo "is_safe=true" >> "$GITHUB_OUTPUT"
           else
-            echo "⚠️ 外部贡献者，需要手动批准"
-            echo "is_safe=false" >> $GITHUB_OUTPUT
+            echo "⚠️ PR 作者或事件触发者不具备写权限，跳过自动审查"
+            echo "is_safe=false" >> "$GITHUB_OUTPUT"
           fi
-          echo "author_association=${{ github.event.pull_request.author_association }}" >> $GITHUB_OUTPUT
+          echo "author_association=$AUTHOR_ASSOCIATION" >> "$GITHUB_OUTPUT"
+          echo "author_permission=$AUTHOR_PERMISSION" >> "$GITHUB_OUTPUT"
+          echo "sender_permission=$SENDER_PERMISSION" >> "$GITHUB_OUTPUT"
   # 第二步：代码审查（只对可信贡献者自动运行）
   code-review:
     name: 自动代码审查
@@ -48,6 +78,9 @@ jobs:
           fetch-depth: 0
           # 关键：检出 PR 的代码，而不是默认分支
           ref: ${{ github.event.pull_request.head.sha }}
+          # 前置安全检查已确认 PR 作者与本次事件触发者均具备写权限。
+          # CodeBuddy 需要完整 PR 工作区进行跨文件审查，因此显式允许可信 fork 的 Head checkout。
+          allow-unsafe-pr-checkout: true
 
       - name: 设置 Node.js 环境
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 问题

仓库默认分支是 `release_humming_bird`。GitHub 的 `pull_request_target` 会从默认分支加载 workflow，因此此前仅合入 `master` 的 #8428 未被实际运行加载。

PR #8424 在 #8428 合入后触发的新 run 仍执行了默认分支上的旧安全脚本，并以 `allow-unsafe-pr-checkout: false` 拒绝可信 fork PR 的 Head checkout。

## 修改

- 在默认分支的 CodeBuddy workflow 中，通过 Collaborator Permission API 校验 PR 作者的真实仓库权限。
- 同时校验本次事件触发者；只有两者均为 `admin` 或 `write` 时才运行自动审查，查询失败时按不可信处理。
- 门禁通过后设置 `allow-unsafe-pr-checkout: true`，恢复可信 fork PR 的 Head checkout。
- 保留 `release_humming_bird` 现有 CodeBuddy 审查主体，不引入 `master` 专属的 `.ai/rules` 依赖。

## 影响

- 外部贡献者、只读用户或权限无法确认的用户继续被拒绝，不会执行携带仓库 Secret 的 CodeBuddy job。
- 具备写权限的可信 contributor 可以恢复完整的 PR diff、行内评论和总结审查流程。
- 只影响合入后新触发的 `pull_request_target` 事件，不会改写已有 Actions run。

## 验证

- `actionlint` 通过；checkout 新输入已由 actions/checkout 官方 `action.yml` 确认存在。
- 权限门禁用例通过：`admin + write` 放行，`read + write` 拒绝，`admin + none` 拒绝。
- 从 Node.js 设置到 CodeBuddy 审查结束的主体内容与目标分支原文件逐行一致。
- `git diff --check` 通过；仅修改 `.github/workflows/code_review.yml`。

## CI 说明

本 PR 自身仍会使用 `release_humming_bird` 上尚未修复的旧 workflow，因此“自动代码审查”可能继续以同一 checkout 错误失败。合入后需要为 #8424 触发一次新的 `synchronize`、`reopened` 或 `ready_for_review` 事件；直接重跑旧 run 不会加载新 workflow。
