### PR TITLE
fix: 修复插件网关回调路由

### DIFF
--- a/docs/plans/2026-06-26-plugin-gateway-full-capability.md
+++ b/docs/plans/2026-06-26-plugin-gateway-full-capability.md
@@ -1060,7 +1060,7 @@ git commit -m "feat: 插件网关支持轮询型插件异步执行 --story=13364
 
 ### Task 7: 回调模式（内部回调入口 + callback 任务）
 
-> **风险标记（spec §2.4 / §11）**：回调型组件常用 `get_node_callback_url(root_pipeline_id, id, version)` 自行拼装回调地址，指向标准运维节点回调端点。运行壳没有引擎节点，需让该 run_id 的回调被路由到网关回调处理而非引擎。本任务交付网关侧回调入口与 `service.schedule(callback_data=...)` 闭环；「下游回调地址正确指向网关」这一路由缝隙在联调中确认；无法重定向回调的组件进 `do_not_open_list`。
+> **联调结论（2026-07-28）**：回调型组件继续使用 `get_node_callback_url(root_pipeline_id, id, version)` 生成带签名 token 的标准运维节点回调地址。节点回调入口在 token 中 `root_pipeline_id == node_id` 且命中 `PluginGatewayRun` 时，将请求转投 `open_plugin_callback`；普通引擎节点仍走原 `NodeCommandDispatcher`。callback 早于 dispatch 落 `WAITING_CALLBACK` 时由网关任务短暂重试，避免用未持久化的 `runtime_outputs` 提前执行 schedule。
 
 **Files:**
 - Modify: `gcloud/apigw/views/plugin_gateway.py`（新增内部回调入口）
@@ -1413,9 +1413,8 @@ git commit -m "test: 插件网关全量能力回归与修补 --story=133649781"
 - ✅ 独立 worker 队列、超时兜底、取消 best-effort、错误映射
 - ⏳ 已知限制（spec §11）：
   1. 运行壳上下文不完备的组件（强依赖全局密码变量 / 引擎节点状态 / 特殊 `parent_data`）需进黑名单
-  2. 回调型组件「回调地址指向网关」的路由缝隙待联调确认
-  3. 多版本插件不做进程级隔离
-  4. 用户级凭证透传/代理身份不在本期
+  2. 多版本插件不做进程级隔离
+  3. 用户级凭证透传/代理身份不在本期
 
 ---
 

--- a/gcloud/plugin_gateway/tasks.py
+++ b/gcloud/plugin_gateway/tasks.py
@@ -25,6 +25,9 @@ from gcloud.plugin_gateway.services.runner import PluginGatewayRunner
 
 logger = logging.getLogger("celery")
 
+CALLBACK_READY_RETRY_INTERVAL_SECONDS = 1
+CALLBACK_READY_MAX_RETRY_TIMES = 30
+
 
 @task(queue="open_plugin_polling")
 def sweep_expired_plugin_gateway_runs():
@@ -210,7 +213,7 @@ def poll_plugin_gateway_run(open_plugin_run_id):
 
 
 @task(queue="open_plugin_callback")
-def callback_plugin_gateway_run(open_plugin_run_id, callback_data=None):
+def callback_plugin_gateway_run(open_plugin_run_id, callback_data=None, ready_retry_times=0):
     try:
         run = PluginGatewayRun.objects.get(open_plugin_run_id=open_plugin_run_id)
     except PluginGatewayRun.DoesNotExist:
@@ -219,6 +222,32 @@ def callback_plugin_gateway_run(open_plugin_run_id, callback_data=None):
 
     if run.run_status in PluginGatewayRun.Status.TERMINAL:
         logger.info("[plugin_gateway] callback task skipped for terminal run(%s)", open_plugin_run_id)
+        return
+
+    if run.run_status != PluginGatewayRun.Status.WAITING_CALLBACK:
+        if ready_retry_times >= CALLBACK_READY_MAX_RETRY_TIMES:
+            logger.warning(
+                "[plugin_gateway] callback task stops waiting for run(%s), current=%s retry=%s",
+                open_plugin_run_id,
+                run.run_status,
+                ready_retry_times,
+            )
+            return
+        logger.info(
+            "[plugin_gateway] callback task waits for run(%s) to enter callback state, current=%s retry=%s",
+            open_plugin_run_id,
+            run.run_status,
+            ready_retry_times,
+        )
+        callback_plugin_gateway_run.apply_async(
+            kwargs={
+                "open_plugin_run_id": open_plugin_run_id,
+                "callback_data": callback_data,
+                "ready_retry_times": ready_retry_times + 1,
+            },
+            countdown=CALLBACK_READY_RETRY_INTERVAL_SECONDS,
+            queue="open_plugin_callback",
+        )
         return
 
     try:

