### PR TITLE
refactor: 更新版本号至 3.34.15 --story=135713970

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -6,7 +6,7 @@ is_use_celery: True
 author: 蓝鲸智云
 introduction: 标准运维是通过一套成熟稳定的任务调度引擎，把在多系统间的工作整合到一个流程，助力运维实现跨系统调度自动化的SaaS应用。
 introduction_en: SOPS is a SaaS application that utilizes a set of mature and stable task scheduling engines to help realize cross-system scheduling automation, and integrates the work among multiple systems into a single process.
-version: 3.34.14
+version: 3.34.15
 category: 运维工具
 language_support: 中文
 desktop:

--- a/app_desc.yaml
+++ b/app_desc.yaml
@@ -1,5 +1,5 @@
 spec_version: 2
-app_version: "3.34.14"
+app_version: "3.34.15"
 app:
     region: default
     bk_app_code: bk_sops

--- a/config/default.py
+++ b/config/default.py
@@ -213,7 +213,7 @@ LOGGING = get_logging_config_dict(locals())
 # mako模板中：<script src="/a.js?v=${ STATIC_VERSION }"></script>
 # 如果静态资源修改了以后，上线前改这个版本号即可
 
-STATIC_VERSION = "3.34.14"
+STATIC_VERSION = "3.34.15"
 DEPLOY_DATETIME = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]


### PR DESCRIPTION
## 变更内容

将 `release_humming_bird` 的三个版本来源统一从 `3.34.14` 更新为 `3.34.15`：

- `app.yml`：PaaS 传统打包版本。
- `app_desc.yaml`：云原生应用版本。
- `config/default.py`：静态资源版本 `STATIC_VERSION`。

本次版本基于 #8435 合入后的最新 `release_humming_bird`。

## 影响

仅更新应用打包及静态资源版本，不涉及运行时逻辑变更。

## 验证

- `app.yml` 和 `app_desc.yaml` YAML 解析通过，版本均为 `3.34.15`。
- `config/default.py` AST 解析通过，`STATIC_VERSION` 为 `3.34.15`。
- Black、isort、Flake8 检查通过。
- `git diff --check upstream/release_humming_bird...HEAD` 通过。
- 最终 diff 仅包含上述三个版本文件，各修改一行。

关联 PR：#8435