### PR TITLE
feat: 诊断控制台列表补充执行开始时间并默认隐藏失败等人工(FAILED停靠) --bug=1010131351157180998

### DIFF
--- a/gcloud/contrib/admin/diagnostics/task_mapping.py
+++ b/gcloud/contrib/admin/diagnostics/task_mapping.py
@@ -39,6 +39,7 @@ def _summarize_task(task):
         "template_id": task.template_id,
         "executor": pi.executor,
         "create_time": _format_dt(pi.create_time),
+        "start_time": _format_dt(pi.start_time),
         "task_url": _task_url(project_id, task.id) if project_id is not None else "",
     }
 

--- a/gcloud/contrib/admin/templates/diagnostics/cases.html
+++ b/gcloud/contrib/admin/templates/diagnostics/cases.html
@@ -50,6 +50,9 @@
       <option value="critical">严重</option>
     </select>
     <input id="f-root_pipeline_id" placeholder="root_pipeline_id">
+    <label class="muted" style="display:flex;align-items:center;gap:4px">
+      <input type="checkbox" id="f-include_failed_parked" onchange="loadList(1)"> 显示失败等人工(FAILED停靠)
+    </label>
     <button class="primary" onclick="loadList(1)">查询</button>
     <span id="total" class="muted"></span>
   </div>
@@ -57,7 +60,7 @@
   <table>
     <thead>
       <tr>
-        <th>任务</th><th>业务</th><th>模板</th><th>stuck_type</th><th>级别</th>
+        <th>任务</th><th>业务</th><th>模板</th><th>执行开始时间</th><th>stuck_type</th><th>级别</th>
         <th>状态</th><th>卡住时长(s)</th><th>命中</th><th>最近出现</th><th>操作</th>
       </tr>
     </thead>
@@ -98,6 +101,7 @@
       var v = document.getElementById('f-' + k).value.trim();
       if (v) params.set(k, v);
     });
+    if (document.getElementById('f-include_failed_parked').checked) params.set('include_failed_parked', '1');
     fetch(SITE_URL + 'admin/diagnostics/cases/?' + params.toString(), { credentials: 'same-origin' })
       .then(function (r) { return r.json(); })
       .then(function (body) {
@@ -105,7 +109,9 @@
         state.page = body.data.page;
         state.total = body.data.total;
         renderList(body.data.items);
-        document.getElementById('total').textContent = '共 ' + body.data.total + ' 条';
+        var hidden = body.data.hidden_failed_parked || 0;
+        document.getElementById('total').textContent =
+          '共 ' + body.data.total + ' 条' + (hidden ? ' (已隐藏 ' + hidden + ' 条失败等人工)' : '');
         document.getElementById('page-info').textContent = '第 ' + state.page + ' 页';
       });
   }
@@ -118,10 +124,12 @@
         : '<span class="muted">' + esc(it.root_pipeline_id) + '</span>';
       var bizCell = task ? esc(task.project_name || task.project_id || '') : '';
       var tplCell = task ? esc(task.template_id || '') : '';
+      var startCell = task ? esc(task.start_time || '') : '';
       return '<tr>' +
         '<td>' + taskCell + '</td>' +
         '<td>' + bizCell + '</td>' +
         '<td>' + tplCell + '</td>' +
+        '<td>' + startCell + '</td>' +
         '<td>' + esc(it.stuck_type) + '</td>' +
         '<td>' + sevTag(it.severity) + '</td>' +
         '<td>' + esc(it.status) + '</td>' +
@@ -131,7 +139,7 @@
         '<td class="row-actions"><button onclick="openDetail(' + it.id + ')">详情</button></td>' +
         '</tr>';
     });