--- a/gcloud/taskflow3/apis/django/v4/node_callback.py
+++ b/gcloud/taskflow3/apis/django/v4/node_callback.py
@@ -25,6 +25,8 @@ from django.views.decorators.http import require_POST
 
 import env
 from gcloud.core.trace import CallFrom, start_trace
+from gcloud.plugin_gateway.models import PluginGatewayRun
+from gcloud.plugin_gateway.tasks import callback_plugin_gateway_run
 from gcloud.taskflow3.celery.tasks import async_node_callback_retry, is_schedule_not_found_error, is_sleep_process_error
 from gcloud.taskflow3.domains.dispatchers import NodeCommandDispatcher
 from gcloud.taskflow3.models import TaskFlowInstance
@@ -66,6 +68,18 @@ def node_callback(request, token):
         message = _(f"节点回调失败: 无效的请求, 请重试. 如持续失败可联系管理员处理. {traceback.format_exc()} | node_callback")
         logger.error(message)
         return JsonResponse({"result": False, "message": message}, status=400)
+
+    if (
+        root_pipeline_id
+        and root_pipeline_id == node_id
+        and PluginGatewayRun.objects.filter(open_plugin_run_id=root_pipeline_id).exists()
+    ):
+        logger.info("[node_callback] route plugin gateway callback run=%s", root_pipeline_id)
+        callback_plugin_gateway_run.apply_async(
+            kwargs={"open_plugin_run_id": root_pipeline_id, "callback_data": callback_data},
+            queue="open_plugin_callback",
+        )
+        return JsonResponse({"result": True, "message": "success"})
 
     taskflow_id = None
     project_id = None

--- a/gcloud/tests/plugin_gateway/test_callback_routing.py
+++ b/gcloud/tests/plugin_gateway/test_callback_routing.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from unittest.mock import patch
+
+from cryptography.fernet import Fernet
+from django.conf import settings
+from django.test import RequestFactory, TestCase
+
+from gcloud.plugin_gateway.models import PluginGatewayRun
+from gcloud.taskflow3.apis.django.v4.node_callback import node_callback
+from gcloud.utils import crypto
+from pipeline_plugins.components.utils.sites.open.utils import get_node_callback_url
+
+
+class PluginGatewayCallbackRoutingTestCase(TestCase):
+    def setUp(self):
+        self.run = PluginGatewayRun.objects.create(
+            source_key="bkflow",
+            plugin_id="danny-test-plugi",
+            plugin_version="1.0.2",
+            client_request_id="task-1-node-1",
+            open_plugin_run_id="36c446392af844909adc447d4a2717b5",
+            callback_url="https://bkflow.example.com/callback",
+            callback_token=crypto.encrypt("callback-token"),
+            run_status=PluginGatewayRun.Status.WAITING_CALLBACK,
+            caller_app_code="bkflow",
+            trigger_payload={},
+        )
+        self.callback_data = {"state": "SUCCESS"}
+
+    def _callback_token(self):
+        callback_url = get_node_callback_url(
+            root_pipeline_id=self.run.open_plugin_run_id,
+            node_id=self.run.open_plugin_run_id,
+            node_version=self.run.plugin_version,
+        )
+        return callback_url.rstrip("/").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _engine_callback_token():
+        return Fernet(settings.CALLBACK_KEY).encrypt(b"root-id:2:node-id:node-version").decode()
+
+    @patch("gcloud.taskflow3.apis.django.v4.node_callback.NodeCommandDispatcher")
+    @patch("gcloud.plugin_gateway.tasks.callback_plugin_gateway_run.apply_async")
+    def test_plugin_gateway_run_callback_routes_to_gateway_task(
+        self, mock_callback_apply_async, mock_node_command_dispatcher
+    ):
+        mock_node_command_dispatcher.return_value.dispatch.return_value = {
+            "result": True,
+            "message": "success",
+        }
+        request = RequestFactory().post(
+            "/",
+            data=json.dumps(self.callback_data),
+            content_type="application/json",
+        )
+
+        response = node_callback(request, self._callback_token())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {"result": True, "message": "success"})
+        mock_callback_apply_async.assert_called_once_with(
+            kwargs={
+                "open_plugin_run_id": self.run.open_plugin_run_id,
+                "callback_data": self.callback_data,
+            },
+            queue="open_plugin_callback",
+        )
+        mock_node_command_dispatcher.assert_not_called()
+
+    @patch("gcloud.taskflow3.apis.django.v4.node_callback.NodeCommandDispatcher")
+    @patch("gcloud.plugin_gateway.tasks.callback_plugin_gateway_run.apply_async")
+    def test_normal_node_callback_still_routes_to_engine(self, mock_callback_apply_async, mock_node_command_dispatcher):
+        mock_node_command_dispatcher.return_value.dispatch.return_value = {
+            "result": True,
+            "message": "success",
+        }
+        request = RequestFactory().post(
+            "/",
+            data=json.dumps(self.callback_data),
+            content_type="application/json",
+        )
+
+        response = node_callback(request, self._engine_callback_token())
+
+        self.assertEqual(response.status_code, 200)
+        mock_node_command_dispatcher.assert_called_once_with(
+            engine_ver=2,
+            node_id="node-id",
+            taskflow_id=None,
+        )
+        mock_node_command_dispatcher.return_value.dispatch.assert_called_once_with(
+            command="callback",
+            operator="",
+            version="node-version",
+            data=self.callback_data,
+        )
+        mock_callback_apply_async.assert_not_called()

