### PR TITLE
fix: 诊断扫描开关默认关闭，与其余诊断开关保持一致 --bug=1010131351157180998

### DIFF
--- a/docs/zh_hans/ops/stuck_governance_phase2_operation.md
+++ b/docs/zh_hans/ops/stuck_governance_phase2_operation.md
@@ -69,11 +69,11 @@ M1 只做“检测立案”，只读为主、执行热路径不变。按下述�
 **Step 0 前置（已就绪）**
 
 - [ ] `requirements.txt` 已指向 `bamboo-pipeline==3.24.13`。
-- [ ] 默认安全配置：`SCAN` 开、`EVENT`/`ALERT`/`APPLY` 关（见下方 env 速查）。
+- [ ] 默认安全配置：`SCAN`/`EVENT`/`ALERT`/`APPLY` 全关（见下方 env 速查）。
 
 **Step 1 休眠部署（先关扫描，验证启动/迁移）**
 
-- [ ] 部署前设 `BKAPP_DIAGNOSTICS_SCAN_ENABLED=0`，其余保持默认关。
+- [ ] 保持默认即可（四个开关默认均为 `0`），无需额外设置环境变量。
 - [ ] 部署 → 确认 `migrate` 正常新建 3 张 `pipeline_diagnostics_*` 表（纯 `CREATE TABLE`，不动存量表）。
 - [ ] 确认 web / celery worker / beat 正常启动，无 `pipeline.contrib.diagnostics` import 报错（app 为条件注册）。
 - [ ] 确认引擎执行热路径行为不变（`EVENT` 关，2.6.5 钩子处于“装好但睡眠”态）。
@@ -103,7 +103,7 @@ M1 只做“检测立案”，只读为主、执行热路径不变。按下述�
 
 | 环境变量 | 默认 | 作用 |
 | --- | --- | --- |
-| `BKAPP_DIAGNOSTICS_SCAN_ENABLED` | `1` | Layer0 周期扫描（检测立案） |
+| `BKAPP_DIAGNOSTICS_SCAN_ENABLED` | `0` | Layer0 周期扫描（检测立案） |
 | `BKAPP_DIAGNOSTICS_EVENT_ENABLED` | `0` | 引擎热路径事件采集 |
 | `BKAPP_DIAGNOSTICS_ALERT_ENABLED` | `0` | 告警 |
 | `BKAPP_DIAGNOSTICS_APPLY_ENABLED` | `0` | 写 / 恢复操作（dry-run 之外） |