-    document.getElementById('tbody').innerHTML = rows.join('') || '<tr><td colspan="10" class="muted">无数据</td></tr>';
+    document.getElementById('tbody').innerHTML = rows.join('') || '<tr><td colspan="11" class="muted">无数据</td></tr>';
   }
 
   function openDetail(caseId) {
@@ -148,7 +156,8 @@
     var task = d.task;
     var taskLine = task
       ? '<a href="' + esc(task.task_url) + '" target="_blank">' + esc(task.task_name || task.task_id) + '</a> '
-        + '(业务: ' + esc(task.project_name || '') + ' · 执行人: ' + esc(task.executor || '') + ')'
+        + '(业务: ' + esc(task.project_name || '') + ' · 执行人: ' + esc(task.executor || '')
+        + ' · 执行开始时间: ' + esc(task.start_time || '-') + ')'
       : '<span class="muted">未关联到任务, root_pipeline_id=' + esc(d.root_pipeline_id) + '</span>';
     var audits = (d.audit_history || []).map(function (a) {
       return '<li>' + esc(a.created_at) + ' · ' + esc(a.operation_type) + ' · ' + esc(a.operator)

--- a/gcloud/contrib/admin/views/diagnostics.py
+++ b/gcloud/contrib/admin/views/diagnostics.py
@@ -23,6 +23,17 @@ from gcloud.iam_auth.view_interceptors.admin import AdminEditViewInterceptor, Ad
 
 _CASE_FILTER_FIELDS = ("status", "stuck_type", "severity", "root_pipeline_id", "node_id")
 
+# 节点执行失败后，引擎会把进程正常 sleep（asleep=True/dead=False），停在 FAILED 节点等待人工重试/跳过。
+# 这是设计内的失败态，并非引擎卡死（见 bamboo_engine handler._execute_fail -> should_sleep）。
+# 因此默认从“卡住”视图排除这类，避免淹没真实结构性问题。引擎侧根治（rules/scanner 区分终态+asleep）
+# 留待 M2 随包发布。evidence 为 JSONTextField（DB 不可按子字段过滤），故用可查询的 message 文案精确匹配。
+_FAILED_PARKED_STUCK_TYPE = "process_alive_but_terminal_state"
+_FAILED_PARKED_MESSAGE_MARK = "terminal state FAILED"
+
+
+def _failed_parked_qs(qs):
+    return qs.filter(stuck_type=_FAILED_PARKED_STUCK_TYPE, message__contains=_FAILED_PARKED_MESSAGE_MARK)
+
 
 def _diagnostic_case_model():
     try:
@@ -154,6 +165,13 @@ def diagnostic_case_list(request):
         if value:
             qs = qs.filter(**{field: value})
 
+    # 默认排除“失败等人工(FAILED 停靠)”这类预期内失败态；显式按该 stuck_type 过滤或勾选开关时保留。
+    include_failed_parked = request.GET.get("include_failed_parked") in ("1", "true", "True")
+    hidden_failed_parked = 0
+    if not include_failed_parked and request.GET.get("stuck_type") != _FAILED_PARKED_STUCK_TYPE:
+        hidden_failed_parked = _failed_parked_qs(qs).count()
+        qs = qs.exclude(stuck_type=_FAILED_PARKED_STUCK_TYPE, message__contains=_FAILED_PARKED_MESSAGE_MARK)
+
     try:
         page_size = min(max(int(request.GET.get("page_size", 50)), 1), 200)
         page_index = max(int(request.GET.get("page", 1)), 1)
@@ -174,6 +192,7 @@ def diagnostic_case_list(request):
         "page": page_obj.number,
         "page_size": page_size,
         "items": items,
+        "hidden_failed_parked": hidden_failed_parked,
     }
     return JsonResponse({"result": True, "data": data})
 

--- a/gcloud/tests/contrib/admin/diagnostics/test_case_list_view.py
+++ b/gcloud/tests/contrib/admin/diagnostics/test_case_list_view.py
@@ -107,3 +107,70 @@ class DiagnosticCaseViewTest(TestCase):
         body = json.loads(resp.content)
         self.assertFalse(body["result"])
         self.assertEqual(body["message"], "case_id is required")
+
+
+@skipUnless(DIAGNOSTICS_AVAILABLE, "pipeline.contrib.diagnostics unavailable (requires bamboo-pipeline>=3.24.12)")
+class FailedParkedFilterTest(TestCase):
+    """节点失败等人工(FAILED 停靠)默认从'卡住'视图排除，开关/显式筛选可查看。"""
+
+    def setUp(self):
+        from pipeline.contrib.diagnostics.models import DiagnosticCase
+
+        self.model = DiagnosticCase
+        # 预期内失败态：应默认隐藏
+        DiagnosticCase.objects.create(
+            root_pipeline_id="root-failed",
+            node_id="nf",
+            stuck_type="process_alive_but_terminal_state",
+            severity=DiagnosticCase.SEVERITY_CRITICAL,
+            status=DiagnosticCase.STATUS_OPEN,
+            message="Process 1 is alive while node nf is in terminal state FAILED",
+        )
+        # 真异常：FINISHED 终态仍存活，不应被隐藏
+        DiagnosticCase.objects.create(
+            root_pipeline_id="root-finished",
+            node_id="ni",
+            stuck_type="process_alive_but_terminal_state",
+            severity=DiagnosticCase.SEVERITY_CRITICAL,
+            status=DiagnosticCase.STATUS_OPEN,
+            message="Process 2 is alive while node ni is in terminal state FINISHED",
+        )
+        # 其它类型不受影响
+        DiagnosticCase.objects.create(
+            root_pipeline_id="root-other",
+            node_id="no",
+            stuck_type="stalled_no_progress",
+            severity=DiagnosticCase.SEVERITY_WARNING,
+            status=DiagnosticCase.STATUS_OPEN,
+        )
+
+    def _list(self, **params):
+        from gcloud.contrib.admin.views import diagnostics
+
+        with mock.patch(_INTERCEPTOR):
+            resp = diagnostics.diagnostic_case_list(_superuser_request("/admin/diagnostics/cases/", **params))
+        return json.loads(resp.content)["data"]
+
+    def test_failed_parked_hidden_by_default(self):
+        data = self._list()
+        roots = {it["root_pipeline_id"] for it in data["items"]}
+        self.assertEqual(data["total"], 2)
+        self.assertEqual(data["hidden_failed_parked"], 1)
+        self.assertNotIn("root-failed", roots)
+        self.assertIn("root-finished", roots)
+        self.assertIn("root-other", roots)
+
+    def test_include_flag_shows_failed_parked(self):
+        data = self._list(include_failed_parked="1")
+        roots = {it["root_pipeline_id"] for it in data["items"]}
+        self.assertEqual(data["total"], 3)
+        self.assertEqual(data["hidden_failed_parked"], 0)
+        self.assertIn("root-failed", roots)
+
+    def test_explicit_stuck_type_filter_not_auto_excluded(self):
+        data = self._list(stuck_type="process_alive_but_terminal_state")
+        roots = {it["root_pipeline_id"] for it in data["items"]}
+        self.assertEqual(data["total"], 2)
+        self.assertEqual(data["hidden_failed_parked"], 0)
+        self.assertIn("root-failed", roots)
+        self.assertIn("root-finished", roots)

--- a/gcloud/tests/contrib/admin/diagnostics/test_task_mapping.py
+++ b/gcloud/tests/contrib/admin/diagnostics/test_task_mapping.py
@@ -15,6 +15,7 @@ def _fake_task(root_id, task_id, name, proj_id, proj_name, executor, template_id
     task.pipeline_instance.name = name
     task.pipeline_instance.executor = executor
     task.pipeline_instance.create_time = datetime(2026, 7, 23, 10, 0, 0)
+    task.pipeline_instance.start_time = datetime(2026, 7, 23, 10, 5, 0)
     task.project.id = proj_id
     task.project.name = proj_name
     return task
@@ -42,6 +43,8 @@ class ResolveTaskSummariesTest(TestCase):
         self.assertEqual(summary["project_name"], "业务X")
         self.assertEqual(summary["executor"], "neo")
         self.assertEqual(summary["template_id"], "55")
+        self.assertEqual(summary["create_time"], "2026-07-23 10:00:00")
+        self.assertEqual(summary["start_time"], "2026-07-23 10:05:00")
         self.assertEqual(summary["task_url"], "https://sops.example.com/taskflow/execute/7/?instance_id=101")
 
     def test_empty_input_returns_empty(self):


### PR DESCRIPTION
## 背景

M1 卡住流程治理控制台（[#8431](https://github.com/TencentBlueKing/bk-sops/pull/8431)）上 stage 后,实测检出结果里有相当比例是 `process_alive_but_terminal_state` 且 evidence 为 `FAILED`。

这类并不是引擎卡死:节点执行失败后引擎会把进程正常 sleep（`asleep=True` / `dead=False`）,停在 FAILED 节点等待人工重试或跳过（见 `bamboo_engine handler._execute_fail -> should_sleep`）。这是**设计内的失败态**,把它们混在"卡住"列表里会淹没真正的结构性问题。

同时列表缺少任务执行开始时间,判断一个 case 卡了多久时需要额外点进详情。

## 变更内容

**1. 列表补充执行开始时间**

`task_mapping._summarize_task` 增加 `start_time`（取 `PipelineInstance.start_time`）,前端表格新增"执行开始时间"列。

**2. 默认隐藏"失败等人工(FAILED 停靠)"**

- `diagnostic_case_list` 默认排除 `stuck_type=process_alive_but_terminal_state` 且 `message` 含 `terminal state FAILED` 的 case
- 响应新增 `hidden_failed_parked` 计数,前端在总数后展示"(已隐藏 N 条失败等人工)",不会让人误以为数据丢了
- 两条保留口子:显式按该 `stuck_type` 过滤时不排除;前端提供"显示失败等人工(FAILED停靠)"勾选框（对应 `include_failed_parked=1`）

## 实现说明

`evidence` 是 `JSONTextField`,DB 层无法按子字段过滤,因此用可查询的 `message` 文案精确匹配来识别这类 case。这是控制台侧的**临时归类**,不动引擎。

引擎侧根治（`rules` 区分终态 + `asleep`、scanner 不把失败停靠的 root 落到 stalled）留待 M2 随包发布,届时本处过滤可以退化为冗余保护。

## 影响面

纯 bk-sops 侧、超管专用页面,无 DB 迁移,不改引擎与执行热路径。

## 测试

`test_case_list_view.py` 新增 67 行覆盖:默认排除、`include_failed_parked=1` 保留、显式按 `stuck_type` 过滤时保留、`hidden_failed_parked` 计数正确;`test_task_mapping.py` 覆盖 `start_time` 映射。

## 关联

- 运维 runbook：`docs/zh_hans/ops/stuck_governance_phase2_operation.md`
- TAPD：`--bug=1010131351157180998`

Made with [Cursor](https://cursor.com)