--- a/gcloud/tests/plugin_gateway/test_dispatch.py
+++ b/gcloud/tests/plugin_gateway/test_dispatch.py
@@ -291,3 +291,54 @@ class PluginGatewayDispatchTaskTestCase(TestCase):
             run_status=PluginGatewayRun.Status.SUCCEEDED,
             outputs={"result": 9},
         )
+
+    @patch("gcloud.plugin_gateway.tasks.callback_plugin_gateway_run.apply_async")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayRunner.run_schedule")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayContextService.resolve_run_context")
+    def test_callback_task_waits_for_dispatch_to_persist_callback_state(
+        self, mock_resolve_context, mock_run_schedule, mock_callback_apply_async
+    ):
+        run = self._create_run(run_status=PluginGatewayRun.Status.RUNNING)
+        callback_data = {"result": "ok"}
+
+        callback_plugin_gateway_run(
+            open_plugin_run_id=run.open_plugin_run_id,
+            callback_data=callback_data,
+            ready_retry_times=2,
+        )
+
+        mock_resolve_context.assert_not_called()
+        mock_run_schedule.assert_not_called()
+        mock_callback_apply_async.assert_called_once_with(
+            kwargs={
+                "open_plugin_run_id": run.open_plugin_run_id,
+                "callback_data": callback_data,
+                "ready_retry_times": 3,
+            },
+            countdown=1,
+            queue="open_plugin_callback",
+        )
+
+    @patch("gcloud.plugin_gateway.tasks.callback_plugin_gateway_run.apply_async")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayCallbackService.callback_run")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayRunner.run_schedule")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayContextService.resolve_run_context")
+    def test_callback_task_stops_waiting_after_ready_retry_limit(
+        self,
+        mock_resolve_context,
+        mock_run_schedule,
+        mock_callback_run,
+        mock_callback_apply_async,
+    ):
+        run = self._create_run(run_status=PluginGatewayRun.Status.RUNNING)
+
+        callback_plugin_gateway_run(
+            open_plugin_run_id=run.open_plugin_run_id,
+            callback_data={"result": "ok"},
+            ready_retry_times=30,
+        )
+
+        mock_resolve_context.assert_not_called()
+        mock_run_schedule.assert_not_called()
+        mock_callback_run.assert_not_called()
+        mock_callback_apply_async.assert_not_called()


### PR DESCRIPTION
## 问题

Plugin Gateway 运行壳将 `service.id` 与 `root_pipeline_id` 设置为网关 run id。回调型组件继续通过 `get_node_callback_url()` 生成标准节点回调地址，回调到达后被原有 `NodeCommandDispatcher` 当作引擎节点处理，因不存在对应 sleep process 而失败。

## 修改

- 在现有节点回调入口识别 `root_pipeline_id == node_id` 且命中 `PluginGatewayRun` 的请求，转投 `open_plugin_callback` 队列
- 普通引擎节点回调保持原有 `NodeCommandDispatcher` 路径
- callback 早于 dispatch 持久化 `WAITING_CALLBACK/runtime_outputs` 时短暂重试，避免提前执行 schedule
- 补充网关回调分流、普通节点兼容及抢跑保护测试
- 回写插件网关实施计划中的联调结论

## 验证

- `python manage.py test gcloud.tests.plugin_gateway pipeline_plugins.tests.utils.sites.open.test_utils --keepdb -v 1`：127 tests passed
- pre-commit `black` / `isort` / `flake8`：passed
- `git diff --check`：passed

无需数据库迁移或新增配置。Stage 发布时需要同时更新承接节点回调的 Web/Callback Server 模块与消费 `open_plugin_callback` 的插件网关 worker。

Story: 133649781