--- a/env.py
+++ b/env.py
@@ -110,11 +110,12 @@ ARCHIVE_EXPIRED_V2_TASK_CRON = tuple(os.getenv("BKAPP_ARCHIVE_EXPIRED_V2_TASK_CR
 ARCHIVE_EXPIRED_V2_TASK_BATCH_NUM = int(os.getenv("BKAPP_ARCHIVE_EXPIRED_V2_TASK_BATCH_NUM", 100))
 
 # 流程卡住治理（诊断检测打底 M1）
-# 诊断能力随 bamboo-pipeline>=3.24.12 提供；下列开关默认低风险打底：
-# 只跑周期扫描检测（SCAN），关热点路径事件写（EVENT）、告警（ALERT）与写操作（APPLY）。
+# 诊断能力随 bamboo-pipeline>=3.24.12 提供；下列开关默认全关，需按运维 checklist 显式开启。
+# SCAN 默认关的原因：Layer0 分组查询（WHERE dead=0 GROUP BY root_pipeline_id）在大 eri_process
+# 表上开销不可忽略；且长等待节点（人工确认 / 长作业）心跳同样停摆，会被判为停滞产生噪音病历。
 # EVENT 与 SCAN 是两个独立开关：仅关 SCAN 不足以关热点路径事件写，务必同时关 EVENT。
 _DIAG_TRUE = ("1", "true", "yes", "on")
-DIAGNOSTICS_SCAN_ENABLED = os.getenv("BKAPP_DIAGNOSTICS_SCAN_ENABLED", "1").lower() in _DIAG_TRUE
+DIAGNOSTICS_SCAN_ENABLED = os.getenv("BKAPP_DIAGNOSTICS_SCAN_ENABLED", "0").lower() in _DIAG_TRUE
 DIAGNOSTICS_EVENT_ENABLED = os.getenv("BKAPP_DIAGNOSTICS_EVENT_ENABLED", "0").lower() in _DIAG_TRUE
 DIAGNOSTICS_ALERT_ENABLED = os.getenv("BKAPP_DIAGNOSTICS_ALERT_ENABLED", "0").lower() in _DIAG_TRUE
 DIAGNOSTICS_APPLY_ENABLED = os.getenv("BKAPP_DIAGNOSTICS_APPLY_ENABLED", "0").lower() in _DIAG_TRUE

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,8 +29,8 @@ django-filter==2.4.0
 prometheus-client==0.9.0
 # 流程卡住治理 M1：诊断检测能力随 bamboo-pipeline 3.24.13 正式发布
 # (基于 3.24.11，不含 3.24.12 的 mako 加固；依赖 bamboo-engine 2.6.5，含 engine.py 热路径钩子)。
-# 升级后 pipeline.contrib.diagnostics 条件注册生效、周期扫描自动激活；
-# 默认 SCAN 开、EVENT/ALERT/APPLY 关(只读检测，低风险)。
+# 升级后 pipeline.contrib.diagnostics 条件注册生效；
+# SCAN/EVENT/ALERT/APPLY 默认全关，需按运维 checklist 显式开启。
 bamboo-pipeline==3.24.13
 drf-yasg==1.20.0
 typing-extensions==3.7.4.3


### PR DESCRIPTION
## 背景

`bamboo-pipeline==3.24.13` 合入后，`pipeline.contrib.diagnostics` 已条件注册生效，四个诊断开关的默认值当前**即时生效**。但其中 `BKAPP_DIAGNOSTICS_SCAN_ENABLED` 默认为 `1`（开），与其余三个（`EVENT`/`ALERT`/`APPLY` 默认 `0`）以及本方案一贯强调的「默认全关、装了不开 = no-op」原则不一致。

运维 runbook 自身也要求「部署前设 `BKAPP_DIAGNOSTICS_SCAN_ENABLED=0`」——既然默认部署就需要手工关掉，不如让代码默认即为关闭，避免依赖运维记得设置环境变量。

## 为什么 SCAN 不宜默认开

1. **DB 开销**：Layer0 候选查询是 `WHERE dead=0 GROUP BY root_pipeline_id HAVING MAX(last_heartbeat) < cutoff`，`HAVING` 在聚合后过滤，索引无法提前裁剪，每轮（默认 `*/10 * * * *`）都要对全部存活进程做分组 + filesort。`eri_process` 目前也没有 `(dead, root_pipeline_id, last_heartbeat)` 复合索引。
2. **误报噪音**：`last_heartbeat` 仅在引擎推进进程时续期，**任何合法长等待**（人工确认节点等审批、长时间作业等回调、暂停流程）心跳同样停摆，超过默认 1 小时阈值后硬规则均不命中，会落到兜底 `stalled_no_progress` 产生噪音病历。

## 改动

- `env.py`：`BKAPP_DIAGNOSTICS_SCAN_ENABLED` 默认 `"1"` → `"0"`；注释同步为「默认全关」并补充默认关的原因。
- `requirements.txt`：去掉「周期扫描自动激活 / 默认 SCAN 开」的描述。
- `docs/zh_hans/ops/stuck_governance_phase2_operation.md`：Step 0 默认说明、Step 1 部署步骤（不再需要手动设 `=0`）、env 速查表默认值同步为 `0`。

## 影响

- 无行为破坏：仅改变默认值。已显式设置 `BKAPP_DIAGNOSTICS_SCAN_ENABLED=1` 的环境不受影响。
- 需要启用时，按 runbook Step 2 显式设 `=1`，并可先将 `BKAPP_DIAGNOSTICS_SCAN_CRON` 调保守（如 `*/30 * * * *`）。
- 已确认无测试断言旧默认值；相关周期任务测试是 mock `scan_stalled_roots`，不受影响。

## 后续建议（不在本 PR 范围）

真正开启 SCAN 之前，建议先：
- 为 `eri_process` 补 `(dead, root_pipeline_id, last_heartbeat)` 复合索引；
- 修复规则对「终态 / asleep 合法长等待」的区分，降低 `stalled_no_progress` 噪音。

Made with [Cursor](https://cursor.com)