### PR TITLE
fix: 锁定 mistune==0.8.4 修复版本日志页面渲染失败 --bug=161525841

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,9 @@ bk-monitor-report==1.2.2
 
 # version log
 django-versionlog==1.8.1
+# django-versionlog 1.8.1 只声明 mistune>=0.8.4，但其渲染逻辑仍调用 0.8.x 的
+# mistune.Markdown(hard_wrap=True)，装到 2.x/3.x 会导致版本日志页面报 TypeError。
+mistune==0.8.4
 
 # iam sdk
 bk-iam==1.3.6


### PR DESCRIPTION
hb 分支的版本日志页面当前无法渲染，本 PR 从依赖侧锁定 mistune 修复。属既存缺陷，与 #8444 的 master 同步无关。

## 现象

访问版本日志页面（`version_log/`）时渲染失败：

```
TypeError: Markdown.__init__() got an unexpected keyword argument 'hard_wrap'
```

## 根因

master 使用的 `django-versionlog==1.6.0` 在 `setup.py` 中精确锁定 `mistune==0.8.4`。hb 升级到 `1.8.1` 后，依赖声明放宽为 `mistune>=0.8.4`，但库的渲染逻辑仍在调用 0.8.x 才有的签名：

```python
# version_log/utils.py:130
parser = mistune.Markdown(hard_wrap=True)
```

mistune 2.x/3.x 已移除 `hard_wrap` 参数。而 hb 的 `requirements.txt` 未声明 mistune，整个依赖树中唯一的约束就是 django-versionlog 自己的 `mistune>=0.8.4`，因此全新安装会解析到 mistune 3.3.4，触发上述报错。

## 为什么锁依赖而不是升级 django-versionlog

`django-versionlog` 当前最新版本仍是 1.8.1（可用版本：1.3.0 ~ 1.8.1），没有修复该问题的新版本，因此只能从依赖侧锁定。

## 验证

在按 hb `requirements.txt` 安装的 Python 3.11 环境中验证：

- 锁定前（mistune 3.3.4）：`version_log.utils.get_parsed_html("V3.34.0")` 抛 `TypeError`
- 锁定后（mistune 0.8.4）：`V3.34.0`、`V3.32.12`、`V3.32.11`、`V3.31.0` 以及英文日志 `V3.34.0(en)` 全部渲染正常
- `pip check` 输出 `No broken requirements found`，无依赖冲突
- mistune 0.8.4 为纯 Python 包，在 Python 3.11 下正常工作

## 影响面

修复前所有版本日志均无法展示（含既有的 V3.34.0 与英文日志），且 `LATEST_VERSION_INFORM=True` 的新版本弹窗同样受影响。

相关：#8447 补充了 V3.34.17 版本日志，需要本 PR 合入后才能正常展示。

Made with [Cursor](https://cursor.com)