### PR TITLE
fix: 隔离第三方插件目录元信息异常

### DIFF
--- a/gcloud/plugin_gateway/services/catalog.py
+++ b/gcloud/plugin_gateway/services/catalog.py
@@ -205,7 +205,7 @@ class PluginGatewayCatalogService:
 
         worker_count = min(cls.THIRD_PARTY_META_WORKERS, len(plugin_entries))
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
-            plugin_metas = executor.map(cls._get_plugin_meta, [plugin["code"] for plugin in plugin_entries])
+            plugin_metas = executor.map(cls._get_plugin_meta_safely, [plugin["code"] for plugin in plugin_entries])
 
         plugins = []
         for plugin, meta in zip(plugin_entries, plugin_metas):
@@ -381,6 +381,14 @@ class PluginGatewayCatalogService:
         if not result.get("result"):
             return None
         return result.get("data", {})
+
+    @staticmethod
+    def _get_plugin_meta_safely(plugin_code):
+        try:
+            return PluginGatewayCatalogService._get_plugin_meta(plugin_code)
+        except Exception:
+            logger.exception("[plugin_gateway] load third-party plugin meta failed plugin_code=%s", plugin_code)
+            return None
 
     @staticmethod
     @cached(

--- a/gcloud/tests/plugin_gateway/test_catalog.py
+++ b/gcloud/tests/plugin_gateway/test_catalog.py
@@ -621,6 +621,29 @@ class PluginGatewayCatalogServiceTestCase(TestCase):
 
         self.assertEqual([plugin["id"] for plugin in plugins], ["bk_plugin_demo_1", "bk_plugin_demo_2"])
 
+    @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._get_plugin_meta")
+    @patch("gcloud.plugin_gateway.services.catalog.PluginGatewayCatalogService._get_third_party_plugin_entries")
+    def test_list_third_party_plugins_skips_plugin_when_loading_meta_raises(
+        self, mock_get_plugin_entries, mock_get_plugin_meta
+    ):
+        mock_get_plugin_entries.return_value = [
+            {"code": "broken_plugin", "name": "Broken Plugin"},
+            {"code": "healthy_plugin", "name": "Healthy Plugin"},
+        ]
+
+        def load_meta(plugin_code):
+            if plugin_code == "broken_plugin":
+                raise ValueError("invalid metadata response")
+            return {"description": "remote plugin", "versions": ["1.0.0"]}
+
+        mock_get_plugin_meta.side_effect = load_meta
+
+        with self.assertLogs("root", level="ERROR") as captured_logs:
+            plugins = PluginGatewayCatalogService._list_third_party_plugins()
+
+        self.assertEqual([plugin["id"] for plugin in plugins], ["healthy_plugin"])
+        self.assertIn("broken_plugin", "\n".join(captured_logs.output))
+
     @patch("gcloud.plugin_gateway.services.catalog.PluginServiceApiClient")
     def test_get_third_party_plugin_entries_loads_all_pages(self, mock_client_cls):
         first_page = [


### PR DESCRIPTION
## 问题

正式环境独立 E2E 中，第三方插件目录在加载 1217 个插件时返回 500。诊断确认其中 `leishao-plugin` 的元数据接口返回 HTML，触发 JSON 解析异常；线程池结果迭代会将这个单插件异常抛给整个目录请求。

## 修复

- 为第三方插件目录的单插件元数据加载增加异常隔离
- 异常插件跳过展示，并记录包含 `plugin_code` 的完整异常日志
- 保持单插件详情接口原有异常行为不变
- 保持元数据并发加载、缓存和目录排序逻辑不变

## 测试

- `python manage.py test gcloud.tests.plugin_gateway.test_catalog -v 2`：27 个通过
- `python manage.py test gcloud.tests.plugin_gateway -v 2`：127 个通过
- Black、isort、Flake8：通过

## 发布后复验

重新请求正式环境第三方插件全量目录，确认正常插件可返回、异常插件被跳过且日志可定位，然后继续后续执行链路 E2E。