### PR TITLE
chore: 依赖升级至 bamboo-pipeline 3.24.14 --bug=1010131351157180998

### DIFF
--- a/docs/zh_hans/ops/stuck_governance_phase2_operation.md
+++ b/docs/zh_hans/ops/stuck_governance_phase2_operation.md
@@ -57,8 +57,9 @@
 
 ## 发布检查
 
-- 已发布版本：`bamboo-pipeline==3.24.13`（依赖 `bamboo-engine==2.6.5`，含 `engine.py` 热路径钩子），均已在 PyPI。
-- 标准运维 `requirements.txt` 已指向 `bamboo-pipeline==3.24.13`；装此一个包即拉齐 runtime 诊断 + core 钩子，不要指向未发布的未来版本。
+- 已发布版本：`bamboo-pipeline==3.24.14`（依赖 `bamboo-engine==2.6.5`，含 `engine.py` 热路径钩子），均已在 PyPI。
+- 标准运维 `requirements.txt` 已指向 `bamboo-pipeline==3.24.14`；装此一个包即拉齐 runtime 诊断 + core 钩子，不要指向未发布的未来版本。
+- 3.24.14 相对 3.24.13 的增量：`child_process_finish` 重复 ACK 幂等修复；M2 可靠事件 `pipeline.contrib.reliable_events` 随包提供但未注册进 `INSTALLED_APPS`，不建表不生效，M1 灰度不受影响。
 - 发布后先在 stage 验证 `/admin/diagnostics/task/`、`/admin/diagnostics/cases/` 页面、证据包导出命令和 dry-run 操作。
 - 观察 `[pipeline_diagnostics_alert]` 与 `[bk_sops_task_diagnostic_alert]` 日志是否符合预期。
 
@@ -68,7 +69,7 @@ M1 只做“检测立案”，只读为主、执行热路径不变。按下述�
 
 **Step 0 前置（已就绪）**
 
-- [ ] `requirements.txt` 已指向 `bamboo-pipeline==3.24.13`。
+- [ ] `requirements.txt` 已指向 `bamboo-pipeline==3.24.14`。
 - [ ] 默认安全配置：`SCAN`/`EVENT`/`ALERT`/`APPLY` 全关（见下方 env 速查）。
 
 **Step 1 休眠部署（先关扫描，验证启动/迁移）**

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,10 @@ prometheus-client==0.9.0
 # (基于 3.24.11，不含 3.24.12 的 mako 加固；依赖 bamboo-engine 2.6.5，含 engine.py 热路径钩子)。
 # 升级后 pipeline.contrib.diagnostics 条件注册生效；
 # SCAN/EVENT/ALERT/APPLY 默认全关，需按运维 checklist 显式开启。
-bamboo-pipeline==3.24.13
+# 3.24.14 增量：child_process_finish 对重复 ACK 幂等（修复子流程 ACK 重放导致的父流程异常）；
+# M2 可靠事件 pipeline.contrib.reliable_events 随包提供但未注册进 INSTALLED_APPS，
+# 本次升级下不建表、不生效，待 M2 Part B 显式接入。
+bamboo-pipeline==3.24.14
 drf-yasg==1.20.0
 typing-extensions==3.7.4.3
 pyyaml==5.4.1


### PR DESCRIPTION
## 变更内容

`requirements.txt`：`bamboo-pipeline` 3.24.13 → **3.24.14**（已发布至 PyPI，依赖 `bamboo-engine==2.6.5` 不变）。
同步更新运维 runbook `docs/zh_hans/ops/stuck_governance_phase2_operation.md` 中的版本引用。

## 3.24.14 相对 3.24.13 的增量

| 上游 PR | 内容 | 对标准运维的影响 |
| --- | --- | --- |
| [#276](https://github.com/TencentBlueKing/bamboo-engine/pull/276) | `child_process_finish` 对重复 ACK 幂等 | **本次升级的实际收益**：修复子流程 ACK 重放导致的父流程异常 |
| [#272](https://github.com/TencentBlueKing/bamboo-engine/pull/272) | M2 可靠事件影子模式（新增 `pipeline.contrib.reliable_events`） | 惰性，见下 |
| [#273](https://github.com/TencentBlueKing/bamboo-engine/pull/273) | M2 callback ACTIVE 兜底接管 | 惰性，见下 |

引擎核心 `bamboo_engine/` 自 3.24.13 以来零改动，故 core 仍为 2.6.5，装此一个包即可。

## 为什么是低风险

- **M2 代码完全惰性**：`pipeline.contrib.reliable_events` 未注册进 `INSTALLED_APPS`（`config/default.py` 只对 `pipeline.contrib.diagnostics` 做了条件注册），因此**不建表、不产生迁移、不注册周期任务**。其采集入口另有 `PIPELINE_RELIABLE_EVENTS_SHADOW_ENABLED` 开关（默认关）且为 fail-safe（异常吞掉不影响回调主链路）。M2 Part B 会显式接入。
- **M1 诊断行为不变**：`SCAN`/`EVENT`/`ALERT`/`APPLY` 四个开关默认仍全关。
- **无 DB 迁移**：本次升级不新增任何表。

## 回滚

`requirements.txt` pin 回 `bamboo-pipeline==3.24.13` 即可，无残留状态。

## 关联

- 设计与灰度 checklist：`docs/zh_hans/ops/stuck_governance_phase2_operation.md`
- TAPD：`--bug=1010131351157180998`

Made with [Cursor](https://cursor.com)