### PR TITLE
fix: 修复插件表单协议相对地址拼接 --story=133649781

### DIFF
--- a/gcloud/plugin_gateway/services/native_forms.py
+++ b/gcloud/plugin_gateway/services/native_forms.py
@@ -20,7 +20,7 @@ def absolute_sops_url(value):
     if urlsplit(value).scheme:
         return value
 
-    return urljoin(settings.BK_SOPS_HOST.rstrip("/") + "/", value.lstrip("/"))
+    return urljoin(settings.BK_SOPS_HOST.rstrip("/") + "/", value)
 
 
 def _component_form(component_cls, form_attr, embedded_attr, key, base=None):

--- a/gcloud/tests/plugin_gateway/test_native_forms.py
+++ b/gcloud/tests/plugin_gateway/test_native_forms.py
@@ -49,6 +49,19 @@ class BuildComponentFormsTestCase(SimpleTestCase):
 
         self.assertEqual(build_component_forms(Component), {"input": None, "output": None})
 
+    def test_preserves_protocol_relative_component_form_host(self):
+        class Component:
+            code = "job_fast_execute_script"
+            form = "//open-plugin.example.com/static/components/job.js"
+            form_is_embedded = False
+
+        forms = build_component_forms(Component)
+
+        self.assertEqual(
+            forms["input"]["data"],
+            "https://open-plugin.example.com/static/components/job.js",
+        )
+
     def test_output_key_matches_real_component_output_script_registration(self):
         static_path = urlsplit(JobExecuteTaskComponent.output_form).path
         static_prefix = urlsplit(settings.STATIC_URL).path


### PR DESCRIPTION
## 问题

开放插件详情处理非内嵌表单 URL 时，会先移除全部前导 `/`。对于 `//host/path` 形式的协议相对地址，这会破坏其 host 语义，最终拼成 `BK_SOPS_HOST/host/path`，导致 BKFlow 无法加载内置插件原生表单。

## 修改

- URL 拼接时保留原始前导斜线，交由 `urljoin` 正确处理根路径、协议相对地址及完整 URL。
- 增加协议相对组件表单地址的回归测试。

## 兼容性

- 不修改插件详情协议、APIGW 资源或执行链路。
- 既有 `/static/...` 和完整 URL 行为保持不变。
- BKFlow 无需配套代码改动。

## 验证

- 新增用例在修复前按预期失败，修复后通过。
- `python manage.py test gcloud.tests.plugin_gateway -v 1`：122 passed。
- Black、isort、Flake8、diff 检查通过。