### PR TITLE
feat: 补齐一期操作审计上报 --story=136920805

### DIFF
--- a/docs/plans/2026-08-07-operation-audit-phase1.md
+++ b/docs/plans/2026-08-07-operation-audit-phase1.md
@@ -1,0 +1,670 @@
+# 标准运维操作审计一期补漏及 API Server 上报实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在不新增蓝鲸审计动作和资源的前提下，补齐标准运维页面与 API Server 的一期 P0 操作审计，并为 API Server 灰度配置 `BK_AUDIT_DATA_TOKEN` 做好代码与验证准备。
+
+**Architecture:** 保留 `bk_audit_add_event` 作为最终发送入口，在其上增加事务提交后发送、脱敏快照和统一动作映射。页面与 API Server 只在业务明确成功后调用统一入口；批量操作按实际成功实例逐条上报，没有准确资源映射的插件网关和包源接口继续延期。
+
+**Tech Stack:** Python 3、Django 3.2、Django REST Framework、pytest、`bk-audit` SDK、TAPD 需求 `136920805`。
+
+## Global Constraints
+
+- 设计依据：`docs/specs/2026-08-07-operation-audit-phase1-design.md`。
+- TAPD：[136920805 标准运维操作审计一期补漏及 API Server 上报](https://tapd.woa.com/10131351/prong/stories/view/1010131351136920805)。
+- 所有提交信息追加 `--story=136920805`。
+- 只使用现有 `project`、`flow`、`task`、`common_flow`、`mini_app`、`periodic_task`、`clocked_task` 七类资源及现有动作。
+- 业务失败、权限失败、参数失败、异步投递失败和事务回滚不得产生成功审计事件。
+- 修改事件只携带脱敏后的前后快照；不得记录密码、Token、密钥、变量值、流程树全文、插件输入输出和日志正文。
+- `BK_AUDIT_DATA_TOKEN`、`BK_AUDIT_ENDPOINT` 只由部署环境提供，仓库不写入默认值和真实密钥。
+- 不修改 API 请求参数、响应结构、HTTP 状态码和 APIGW schema。
+- `plugin_gateway_create_run`、`plugin_gateway_cancel_run`、包源管理/同步、流程市场标签及高频只读接口不在一期接入。
+- 当前 `master` 工作区包含用户未提交内容；执行时必须先用独立 worktree 从最新 `upstream/master` 创建功能分支，禁止把现有脏文件带入提交。
+
+---
+
+## 文件结构与职责
+
+**新增文件**
+
+- `gcloud/contrib/audit/mappings.py`：集中维护任务创建、周期任务创建、模板资源/动作选择。
+- `gcloud/contrib/audit/operations.py`：按导入/删除结果中的真实成功 ID 逐条注册模板事件。
+- `gcloud/tests/contrib/audit/__init__.py`、`test_utils.py`、`test_mappings.py`、`test_page_events.py`：审计底座、映射和页面事件测试。
+- `gcloud/tests/template_base/apis/drf/test_template_audit.py`：页面导入和批量删除测试。
+
+**底座修改**
+
+- `gcloud/contrib/audit/utils.py`：事务安全入口、固定错误日志、快照开关短路。
+- `gcloud/contrib/audit/instances.py`：支持明确的前后快照输入并保持旧调用兼容。
+- `gcloud/contrib/audit/serializers.py`：收紧审计字段，移除敏感和大字段。
+
+**页面入口修改**
+
+- `gcloud/core/apis/drf/viewsets/project.py`、`appmaker.py`、`periodic_task.py`、`project_config.py`、`taskflow.py`。
+- `gcloud/clocked_task/viewset.py`、`gcloud/periodictask/api.py`。
+- `gcloud/taskflow3/apis/django/api.py`、`v4/node_action.py`、`gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py`。
+- `gcloud/contrib/function/api.py`、`gcloud/template_base/apis/django/api.py`、`gcloud/template_base/apis/drf/viewsets/template.py`。
+
+**API Server 入口修改**
+
+- 任务：`create_task.py`、`create_and_start_task.py`、`fast_create_task.py`、`start_task.py`、`operate_task.py`、`operate_node.py`、`node_callback.py`、`modify_constants_for_task.py`。
+- 调度：`create_periodic_task.py`、`set_periodic_task_enabled.py`、`modify_cron_for_periodic_task.py`、`modify_constants_for_periodic_task.py`、`create_clocked_task.py`。
+- 流程/项目：`create_template.py`、`import_project_template.py`、`import_common_template.py`、`copy_template_across_project.py`、`register_project.py`、`claim_functionalization_task.py`、`apply_webhook_configs.py`、`modify_project_executor_proxy.py`、`modify_template_notify.py`、`modify_template_executor_proxy.py`。
+- API Server 测试文件在 Task 5-7 的 Files 段逐项列出；当前不存在的文件按对应接口名创建。
+
+---
+
+### Task 1: 建立事务安全、脱敏且向后兼容的审计底座
+
+**Files:**
+
+- Create: `gcloud/tests/contrib/audit/__init__.py`
+- Create: `gcloud/tests/contrib/audit/test_utils.py`
+- Modify: `gcloud/contrib/audit/utils.py`
+- Modify: `gcloud/contrib/audit/instances.py`
+- Modify: `gcloud/contrib/audit/serializers.py`
+
+**Interfaces:**
+
+- Produces: `sanitize_audit_data(data: Any) -> Any`
+- Produces: `AuditSnapshot(dict)`，用于标记已经由审计序列化器生成并脱敏的修改前数据。
+- Produces: `get_audit_snapshot(resource_id: str, instance: Model, data: dict = None) -> Optional[dict]`
+- Produces: `bk_audit_add_event_on_commit(username: str, action_id: str, resource_id: str = None, instance: Model = None, origin_data: dict = None, data: dict = None) -> None`
+- Preserves: `bk_audit_add_event(username, action_id, resource_id=None, instance=None, origin_data=None, *args, **kwargs)`
+
+- [ ] **Step 1: 写开关、事务和异常隔离失败测试**
+
+```python
+from unittest import mock
+
+from django.test import TestCase, override_settings
+
+from gcloud.contrib.audit import utils
+
+
+class AuditEventOnCommitTestCase(TestCase):
+    @override_settings(ENABLE_BK_AUDIT=False)
+    @mock.patch("gcloud.contrib.audit.utils.build_instance")
+    def test_disabled_does_not_build_or_register_event(self, build_instance):
+        utils.bk_audit_add_event_on_commit("admin", "task_edit", "task", mock.Mock(id=1))
+        build_instance.assert_not_called()
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.bk_audit_add_event")
+    def test_commit_sends_once(self, add_event):
+        with self.captureOnCommitCallbacks(execute=True):
+            utils.bk_audit_add_event_on_commit("admin", "task_edit", "task", mock.Mock(id=1))
+        add_event.assert_called_once()
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.bk_audit_add_event")
+    def test_rollback_does_not_send(self, add_event):
+        from django.db import transaction
+
+        try:
+            with transaction.atomic():
+                utils.bk_audit_add_event_on_commit("admin", "task_edit", "task", mock.Mock(id=1))
+                raise RuntimeError("rollback")
+        except RuntimeError:
+            pass
+        add_event.assert_not_called()
+```
+
+再增加客户端抛异常用例，断言调用方不抛异常且日志包含 `bk_audit_add_event_failed action_id=task_edit resource_id=task instance_id=1`，日志中不包含请求体和 Token。
+
+- [ ] **Step 2: 运行底座测试确认失败**
+
+Run: `pytest -q gcloud/tests/contrib/audit/test_utils.py`
+
+Expected: FAIL，原因是三个新接口尚不存在。
+
+- [ ] **Step 3: 实现开关短路、事务提交后发送和安全日志**
+
+```python
+from functools import partial
+
+from django.db import transaction
+
+
+def bk_audit_add_event_on_commit(
+    username, action_id, resource_id=None, instance=None, origin_data=None, data=None
+):
+    if not settings.ENABLE_BK_AUDIT:
+        return
+    transaction.on_commit(
+        partial(
+            bk_audit_add_event,
+            username=username,
+            action_id=action_id,
+            resource_id=resource_id,
+            instance=instance,
+            origin_data=origin_data,
+            data=data,
+        )
+    )
+```
+
+`bk_audit_add_event` 继续吞掉 SDK 异常，但日志只输出 action/resource/instance ID 和异常栈，不再格式化整个实例。
+
+```python
+instance_id = getattr(instance, "id", None)
+try:
+    audit_instance = build_instance(resource_id, instance, origin_data=origin_data, data=data)
+    bk_audit_client.add_event(
+        action=Action(action_id),
+        resource_type=ResourceType(resource_id) if resource_id else None,
+        audit_context=AuditContext(username=username),
+        instance=audit_instance,
+    )
+except Exception:
+    logger.exception(
+        "bk_audit_add_event_failed action_id=%s resource_id=%s instance_id=%s",
+        action_id,
+        resource_id,
+        instance_id,
+    )
+```
+
+- [ ] **Step 4: 实现快照覆盖和递归脱敏**
+
+`BaseInstance` 新增可选 `data`；未传时保持旧序列化行为。`get_audit_snapshot` 返回 `AuditSnapshot`；各资源的 `prepare_origin_data` 遇到该标记时直接使用其中的安全字段，只有旧调用传入普通 dict 时才继续走原有请求 serializer 校验。这样新快照不会被 `UpdatePeriodicTaskSerializer` 等旧请求格式再次校验，旧调用也不改变语义。
+
+`sanitize_audit_data` 对 `pipeline_tree`、`constants`、`form`、`task_parameters`、`inputs`、`outputs`、`headers`、`extra_info` 整项移除，对 key 名含 `password`、`token`、`secret`、`credential` 的值替换为 `******`，对列表和嵌套字典递归处理。`get_audit_snapshot` 在开关关闭时直接返回 `None`，开启时读取实例审计序列化数据、脱敏并包装为 `AuditSnapshot`。
+
+- [ ] **Step 5: 收紧资源序列化字段**
+
+将 `TaskSerializer` 从 `fields = "__all__"` 改为明确字段：`id`、`name`、`project`、`category`、`template_id`、`template_source`、`create_method`、`creator_name`、`executor_name`、`flow_type`、`current_flow`、`is_started`、`is_finished`、`is_revoked`、`create_time`、`start_time`、`finish_time`。从 `PeriodicTaskSerializer` 移除 `form`，计划任务审计数据移除 `task_parameters`。
+
+测试构造含 password、Authorization header、constants 和 pipeline_tree 的嵌套数据，断言事件与日志均不含对应值。
+
+- [ ] **Step 6: 运行底座测试并提交**
+
+Run: `pytest -q gcloud/tests/contrib/audit/test_utils.py`
+
+Expected: PASS，事务提交一次、回滚零次、开关关闭零次、SDK 异常不影响调用方。
+
+```bash
+git add gcloud/contrib/audit/utils.py gcloud/contrib/audit/instances.py gcloud/contrib/audit/serializers.py gcloud/tests/contrib/audit
+git commit -m "feat(audit): add transaction-safe event delivery --story=136920805"
+```
+
+---
+
+### Task 2: 集中现有动作和资源映射
+
+**Files:**
+
+- Create: `gcloud/contrib/audit/mappings.py`
+- Create: `gcloud/tests/contrib/audit/test_mappings.py`
+- Modify: `gcloud/core/apis/drf/viewsets/taskflow.py`
+- Modify: `gcloud/core/apis/drf/viewsets/periodic_task.py`
+
+**Interfaces:**
+
+- Produces: `get_task_create_action(template_source: str, create_method: str = None) -> Optional[str]`
+- Produces: `get_periodic_task_create_action(template_source: str) -> Optional[str]`
+- Produces: `get_template_audit_meta(template_model_cls: type) -> Tuple[str, str, str]`，依次返回 create/delete/resource ID。
+
+- [ ] **Step 1: 写完整映射失败测试**
+
+```python
+import pytest
+
+from gcloud.common_template.models import CommonTemplate
+from gcloud.constants import COMMON, ONETIME, PROJECT
+from gcloud.iam_auth import IAMMeta
+from gcloud.tasktmpl3.models import TaskTemplate
+
+from gcloud.contrib.audit.mappings import (
+    get_periodic_task_create_action,
+    get_task_create_action,
+    get_template_audit_meta,
+)
+
+
+@pytest.mark.parametrize(
+    "source,method,expected",
+    [
+        (PROJECT, None, IAMMeta.FLOW_CREATE_TASK_ACTION),
+        (COMMON, None, IAMMeta.COMMON_FLOW_CREATE_TASK_ACTION),
+        (ONETIME, None, IAMMeta.PROJECT_FAST_CREATE_TASK_ACTION),
+        (PROJECT, "app_maker", IAMMeta.MINI_APP_CREATE_TASK_ACTION),
+        ("unknown", None, None),
+    ],
+)
+def test_task_create_action(source, method, expected):
+    assert get_task_create_action(source, method) == expected
+
+
+def test_template_meta_uses_existing_resources():
+    assert get_template_audit_meta(TaskTemplate) == (
+        IAMMeta.FLOW_CREATE_ACTION,
+        IAMMeta.FLOW_DELETE_ACTION,
+        IAMMeta.FLOW_RESOURCE,
+    )
+    assert get_template_audit_meta(CommonTemplate) == (
+        IAMMeta.COMMON_FLOW_CREATE_ACTION,
+        IAMMeta.COMMON_FLOW_DELETE_ACTION,
+        IAMMeta.COMMON_FLOW_RESOURCE,
+    )
+```
+
+同时断言 PROJECT/COMMON 周期任务分别映射到 `FLOW_CREATE_PERIODIC_TASK_ACTION` 和 `COMMON_FLOW_CREATE_PERIODIC_TASK_ACTION`；未知来源返回 `None`。
+
+- [ ] **Step 2: 运行映射测试确认失败**
+
+Run: `pytest -q gcloud/tests/contrib/audit/test_mappings.py`
+
+Expected: FAIL，模块尚不存在。
+
+- [ ] **Step 3: 实现映射并替换页面重复字典**
+
+`mappings.py` 只依赖 constants、IAMMeta 和模板模型，不访问请求或数据库。页面任务创建与周期任务创建改为调用映射函数；返回 `None` 时跳过审计并记录 warning，不能回退到项目流程动作。
+
+- [ ] **Step 4: 运行测试并提交**
+
+Run: `pytest -q gcloud/tests/contrib/audit/test_mappings.py gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py`
+
+Expected: PASS。
+
+```bash
+git add gcloud/contrib/audit/mappings.py gcloud/tests/contrib/audit/test_mappings.py gcloud/core/apis/drf/viewsets/taskflow.py gcloud/core/apis/drf/viewsets/periodic_task.py
+git commit -m "refactor(audit): centralize existing action mappings --story=136920805"
+```
+
+---
+
+### Task 3: 修正首版页面审计时机并补齐页面任务类 P0
+
+**Files:**
+
+- Create: `gcloud/tests/contrib/audit/test_page_events.py`
+- Modify: `gcloud/core/apis/drf/viewsets/project.py`、`appmaker.py`、`taskflow.py`
+- Modify: `gcloud/taskflow3/apis/django/api.py`、`v4/node_action.py`
+- Modify: `gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py`
+- Modify: `gcloud/contrib/function/api.py`
+
+**Interfaces:**
+
+- Consumes: `get_audit_snapshot`、`bk_audit_add_event_on_commit`。
+- Produces: 页面任务操作只有 `result is True` 时发送现有动作事件。
+
+- [ ] **Step 1: 写成功/失败及时序回归测试**
+
+逐一 patch 所在模块的 `bk_audit_add_event_on_commit`：
+
+| 入口 | 成功动作 | 失败断言 |
+| --- | --- | --- |
+| `ProjectSetViewSet.update` | `project_edit/project`，带修改前快照 | serializer 抛错时零次 |
+| `AppmakerListViewSet.destroy` | `mini_app_delete/mini_app` | 删除抛错时零次 |
+| `task_action` | `task_operate/task` | `ctx["result"] is False` 时零次 |
+| `nodes_action`、V4 `node_action`、`spec_nodes_timer_reset` | `task_operate/task` | 模型返回失败时零次 |
+| `UpdateTaskConstantsView.post` | `task_edit/task` | `set_result["result"] is False` 时零次 |
+| `FunctionTaskClaimantTransferView.post` | `task_claim/task` | 权限/认领人不匹配时零次 |
+| `convert_to_common_task` | `task_edit/task` | creator/current_flow 校验失败时零次 |
+| `task_func_claim` | `task_claim/task` | `ctx["result"] is False` 时零次 |
+
+成功测试使用 `captureOnCommitCallbacks(execute=True)`，断言 username、action、resource、instance 和调用次数。项目、任务参数和职能任务转换断言 origin 存在且不含变量值。
+
+- [ ] **Step 2: 运行页面任务测试确认失败**
+
+Run: `pytest -q gcloud/tests/contrib/audit/test_page_events.py`
+
+Expected: FAIL，现有项目/删除事件提前发送，节点和参数入口缺少事件，任务操作失败仍发送。
+
+- [ ] **Step 3: 将已有调用移动到成功结果之后**
+
+- `ProjectSetViewSet.update`：父类调用前捕获 origin，成功返回后取得当前实例并注册 `project_edit`。
+- `AppmakerListViewSet.destroy`：先执行删除；成功后使用删除前实例注册 `mini_app_delete`。
+- `task_action`、`task_func_claim`：仅在 `ctx.get("result") is True` 时注册。
+
+- [ ] **Step 4: 为节点、参数和职能任务增加成功事件**
+
+```python
+ctx = task.nodes_action(action, node_id, username, **kwargs)
+if ctx.get("result") is True:
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.TASK_OPERATE_ACTION,
+        resource_id=IAMMeta.TASK_RESOURCE,
+        instance=task,
+    )
+return JsonResponse(ctx)
+```
+
+任务参数修改在 `set_task_constants` 前捕获快照，成功后上报 `task_edit`。职能任务转交通过 FunctionTask 找到关联 task 后上报 `task_claim`，不能把 FunctionTask ID 当作 task ID。`convert_to_common_task` 的注册放在 `transaction.atomic()` 内并依赖 on-commit。
+
+- [ ] **Step 5: 运行测试并提交**
+
+Run: `pytest -q gcloud/tests/contrib/audit/test_page_events.py gcloud/tests/taskflow3/test_api.py`
+
+Expected: PASS。
+
+```bash
+git add gcloud/core/apis/drf/viewsets/project.py gcloud/core/apis/drf/viewsets/appmaker.py gcloud/core/apis/drf/viewsets/taskflow.py gcloud/taskflow3/apis/django/api.py gcloud/taskflow3/apis/django/v4/node_action.py gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py gcloud/contrib/function/api.py gcloud/tests/contrib/audit/test_page_events.py
+git commit -m "feat(audit): cover page task operations after success --story=136920805"
+```
+
+---
+
+### Task 4: 补齐页面计划任务、周期任务、项目代理和流程批量操作
+
+**Files:**
+
+- Modify: `gcloud/clocked_task/viewset.py`
+- Modify: `gcloud/periodictask/api.py`
+- Modify: `gcloud/core/apis/drf/viewsets/periodic_task.py`、`project_config.py`
+- Modify: `gcloud/template_base/apis/django/api.py`、`gcloud/template_base/apis/drf/viewsets/template.py`
+- Create: `gcloud/contrib/audit/operations.py`
+- Modify: `gcloud/tests/clocked_task/test_clocked_task_api.py`、`gcloud/tests/periodictask/models/test_periodic_task.py`
+- Create: `gcloud/tests/template_base/apis/drf/test_template_audit.py`
+
+**Interfaces:**
+
+- Consumes: 事务安全入口和模板动作映射。
+- Produces: `audit_imported_templates(username, template_model_cls, import_result) -> None`，只遍历 `import_result["data"]["flows"]` 中的真实落库 ID。
+- Produces: `audit_deleted_templates(username, template_model_cls, instances_by_id, success_ids) -> None`。
+
+- [ ] **Step 1: 写调度、项目配置和模板批量测试**
+
+- 计划任务：create=`flow_create_clocked_task`、retrieve=`clocked_task_view`、update=`clocked_task_edit`、destroy=`clocked_task_delete`，资源均为 `clocked_task`；update/destroy 失败零事件，update origin 不含 `task_parameters`。
+- 页面周期任务：启停、Cron、constants 修改成功均发送 `periodic_task_edit/periodic_task`，失败零次；destroy 在删除成功后发送；创建动作按 template_source 区分项目/公共流程。
+- 项目执行代理：`ProjectConfigViewSet.update` 成功发送 `project_edit/project`，data 只含 `executor_proxy`、`executor_proxy_exempts`。
+- 页面导入：项目/公共模板分别发送 `flow_create/flow`、`common_flow_create/common_flow`，只查询 flows 返回 ID。
+- 批量删除：只对 `result["data"]["success"]` 中的删除前实例发送对应 delete 动作；fail 列表、Webhook 清理失败和 manager 失败均零事件。
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run: `pytest -q gcloud/tests/clocked_task/test_clocked_task_api.py gcloud/tests/periodictask/models/test_periodic_task.py gcloud/tests/template_base/apis/drf/test_template_audit.py`
+
+Expected: FAIL，目标入口尚未完整接入事务安全审计。
+
+- [ ] **Step 3: 实现按实际成功实例上报**
+
+在 `operations.py` 实现两个批量助手。导入助手先检查 `import_result.get("result") is True`，再把 `flows.keys()` 转为整数并查询目标模型；删除助手只遍历 success ID。两个助手都通过 `get_template_audit_meta` 取得现有动作/资源，不能接受调用方任意传 action。
+
+```python
+def audit_imported_templates(username, template_model_cls, import_result):
+    if import_result.get("result") is not True:
+        return
+    create_action, _, resource_id = get_template_audit_meta(template_model_cls)
+    template_ids = [int(template_id) for template_id in import_result["data"]["flows"]]
+    for instance in template_model_cls.objects.filter(id__in=template_ids):
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=create_action,
+            resource_id=resource_id,
+            instance=instance,
+        )
+```
+
+批量删除在 manager 调用前保存 `{instance.id: instance}`，成功后只遍历 success ID；导入事件使用 flows keys 查询导入后模板，不使用导入文件旧 ID。项目执行代理用 Project 作审计实例，手工构造代理与豁免用户前后小快照。
+
+```python
+for template_id in result["data"]["success"]:
+    instance = instances[template_id]
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=delete_action,
+        resource_id=resource_id,
+        instance=instance,
+        origin_data=get_audit_snapshot(resource_id, instance),
+        data={"id": template_id, "is_deleted": True},
+    )
+```
+
+- [ ] **Step 4: 运行测试并提交**
+
+Run: `pytest -q gcloud/tests/clocked_task/test_clocked_task_api.py gcloud/tests/periodictask/models/test_periodic_task.py gcloud/tests/template_base/apis/drf/test_template_audit.py`
+
+Expected: PASS。
+
+```bash
+git add gcloud/contrib/audit/operations.py gcloud/clocked_task/viewset.py gcloud/periodictask/api.py gcloud/core/apis/drf/viewsets/periodic_task.py gcloud/core/apis/drf/viewsets/project_config.py gcloud/template_base/apis/django/api.py gcloud/template_base/apis/drf/viewsets/template.py gcloud/tests/clocked_task/test_clocked_task_api.py gcloud/tests/periodictask/models/test_periodic_task.py gcloud/tests/template_base/apis/drf/test_template_audit.py
+git commit -m "feat(audit): cover page schedules and template batches --story=136920805"
+```
+
+---
+
+### Task 5: 补齐 API Server 任务生命周期 P0
+
+**Files:**
+
+- Modify: `gcloud/apigw/views/create_task.py`、`create_and_start_task.py`、`fast_create_task.py`、`start_task.py`
+- Modify: `gcloud/apigw/views/operate_task.py`、`operate_node.py`、`node_callback.py`、`modify_constants_for_task.py`
+- Modify: `gcloud/tests/apigw/views/test_create_task.py`、`test_create_and_start_task.py`、`test_start_task.py`、`test_operate_task.py`、`test_operate_node.py`、`test_node_callback.py`
+- Create: `gcloud/tests/apigw/views/test_fast_create_task.py`、`test_modify_constants_for_task.py`
+
+**Interfaces:**
+
+- Consumes: `get_task_create_action`、`get_audit_snapshot`、`bk_audit_add_event_on_commit`。
+- Produces: 任务事件均使用实际 `TaskFlowInstance.id`，scope 使用已解析的 `request.project`。
+
+- [ ] **Step 1: 为八个任务接口写审计断言**
+
+| 接口 | action/resource | 成功条件 |
+| --- | --- | --- |
+| `create_task` | project/common 对应 create-task，`task` | task 已创建 |
+| `create_and_start_task` | create-task + `task_operate`，`task` | task 落库，`apply_async` 返回后各一次 |
+| `fast_create_task` | `project_fast_create_task/task` | task 已创建 |
+| `start_task` | `task_operate/task` | `apply_async` 成功返回 |
+| `operate_task` | `task_operate/task` | start 投递成功或其他分支 `ctx.result=True` |
+| `operate_node` | `task_operate/task` | `result.result=True` |
+| `node_callback` | `task_operate/task` | callback `result=True` |
+| `modify_constants_for_task` | `task_edit/task` | reset `result=True` |
+
+失败测试覆盖模板/任务不存在、任务已启动、模型返回 `result=False`、`apply_async` 抛异常。`create_and_start_task` 投递失败允许记录已完成的创建事件，但不得记录 `task_operate`。
+
+`create_task` 和 `start_task` 各增加两组 project-inject 用例：路由传 CMDB 业务 ID 与传内部项目 ID 时，审计实例都必须是注入后查询得到的 TaskFlowInstance，不能把原始路由值当作资源 ID。
+
+- [ ] **Step 2: 运行任务测试确认失败**
+
+Run: `pytest -q gcloud/tests/apigw/views/test_create_task.py gcloud/tests/apigw/views/test_create_and_start_task.py gcloud/tests/apigw/views/test_start_task.py gcloud/tests/apigw/views/test_operate_task.py gcloud/tests/apigw/views/test_operate_node.py gcloud/tests/apigw/views/test_node_callback.py`
+
+Expected: FAIL，审计调用尚未补齐。
+
+- [ ] **Step 3: 在真实成功点注册事件**
+
+创建事件紧跟 TaskFlowInstance 持久化；启动事件紧跟各文件中现有的 `prepare_and_start_task.apply_async` 调用成功返回；模型业务方法必须检查 `result.get("result") is True`。`create_and_start_task` 注册创建和启动两个事件。constants 修改前捕获 origin，不能把请求 constants 传给审计。
+
+- [ ] **Step 4: 补缺失测试文件并运行全部任务测试**
+
+创建 `test_fast_create_task.py` 和 `test_modify_constants_for_task.py`；验证 action/resource/instance/call-count 和失败零事件。
+
+Run: `pytest -q gcloud/tests/apigw/views/test_create_task.py gcloud/tests/apigw/views/test_create_and_start_task.py gcloud/tests/apigw/views/test_fast_create_task.py gcloud/tests/apigw/views/test_start_task.py gcloud/tests/apigw/views/test_operate_task.py gcloud/tests/apigw/views/test_operate_node.py gcloud/tests/apigw/views/test_node_callback.py gcloud/tests/apigw/views/test_modify_constants_for_task.py`
+
+Expected: PASS，原请求/响应断言不变。
+
+- [ ] **Step 5: 提交**
+
+```bash
+git add gcloud/apigw/views/create_task.py gcloud/apigw/views/create_and_start_task.py gcloud/apigw/views/fast_create_task.py gcloud/apigw/views/start_task.py gcloud/apigw/views/operate_task.py gcloud/apigw/views/operate_node.py gcloud/apigw/views/node_callback.py gcloud/apigw/views/modify_constants_for_task.py gcloud/tests/apigw/views
+git commit -m "feat(audit): cover api server task operations --story=136920805"
+```
+
+---
+
+### Task 6: 补齐 API Server 周期任务和计划任务 P0
+
+**Files:**
+
+- Modify: `gcloud/apigw/views/create_periodic_task.py`、`set_periodic_task_enabled.py`
+- Modify: `gcloud/apigw/views/modify_cron_for_periodic_task.py`、`modify_constants_for_periodic_task.py`
+- Modify: `gcloud/apigw/views/create_clocked_task.py`
+- Modify: `gcloud/tests/apigw/views/test_create_periodic_task.py`、`test_set_periodic_task_enabled.py`、`test_modify_cron_for_periodic_task.py`、`test_modify_constants_for_periodic_task.py`
+- Create: `gcloud/tests/apigw/views/test_create_clocked_task.py`
+
+**Interfaces:**
+
+- Consumes: 周期任务创建映射、快照、on-commit 发送。
+
+- [ ] **Step 1: 写调度接口成功和失败测试**
+
+- `create_periodic_task`：project/common 分别断言 `flow_create_periodic_task`/`common_flow_create_periodic_task`，资源 `periodic_task`。
+- 启停、Cron、constants 修改：断言 `periodic_task_edit/periodic_task`，模型异常或业务失败零次。
+- `create_clocked_task`：断言 `flow_create_clocked_task/clocked_task`；模板不存在和 serializer 失败零次。
+- constants 与计划任务参数不得出现在 origin/current。
+
+- [ ] **Step 2: 运行调度测试确认失败**
+
+Run: `pytest -q gcloud/tests/apigw/views/test_create_periodic_task.py gcloud/tests/apigw/views/test_set_periodic_task_enabled.py gcloud/tests/apigw/views/test_modify_cron_for_periodic_task.py gcloud/tests/apigw/views/test_modify_constants_for_periodic_task.py gcloud/tests/apigw/views/test_create_clocked_task.py`
+
+Expected: FAIL；若最后一个测试文件当前不存在，先创建同名 APITest 文件。
+
+- [ ] **Step 3: 在调度持久化成功后注册事件**
+
+修改类在调用模型方法前取快照，成功后注册 `periodic_task_edit`；创建类只传实际创建实例。`request.project.id` 只用于 scope，审计实例 ID 使用 PeriodicTask/ClockedTask 自身 ID。
+
+- [ ] **Step 4: 运行测试并提交**
+
+Run: `pytest -q gcloud/tests/apigw/views/test_create_periodic_task.py gcloud/tests/apigw/views/test_set_periodic_task_enabled.py gcloud/tests/apigw/views/test_modify_cron_for_periodic_task.py gcloud/tests/apigw/views/test_modify_constants_for_periodic_task.py gcloud/tests/apigw/views/test_create_clocked_task.py`
+
+Expected: PASS。
+
+```bash
+git add gcloud/apigw/views/create_periodic_task.py gcloud/apigw/views/set_periodic_task_enabled.py gcloud/apigw/views/modify_cron_for_periodic_task.py gcloud/apigw/views/modify_constants_for_periodic_task.py gcloud/apigw/views/create_clocked_task.py gcloud/tests/apigw/views
+git commit -m "feat(audit): cover api server scheduled tasks --story=136920805"
+```
+
+---
+
+### Task 7: 补齐 API Server 流程、项目和配置 P0
+
+**Files:**
+
+- Modify: `gcloud/apigw/views/create_template.py`、`import_project_template.py`、`import_common_template.py`、`copy_template_across_project.py`
+- Modify: `gcloud/apigw/views/register_project.py`、`claim_functionalization_task.py`、`apply_webhook_configs.py`、`modify_project_executor_proxy.py`
+- Modify: `gcloud/apigw/views/modify_template_notify.py`、`modify_template_executor_proxy.py`
+- Modify: `gcloud/tests/apigw/views/test_import_common_template.py`、`test_apply_webhook_configs.py`、`test_modify_template_notify.py`、`test_modify_template_executor_proxy.py`
+- Create: `gcloud/tests/apigw/views/test_create_template.py`、`test_import_project_template.py`、`test_copy_template_across_project.py`、`test_register_project.py`、`test_claim_functionalization_task.py`、`test_modify_project_executor_proxy.py`
+
+**Interfaces:**
+
+- Consumes: 模板映射、快照、批量成功实例逻辑、on-commit 发送。
+- Produces: Webhook 快照只含模板 ID、enable 状态和事件类型集合。
+
+- [ ] **Step 1: 写流程导入/复制和已有入口回归测试**
+
+- 项目导入/跨项目复制只对 `flows` 目标 ID 发送 `flow_create/flow`；公共导入发送 `common_flow_create/common_flow`。
+- import `result=False` 或异常时零事件。
+- `create_template`、`modify_template_notify`、`modify_template_executor_proxy` 保持原 action/resource，改为 on-commit；失败零事件，修改有 origin。
+
+- [ ] **Step 2: 写项目、认领、Webhook 和执行代理测试**
+
+| 接口 | action/resource | 数据限制 |
+| --- | --- | --- |
+| `register_project` | `project_edit/project` | 新建/恢复后的内部 Project |
+| `claim_functionalization_task` | `task_claim/task` | 仅 `task_claim().result=True` |
+| `apply_webhook_configs` | 每个受影响模板 `flow_edit/flow` | 不含 endpoint、headers、extra_info |
+| `modify_project_executor_proxy` | `project_edit/project` | 仅代理与豁免用户前后值 |
+
+Webhook disable-all 使用真实模板 ID 集合；创建/更新使用最终受影响 scope_code 查询 TaskTemplate。事务回滚时零事件。
+
+- [ ] **Step 3: 运行流程/项目测试确认失败**
+
+Run: `pytest -q gcloud/tests/apigw/views/test_import_project_template.py gcloud/tests/apigw/views/test_import_common_template.py gcloud/tests/apigw/views/test_copy_template_across_project.py gcloud/tests/apigw/views/test_apply_webhook_configs.py gcloud/tests/apigw/views/test_modify_template_notify.py gcloud/tests/apigw/views/test_modify_template_executor_proxy.py`
+
+Expected: FAIL；创建当前缺失的 `test_copy_template_across_project.py`、`test_register_project.py`、`test_claim_functionalization_task.py`、`test_modify_project_executor_proxy.py`。
+
+- [ ] **Step 4: 实现批量成功实例和安全 Webhook 快照**
+
+导入/复制根据 `flows.keys()` 查询目标模型，不使用源 ID。Webhook 只构造以下数据：
+
+```python
+data = {
+    "template_id": template.id,
+    "webhook_enabled": enabled,
+    "event_types": sorted(event_types),
+}
+```
+
+禁止传 endpoint、headers、extra_info。项目注册必须在 CC 查询、项目保存和配置初始化均成功后注册事件。
+
+- [ ] **Step 5: 运行测试并提交**
+
+Run: `pytest -q gcloud/tests/apigw/views/test_import_project_template.py gcloud/tests/apigw/views/test_import_common_template.py gcloud/tests/apigw/views/test_copy_template_across_project.py gcloud/tests/apigw/views/test_register_project.py gcloud/tests/apigw/views/test_claim_functionalization_task.py gcloud/tests/apigw/views/test_apply_webhook_configs.py gcloud/tests/apigw/views/test_modify_project_executor_proxy.py gcloud/tests/apigw/views/test_modify_template_notify.py gcloud/tests/apigw/views/test_modify_template_executor_proxy.py`
+
+Expected: PASS。
+
+```bash
+git add gcloud/apigw/views gcloud/tests/apigw/views
+git commit -m "feat(audit): cover api server flow and project writes --story=136920805"
+```
+
+---
+
+### Task 8: 全局回归、延期边界和 Token 灰度验收
+
+**Files:**
+
+- Modify: `docs/specs/2026-08-07-operation-audit-phase1-design.md`（只追加 TAPD 与最终验证结果）
+- Verify only: `config/default.py`、`gcloud/apigw/management/commands/data/api-resources.yml`、插件网关与包源路径
+
+**Interfaces:**
+
+- Produces: 测试证据和 API Server Token 灰度检查单。
+
+- [ ] **Step 1: 运行一期定向回归**
+
+```bash
+pytest -q \
+  gcloud/tests/contrib/audit \
+  gcloud/tests/clocked_task/test_clocked_task_api.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_create_and_start_task.py \
+  gcloud/tests/apigw/views/test_start_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py \
+  gcloud/tests/apigw/views/test_node_callback.py \
+  gcloud/tests/apigw/views/test_create_periodic_task.py \
+  gcloud/tests/apigw/views/test_set_periodic_task_enabled.py \
+  gcloud/tests/apigw/views/test_modify_cron_for_periodic_task.py \
+  gcloud/tests/apigw/views/test_modify_constants_for_periodic_task.py \
+  gcloud/tests/apigw/views/test_import_common_template.py \
+  gcloud/tests/apigw/views/test_apply_webhook_configs.py \
+  gcloud/tests/apigw/views/test_modify_template_notify.py \
+  gcloud/tests/apigw/views/test_modify_template_executor_proxy.py
+```
+
+Expected: 全部 PASS。
+
+- [ ] **Step 2: 运行格式、静态与差异检查**
+
+```bash
+black --check gcloud/contrib/audit gcloud/apigw/views gcloud/clocked_task gcloud/periodictask gcloud/taskflow3/apis gcloud/tests/contrib/audit gcloud/tests/apigw/views
+flake8 --config=.flake8 gcloud/contrib/audit gcloud/apigw/views gcloud/clocked_task gcloud/periodictask gcloud/taskflow3/apis gcloud/tests/contrib/audit gcloud/tests/apigw/views
+git diff --check
+```
+
+Expected: 三条命令均退出 0。
+
+- [ ] **Step 3: 核对无 schema 变化、无错误映射、无密钥**
+
+```bash
+git diff --exit-code upstream/master -- gcloud/apigw/management/commands/data/api-resources.yml
+git diff upstream/master -- gcloud/apigw/views/plugin_gateway.py gcloud/core/apis/drf/viewsets/package_source.py gcloud/core/apis/drf/viewsets/sync_task.py
+if git diff upstream/master | rg -n "BK_AUDIT_DATA_TOKEN\s*=\s*['\"][^'\"]+|BK_AUDIT_ENDPOINT\s*=\s*['\"]https?://|plugin_gateway_(create|cancel).*bk_audit|package_source.*bk_audit"; then exit 1; fi
+```
+
+Expected: APIGW YAML 无差异；延期文件无审计改动；最后一条无匹配。真实 Token 不进入终端输出、fixture 或提交。
+
+- [ ] **Step 4: 记录代码验证结果并提交文档**
+
+在设计文档末尾追加 TAPD `136920805`、实际测试命令及通过数量；预发布/生产标记为“待环境灰度”，不能把单元测试写成审计中心实收证明。
+
+```bash
+git add docs/specs/2026-08-07-operation-audit-phase1-design.md docs/plans/2026-08-07-operation-audit-phase1.md
+git commit -m "docs(audit): record phase one verification plan --story=136920805"
+```
+
+- [ ] **Step 5: 代码合入和部署后执行 API Server Token 灰度**
+
+1. Token 为空部署一期代码，确认业务行为与现状一致。
+2. 预发布 API Server 配置 `BK_AUDIT_ENDPOINT` 与 `BK_AUDIT_DATA_TOKEN`，滚动重启。
+3. 对任务创建、任务操作、周期任务修改、流程导入、项目代理修改分别执行一次成功和一次失败请求。
+4. 在审计中心核对成功事件，确认失败请求无成功事件；抽样核对 username、action ID、resource ID、instance ID。
+5. 搜索 `bk_audit_add_event_failed`，确认无 Token、请求体和敏感值。
+6. 生产只在少量 API Server 实例配置 Token；对照访问日志与审计中心事件数量后再全量。
+7. 页面模块和 Worker 的 Token 状态分别核验，不能以 API Server 已开启代替全站已开启。
+
+Expected: 预发布实收与访问日志抽样一致后才允许生产灰度；异常时回退环境变量并保留代码，不提交密钥变更。

--- a/docs/specs/2026-08-07-operation-audit-phase1-design.md
+++ b/docs/specs/2026-08-07-operation-audit-phase1-design.md
@@ -1,0 +1,284 @@
+# 标准运维操作审计一期补漏设计
+
+## 背景
+
+标准运维在 2024 年接入蓝鲸审计中心后，主要在页面侧项目、流程、任务、轻应用、周期任务等主路径中手工调用 `bk_audit_add_event`。随着 API Server、计划任务、任务参数修改、Webhook 等能力演进，现有审计出现三类缺口：
+
+1. 同一业务操作在页面入口有审计，API Server 入口没有审计。
+2. 首版已经定义了资源和动作，但部分入口从未调用审计上报。
+3. 部分旧调用在业务完成前上报，或者没有判断业务返回结果，可能产生误报。
+
+当前 `BK_AUDIT_DATA_TOKEN` 为空时，`ENABLE_BK_AUDIT` 为 `False`，所有审计调用直接返回。API Server 在 Token 未配置的状态下不会向审计中心发送事件。
+
+## 一期目标
+
+一期在不新增审计动作、不新增审计资源的前提下，完成以下目标：
+
+- 复用现有项目、流程、任务、公共流程、轻应用、周期任务、计划任务资源补齐 P0 写操作。
+- 页面与 API Server 对同一种业务操作使用相同的审计动作。
+- 审计事件只在业务成功、事务提交后发送。
+- 修改类操作携带脱敏后的修改前和修改后快照。
+- 批量操作按实际成功资源逐条发送事件。
+- 代码验证完成后，通过部署环境变量灰度打开 API Server 审计上报。
+
+## 非目标
+
+- 不新增审计中心动作或资源。
+- 不调整 IAM 权限模型。
+- 不接入插件网关运行/取消，因为现有七类资源无法准确表达插件运行实例。
+- 不接入包源管理与同步，因为现有资源无法表达包源实例，且无资源的 `admin_edit` 不能满足对象追溯要求。
+- 不接入流程市场标签等无法准确映射到现有资源的操作。
+- 不审计列表、计数、状态轮询、预览、普通日志读取等高频只读接口。
+- 不改变 API 请求参数、响应结构、HTTP 状态码和 APIGW 资源 schema。
+- 不在代码仓库保存审计 Token、Endpoint 或其他部署密钥。
+
+## 设计原则
+
+1. **成功后上报**：权限校验通过不等于业务操作成功；事件只能在业务结果成功后产生。
+2. **事务一致性**：数据库事务中的操作通过 `transaction.on_commit` 触发审计，回滚事务不产生成功事件。
+3. **入口一致性**：页面、API Server、MCP 复用同一动作语义，不因调用入口不同而改变 action ID。
+4. **资源真实**：事件中的资源 ID 必须是完成 scope 解析后的内部实例 ID，不能直接使用含义不确定的原始路由参数。
+5. **不错误映射**：没有合适现有资源的操作明确延期，不用 `admin_edit` 或其他资源强行承载。
+6. **业务可用性优先**：审计客户端异常不阻断业务，但必须留下可检索的结构化错误日志。
+7. **最小敏感数据**：只记录识别资源和理解变更所需的信息，不记录密钥、变量值、流程树全文和日志正文。
+
+## 现有动作与资源复用
+
+一期只使用 `IAMMeta` 中已经存在的动作和七类资源。
+
+| 业务操作 | action ID | resource ID |
+| --- | --- | --- |
+| 项目注册、项目执行代理修改 | `project_edit` | `project` |
+| 项目流程创建/导入/复制 | `flow_create` | `flow` |
+| 项目流程配置、Webhook 修改 | `flow_edit` | `flow` |
+| 项目流程批量删除 | `flow_delete` | `flow` |
+| 公共流程导入 | `common_flow_create` | `common_flow` |
+| 公共流程批量删除 | `common_flow_delete` | `common_flow` |
+| 项目流程创建任务 | `flow_create_task` | `task` |
+| 公共流程创建任务 | `common_flow_create_task` | `task` |
+| 一次性任务快速创建 | `project_fast_create_task` | `task` |
+| 任务启动、暂停、继续、撤销、节点操作、节点回调 | `task_operate` | `task` |
+| 任务参数修改、职能任务转普通任务 | `task_edit` | `task` |
+| 职能任务认领、认领转交 | `task_claim` | `task` |
+| 项目流程创建周期任务 | `flow_create_periodic_task` | `periodic_task` |
+| 公共流程创建周期任务 | `common_flow_create_periodic_task` | `periodic_task` |
+| 周期任务修改/删除 | `periodic_task_edit` / `periodic_task_delete` | `periodic_task` |
+| 项目流程创建计划任务 | `flow_create_clocked_task` | `clocked_task` |
+| 计划任务修改/删除 | `clocked_task_edit` / `clocked_task_delete` | `clocked_task` |
+
+详情查看动作保留首版已有行为；一期不扩大详情读取审计范围。
+
+## 审计底座
+
+### 1. 保持兼容的公共入口
+
+保留 `bk_audit_add_event(username, action_id, resource_id, instance, origin_data)` 作为最终发送入口，避免一次性修改所有首版调用。
+
+新增事务安全的调用入口，职责包括：
+
+- 在启用审计时生成必要快照。
+- 在事务提交后调用现有发送函数。
+- 接受修改前快照，生成 `instance_origin_data`。
+- 保持审计异常不向业务调用方抛出。
+
+页面和 API Server 新增调用统一使用事务安全入口；首版存在时机问题的调用迁移到该入口。
+
+### 2. 修改前后快照
+
+修改操作在业务变更前，使用与当前资源一致的审计序列化器生成修改前快照；事务成功后，再生成修改后快照并发送事件。
+
+快照规则：
+
+- 流程不记录 `pipeline_tree` 全文。
+- 任务不记录 constants 的值和插件输入输出。
+- 周期任务、计划任务不记录任务参数值，只保留名称、调度配置摘要、模板关联等必要字段。
+- Webhook 不记录 endpoint 中的认证信息、headers、extra_info 明文。
+- 项目执行代理只记录代理用户名和豁免用户标识，不记录无关项目配置。
+
+创建操作没有修改前快照；删除操作的修改前快照来自删除前实例，修改后状态按资源的软删除或删除结果表达。
+
+### 3. 成功判定
+
+不同入口按真实业务结果判定：
+
+- DRF 正常返回 2xx 且持久化完成，视为成功。
+- 返回字典或 `JsonResponse` 的旧接口必须满足 `result is True`。
+- 异步启动接口在任务成功进入队列后记录 `task_operate`，该事件表示“启动请求已受理”，不代表任务最终执行成功。
+- `create_and_start_task` 产生两个事件：任务创建成功和启动请求受理成功。两个动作语义不同，不做合并。
+- 权限拒绝、参数校验失败、业务返回失败、事务回滚、异步投递异常均不发送成功事件。
+
+### 4. 批量操作
+
+项目/公共流程导入、跨项目复制、批量删除根据最终结果逐个资源发送事件：
+
+- 只对实际创建或删除成功的模板发送。
+- 失败模板不发送成功事件。
+- 资源 ID 使用导入、复制后生成的真实模板 ID。
+- 不在一期引入新的批次资源或批次动作。
+
+### 5. 失败处理与日志
+
+审计客户端异常继续被捕获，不影响业务响应。错误日志至少包含：
+
+- 固定事件标识 `bk_audit_add_event_failed`。
+- action ID、resource ID、instance ID。
+- 异常类型和异常栈。
+
+日志不得包含 Token、原始请求体、变量值或其他敏感字段。一期不实现持久化重试队列；灰度阶段通过错误日志和审计中心实收数量发现丢失。
+
+## 页面侧 P0 补漏
+
+| 模块 | 操作 |
+| --- | --- |
+| 计划任务 | 创建、详情查看、修改、删除 |
+| 任务控制 | V3/V4 节点操作、指定节点计时器调整 |
+| 任务参数 | 修改任务全局变量 |
+| 周期任务 | 启停、Cron 修改、参数修改的旧页面接口 |
+| 职能任务 | 认领转交、转普通任务 |
+| 流程 | 项目/公共流程导入、批量删除 |
+| 项目配置 | 项目执行代理修改 |
+
+首版已有调用同时修正以下问题：
+
+- 项目修改从“修改前上报”改为“修改成功后上报”。
+- 轻应用删除和周期任务删除从“删除前上报”改为“删除成功后上报”。
+- 任务操作和职能任务认领只在返回 `result=true` 时上报。
+- 公共流程创建周期任务使用 `common_flow_create_periodic_task`，不再统一使用项目流程动作。
+
+## API Server P0 补漏
+
+### 任务类
+
+- `create_task`
+- `create_and_start_task`
+- `fast_create_task`
+- `start_task`
+- `operate_task`
+- `operate_node`
+- `node_callback`
+- `modify_constants_for_task`
+
+任务创建动作根据 `template_source` 和创建方式选择，不使用固定 action ID。
+
+### 周期任务和计划任务
+
+- `create_periodic_task`
+- `set_periodic_task_enabled`
+- `modify_cron_for_periodic_task`
+- `modify_constants_for_periodic_task`
+- `create_clocked_task`
+
+周期任务创建根据项目流程或公共流程选择对应创建动作。
+
+### 流程类
+
+- `import_project_template`
+- `import_common_template`
+- `copy_template_across_project`
+- 已有 `create_template` 保留并补测试
+
+### 项目和流程配置
+
+- `register_project`
+- `claim_functionalization_task`
+- `apply_webhook_configs`
+- `modify_project_executor_proxy`
+- 已有 `modify_template_notify`、`modify_template_executor_proxy` 保留并补测试
+
+Webhook 批量配置按实际受影响模板逐条使用 `flow_edit` 上报，不记录 Webhook 认证信息。
+
+## 明确延期的入口
+
+以下接口一期不发送蓝鲸审计事件：
+
+- `plugin_gateway_create_run`
+- `plugin_gateway_cancel_run`
+- 包源创建、修改、删除和同步
+- 流程市场标签创建
+- API Server 列表、计数、状态轮询、预览和日志读取接口
+- 系统 callback、插件内部 callback 等非用户业务操作
+
+这些入口必须在后续新增合适动作和资源后再接入，不能在一期映射为其他资源。
+
+## API 和权限边界
+
+- 审计调用放在权限校验和参数校验之后，不替代 IAM 校验。
+- 权限拒绝不记录成功业务事件；拒绝事件属于后续安全审计范围。
+- 使用 `project_inject` 的网关接口必须使用 `request.project.id` 和注入后的项目对象构造审计资源，不能重新解释原始 `bk_biz_id/project_id`。
+- 信任应用接口保留当前权限边界，审计操作者使用请求上下文中已验证的用户；项目注册同时保留调用应用信息在现有访问日志中。
+- `dispatch_plugin_query` 本身不产生通用业务审计；如果它调用了已覆盖的底层写入口，由底层入口负责发送事件。
+
+## Token 与部署
+
+代码继续通过以下环境变量控制审计：
+
+- `BK_AUDIT_ENDPOINT`
+- `BK_AUDIT_DATA_TOKEN`
+
+仓库不新增 Token 默认值，也不提交任何真实 Token。
+
+上线顺序：
+
+1. Token 为空时部署一期代码。
+2. 在预发布环境配置 Token，验证 API Server 事件能够被审计中心接收。
+3. 在生产 API Server 少量实例配置 Token 并重启/滚动发布。
+4. 对照 API Server 访问日志、内部操作记录和审计中心实收事件。
+5. 确认身份、动作、资源 ID、成功判定和事件数量一致后，全量 API Server。
+6. 页面模块是否配置 Token 单独发布和核验，不能用 API Server 上线状态代替全站审计状态。
+
+如果后续需要在 Worker 记录异步操作的最终结果，Worker 必须单独配置 Token；该能力不属于一期。
+
+## 测试设计
+
+### 审计底座
+
+- Token 关闭时不构造实例、不调用审计客户端。
+- Token 开启时成功调用一次客户端。
+- 审计客户端异常不影响业务，并产生固定错误标识日志。
+- 事务回滚不发送事件，事务提交只发送一次。
+- 修改事件包含脱敏后的修改前和修改后快照。
+
+### 页面入口
+
+- 每个新增 P0 入口覆盖成功上报和业务失败不上报。
+- 首版提前上报问题覆盖回归测试。
+- 项目/公共流程、一次性任务的动作映射分别验证。
+- 周期任务和计划任务动作映射分别验证。
+
+### API Server
+
+- 每个写接口验证 action ID、resource ID、实例 ID 和调用次数。
+- `create_and_start_task` 验证创建与启动两个事件。
+- 异步投递失败不发送启动成功事件。
+- 批量导入、复制、删除按实际成功实例发送。
+- Webhook 事件不包含 endpoint 认证信息和 extra_info。
+- scope 为 CMDB 业务 ID 或内部项目 ID 时，审计资源均使用解析后的内部实例 ID。
+
+### 回归范围
+
+- 原有请求、响应和 APIGW schema 不变。
+- 原有操作记录 `record_operation` 保持不变，蓝鲸审计不能替代本地操作记录。
+- Token 为空时业务行为、返回值和日志主流程与现状一致。
+
+## 验收标准
+
+一期完成必须同时满足：
+
+1. 范围内所有 P0 页面和 API Server 写操作均有成功路径测试。
+2. 权限失败、参数失败、业务失败和事务回滚不会产生成功审计事件。
+3. 所有事件只使用现有动作和七类现有资源。
+4. 插件网关、包源等延期入口没有被错误映射。
+5. 测试中未出现密钥、变量值、流程树全文和日志正文。
+6. Token 为空时审计客户端调用次数为零。
+7. 预发布配置 Token 后，审计中心能够查询到 API Server 事件。
+8. 生产 Token 通过灰度配置启用，不在代码仓库出现真实密钥。
+
+## 实施与验证记录
+
+- TAPD：[`136920805` 标准运维操作审计一期补漏及 API Server 上报](https://tapd.woa.com/10131351/prong/stories/view/1010131351136920805)。
+- 审计底座、动作映射、批量成功实例、敏感数据脱敏、事务提交/回滚、页面/API Server 静态覆盖和 Webhook 安全摘要共 59 项测试通过。
+- API Server 现有任务、调度、导入、Webhook 和模板配置回归共 69 项测试通过；与审计定向测试合并执行为 `128 passed`。
+- 页面相关扩展回归中 28 项通过；另 13 项被仓库既有测试隔离问题阻塞，根因均为测试 patch 污染 DRF 路由扫描后触发 `MagicMock.__name__`，与审计变更前已确认的基线问题一致。
+- 变更文件通过 Python 3.6 语法编译、Black、Flake8 和 `git diff --check`。
+- `api-resources.yml`、`IAMMeta` 动作/资源配置、`config/default.py`、插件网关、包源和同步入口相对 `upstream/master` 均无差异；仓库未写入 Token 或 Endpoint。
+- 审计中心实收、预发布 API Server Token 开启及生产灰度仍属于部署后验收，不能由本地测试替代。

--- a/gcloud/apigw/views/apply_webhook_configs.py
+++ b/gcloud/apigw/views/apply_webhook_configs.py
@@ -16,21 +16,80 @@ import copy
 import ujson as json
 from apigw_manager.apigw.decorators import apigw_require
 from blueapps.account.decorators import login_exempt
+from django.conf import settings
 from django.db import transaction
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from webhook.models import Subscription, Scope
+from webhook.base_models import Webhook
+from webhook.models import Scope, Subscription
 from webhook.models import Webhook as WebhookModel
 from webhook.utils import process_sensitive_info
-from webhook.base_models import Webhook
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
 from gcloud.apigw.serializers import WebhookSerializer
 from gcloud.apigw.views.utils import logger
 from gcloud.constants import WebhookScopeType
+from gcloud.contrib.audit.instances import AuditSnapshot
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw.apply_webhook_configs import ApplyWebhookConfigs
+from gcloud.tasktmpl3.models import TaskTemplate
+
+
+def _get_webhook_audit_context(project_id, template_ids):
+    if not settings.ENABLE_BK_AUDIT:
+        return {}, {}
+    try:
+        templates = {
+            str(template.id): template
+            for template in TaskTemplate.objects.filter(project_id=project_id, id__in=template_ids, is_deleted=False)
+        }
+        scope_codes = list(templates)
+        enabled_by_template = {
+            str(item["scope_code"]): item.get("enable_webhook", False)
+            for item in WebhookModel.objects.filter(
+                scope_type=WebhookScopeType.TEMPLATE.value, scope_code__in=scope_codes
+            ).values("scope_code", "enable_webhook")
+        }
+        events_by_template = {scope_code: set() for scope_code in scope_codes}
+        for scope_code, event_code in Subscription.objects.filter(
+            scope_type=WebhookScopeType.TEMPLATE.value, scope_code__in=scope_codes
+        ).values_list("scope_code", "event_code"):
+            events_by_template.setdefault(str(scope_code), set()).add(event_code)
+        origins = {
+            scope_code: AuditSnapshot(
+                {
+                    "template_id": template.id,
+                    "webhook_enabled": enabled_by_template.get(scope_code, False),
+                    "event_types": sorted(events_by_template.get(scope_code, set())),
+                }
+            )
+            for scope_code, template in templates.items()
+        }
+        return templates, origins
+    except Exception:
+        logger.exception("bk_audit_webhook_snapshot_failed")
+        return {}, {}
+
+
+def _audit_webhook_changes(username, templates, origins, enabled, events_by_template):
+    for scope_code, template in templates.items():
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.FLOW_EDIT_ACTION,
+            resource_id=IAMMeta.FLOW_RESOURCE,
+            instance=template,
+            origin_data=origins[scope_code],
+            data=AuditSnapshot(
+                {
+                    "template_id": template.id,
+                    "webhook_enabled": enabled,
+                    "event_types": sorted(events_by_template.get(scope_code, [])),
+                }
+            ),
+        )
 
 
 @login_exempt
@@ -61,11 +120,19 @@ def apply_webhook_configs(request, project_id):
     webhook_configs = ser.validated_data
     enable_webhook = webhook_configs.pop("enable_webhook", True)
     template_ids = webhook_configs.pop("template_ids")
+    templates, audit_origins = _get_webhook_audit_context(request.project.id, template_ids)
 
     # 关闭webhook：关闭指定模板的所有webhook开关
     if enable_webhook is False:
         scope_codes = [str(template_id) for template_id in template_ids]
         WebhookModel.objects.filter(scope_type="template", scope_code__in=scope_codes).update(enable_webhook=False)
+        _audit_webhook_changes(
+            request.user.username,
+            templates,
+            audit_origins,
+            False,
+            {scope_code: origin["event_types"] for scope_code, origin in audit_origins.items()},
+        )
         return {"result": True, "message": "success", "code": err_code.SUCCESS.code}
 
     events = webhook_configs.pop("events")
@@ -144,5 +211,13 @@ def apply_webhook_configs(request, project_id):
     except Exception as e:
         logger.exception("apply_webhook_configs error")
         return {"result": False, "message": f"fail: {e}", "code": err_code.UNKNOWN_ERROR.code}
+
+    _audit_webhook_changes(
+        request.user.username,
+        templates,
+        audit_origins,
+        True,
+        {scope_code: events for scope_code in templates},
+    )
 
     return {"result": True, "message": "success", "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/claim_functionalization_task.py
+++ b/gcloud/apigw/views/claim_functionalization_task.py
@@ -13,18 +13,19 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
-from django.views.decorators.http import require_POST
-from django.views.decorators.csrf import csrf_exempt
-
+from apigw_manager.apigw.decorators import apigw_require
 from blueapps.account.decorators import login_exempt
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
 from gcloud import err_code
-from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.apigw.decorators import project_inject
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.apigw.views.utils import logger
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.iam_auth import IAMMeta
+from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import FunctionTaskInterceptor
 from gcloud.taskflow3.models import TaskFlowInstance
-from gcloud.apigw.views.utils import logger
-from gcloud.iam_auth.intercept import iam_intercept
-from apigw_manager.apigw.decorators import apigw_require
 
 
 @login_exempt
@@ -50,6 +51,7 @@ def claim_functionalization_task(request, task_id, project_id):
 
     try:
         task = TaskFlowInstance.objects.get(pk=task_id, project_id=request.project.id)
+        origin_data = get_audit_snapshot(IAMMeta.TASK_RESOURCE, task)
         result = task.task_claim(request.user.username, constants, name)
     except Exception as e:
         logger.exception("[API] claim_functionalization_task fail: {}".format(e))
@@ -61,4 +63,11 @@ def claim_functionalization_task(request, task_id, project_id):
 
     if result["result"] is False:
         return {"result": False, "message": result["message"], "code": err_code.UNKNOWN_ERROR.code}
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.TASK_CLAIM_ACTION,
+        resource_id=IAMMeta.TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
     return {"result": True, "data": result["message"], "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/copy_template_across_project.py
+++ b/gcloud/apigw/views/copy_template_across_project.py
@@ -11,6 +11,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 import json
+
 from apigw_manager.apigw.decorators import apigw_require
 from blueapps.account.decorators import login_exempt
 from django.views.decorators.csrf import csrf_exempt
@@ -18,19 +19,15 @@ from django.views.decorators.http import require_POST
 from pipeline.exceptions import SubprocessExpiredError
 
 from gcloud import err_code
-from gcloud.apigw.decorators import (
-    mark_request_whether_is_trust,
-    project_inject,
-    return_json_response,
-)
-
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.apigw.validators.copy_template_across_project import CopyTemplateAcrossProjectValidator
 from gcloud.apigw.views.utils import logger
+from gcloud.contrib.audit.operations import audit_imported_templates
 from gcloud.iam_auth.intercept import iam_intercept
+from gcloud.iam_auth.view_interceptors.apigw import CopyTemplateInterceptor
 from gcloud.tasktmpl3.models import TaskTemplate
 from gcloud.template_base.utils import format_import_result_to_response_data
 from gcloud.utils.decorators import request_validate
-from gcloud.iam_auth.view_interceptors.apigw import CopyTemplateInterceptor
-from gcloud.apigw.validators.copy_template_across_project import CopyTemplateAcrossProjectValidator
 
 TEMPLATE_COPY_MAX_NUMBER = 10
 
@@ -85,4 +82,5 @@ def copy_template_across_project(request, project_id):
             "code": err_code.UNKNOWN_ERROR.code,
         }
 
+    audit_imported_templates(request.user.username, TaskTemplate, import_result)
     return format_import_result_to_response_data(import_result)

--- a/gcloud/apigw/views/create_and_start_task.py
+++ b/gcloud/apigw/views/create_and_start_task.py
@@ -34,9 +34,12 @@ from gcloud.apigw.views.utils import logger
 from gcloud.common_template.models import CommonTemplate
 from gcloud.conf import settings
 from gcloud.constants import BUSINESS, COMMON, TaskCreateMethod
+from gcloud.contrib.audit.mappings import get_task_create_action
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.models import EngineConfig
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import CreateTaskInterceptor
 from gcloud.taskflow3.celery.tasks import prepare_and_start_task
@@ -195,10 +198,25 @@ def create_and_start_task(request, template_id, project_id):
     arn_creator = AutoRetryNodeStrategyCreator(taskflow_id=task.id, root_pipeline_id=task.pipeline_instance.instance_id)
     arn_creator.batch_create_strategy(task.pipeline_instance.execution_data)
 
+    create_action_id = get_task_create_action(template_source, create_method)
+    if create_action_id:
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=create_action_id,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
+
     prepare_and_start_task.apply_async(
         kwargs=dict(task_id=task.id, project_id=project.id, username=request.user.username),
         queue=queue,
         routing_key=routing_key,
+    )
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.TASK_OPERATE_ACTION,
+        resource_id=IAMMeta.TASK_RESOURCE,
+        instance=task,
     )
 
     return {

--- a/gcloud/apigw/views/create_clocked_task.py
+++ b/gcloud/apigw/views/create_clocked_task.py
@@ -12,24 +12,25 @@ specific language governing permissions and limitations under the License.
 """
 
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from rest_framework.exceptions import ValidationError
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
-from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.apigw.decorators import project_inject
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.apigw.validators import CreateTaskValidator
+from gcloud.apigw.views.utils import logger
 from gcloud.clocked_task.models import ClockedTask
 from gcloud.clocked_task.serializer import ClockedTaskSerializer
 from gcloud.constants import PROJECT
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.iam_auth import IAMMeta
+from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw.create_clocked_task import CreateClockedTaskInterceptor
 from gcloud.tasktmpl3.models import TaskTemplate
-from gcloud.apigw.views.utils import logger
-from gcloud.apigw.validators import CreateTaskValidator
 from gcloud.utils.decorators import request_validate
-from gcloud.iam_auth.intercept import iam_intercept
-from apigw_manager.apigw.decorators import apigw_require
 
 
 @login_exempt
@@ -59,7 +60,11 @@ def create_clocked_task(request, template_id, project_id):
         result = {
             "result": False,
             "message": "template[id={template_id}] of project[project_id={project_id} , biz_id{biz_id}] "
-            "does not exist".format(template_id=template_id, project_id=project.id, biz_id=project.bk_biz_id,),
+            "does not exist".format(
+                template_id=template_id,
+                project_id=project.id,
+                biz_id=project.bk_biz_id,
+            ),
             "code": err_code.CONTENT_NOT_EXIST.code,
         }
         return result
@@ -86,6 +91,12 @@ def create_clocked_task(request, template_id, project_id):
         return result
 
     task = ClockedTask.objects.create_task(**validated_data, creator=request.user.username)
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.FLOW_CREATE_CLOCKED_TASK_ACTION,
+        resource_id=IAMMeta.CLOCKED_TASK_RESOURCE,
+        instance=task,
+    )
     response_serializer = ClockedTaskSerializer(instance=task)
     response_data = response_serializer.data
     response_data.pop("clocked_task_id")

--- a/gcloud/apigw/views/create_periodic_task.py
+++ b/gcloud/apigw/views/create_periodic_task.py
@@ -27,7 +27,10 @@ from gcloud.apigw.validators import CreatePriodicTaskValidator
 from gcloud.apigw.views.utils import info_data_from_period_task, logger
 from gcloud.common_template.models import CommonTemplate
 from gcloud.constants import NON_COMMON_TEMPLATE_TYPES, PROJECT
+from gcloud.contrib.audit.mappings import get_periodic_task_create_action
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.core.models import ProjectConfig
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import CreatePeriodicTaskInterceptor
 from gcloud.periodictask.models import PeriodicTask
@@ -140,5 +143,13 @@ def create_periodic_task(request, template_id, project_id):
         logger.exception("[API] create_periodic_task create error: {}".format(e))
         return {"result": False, "message": str(e), "code": err_code.UNKNOWN_ERROR.code}
 
+    action_id = get_periodic_task_create_action(template_source)
+    if action_id:
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=action_id,
+            resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+            instance=task,
+        )
     data = info_data_from_period_task(task, include_edit_info=include_edit_info)
     return {"result": True, "data": data, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/create_task.py
+++ b/gcloud/apigw/views/create_task.py
@@ -34,10 +34,13 @@ from gcloud.apigw.views.utils import logger
 from gcloud.common_template.models import CommonTemplate
 from gcloud.conf import settings
 from gcloud.constants import NON_COMMON_TEMPLATE_TYPES, PROJECT, TaskCreateMethod
+from gcloud.contrib.audit.mappings import get_task_create_action
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.models import EngineConfig
 from gcloud.core.trace import CallFrom, trace_view
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import CreateTaskInterceptor
 from gcloud.taskflow3.domains.auto_retry import AutoRetryNodeStrategyCreator
@@ -240,6 +243,14 @@ def create_task(request, template_id, project_id):
         root_pipeline_id=task.pipeline_instance.instance_id,
         pipeline_tree=task.pipeline_instance.execution_data,
     )
+    action_id = get_task_create_action(template_source, create_method)
+    if action_id:
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=action_id,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     result_data = {"task_id": task.id, "task_url": task.url, "pipeline_tree": task.pipeline_tree}
     if task.flow_type == "common_func":
         result_data["function_task_claim_url"] = task.get_function_task_claim_url()

--- a/gcloud/apigw/views/create_template.py
+++ b/gcloud/apigw/views/create_template.py
@@ -22,7 +22,7 @@ from django.views.decorators.http import require_POST
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
 from gcloud.apigw.views.utils import logger
-from gcloud.contrib.audit.utils import bk_audit_add_event
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.iam_auth import IAMMeta
@@ -200,7 +200,7 @@ def create_template(request, project_id):
     )
 
     # 5. 审计上报
-    bk_audit_add_event(
+    bk_audit_add_event_on_commit(
         username=creator,
         action_id=IAMMeta.FLOW_CREATE_ACTION,
         resource_id=IAMMeta.FLOW_RESOURCE,

--- a/gcloud/apigw/views/fast_create_task.py
+++ b/gcloud/apigw/views/fast_create_task.py
@@ -24,8 +24,11 @@ from gcloud.apigw.validators import FastCreateTaskValidator
 from gcloud.apigw.views.utils import logger
 from gcloud.common_template.models import CommonTemplate
 from gcloud.constants import ONETIME, TASK_CATEGORY, TASK_NAME_MAX_LENGTH, TaskCreateMethod
+from gcloud.contrib.audit.mappings import get_task_create_action
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import FastCreateTaskInterceptor
 from gcloud.taskflow3.models import TaskFlowInstance
@@ -102,6 +105,12 @@ def fast_create_task(request, project_id):
         taskflow_kwargs["flow_type"] = "common"
         taskflow_kwargs["current_flow"] = "execute_task"
     task = TaskFlowInstance.objects.create(**taskflow_kwargs)
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=get_task_create_action(ONETIME),
+        resource_id=IAMMeta.TASK_RESOURCE,
+        instance=task,
+    )
     return {
         "result": True,
         "data": {"task_id": task.id, "task_url": task.url, "pipeline_tree": task.pipeline_tree},

--- a/gcloud/apigw/views/import_common_template.py
+++ b/gcloud/apigw/views/import_common_template.py
@@ -23,10 +23,8 @@ from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
 from gcloud.apigw.views.utils import logger
 from gcloud.common_template.models import CommonTemplate
-from gcloud.template_base.utils import (
-    format_import_result_to_response_data,
-    read_encoded_template_data,
-)
+from gcloud.contrib.audit.operations import audit_imported_templates
+from gcloud.template_base.utils import format_import_result_to_response_data, read_encoded_template_data
 
 
 @login_exempt
@@ -73,4 +71,5 @@ def import_common_template(request):
             "code": err_code.UNKNOWN_ERROR.code,
         }
 
+    audit_imported_templates(request.user.username, CommonTemplate, import_result)
     return format_import_result_to_response_data(import_result)

--- a/gcloud/apigw/views/import_project_template.py
+++ b/gcloud/apigw/views/import_project_template.py
@@ -19,17 +19,11 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from gcloud import err_code
-from gcloud.apigw.decorators import (
-    mark_request_whether_is_trust,
-    project_inject,
-    return_json_response,
-)
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
 from gcloud.apigw.views.utils import logger
+from gcloud.contrib.audit.operations import audit_imported_templates
 from gcloud.tasktmpl3.models import TaskTemplate
-from gcloud.template_base.utils import (
-    format_import_result_to_response_data,
-    read_encoded_template_data,
-)
+from gcloud.template_base.utils import format_import_result_to_response_data, read_encoded_template_data
 
 
 @login_exempt
@@ -78,4 +72,5 @@ def import_project_template(request, project_id):
             "code": err_code.UNKNOWN_ERROR.code,
         }
 
+    audit_imported_templates(request.user.username, TaskTemplate, import_result)
     return format_import_result_to_response_data(import_result)

--- a/gcloud/apigw/views/modify_constants_for_periodic_task.py
+++ b/gcloud/apigw/views/modify_constants_for_periodic_task.py
@@ -13,17 +13,18 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
-from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.apigw.decorators import project_inject
-from gcloud.periodictask.models import PeriodicTask
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import PeriodicTaskEditInterceptor
-from apigw_manager.apigw.decorators import apigw_require
+from gcloud.periodictask.models import PeriodicTask
 
 
 @login_exempt
@@ -52,9 +53,18 @@ def modify_constants_for_periodic_task(request, task_id, project_id):
             "code": err_code.CONTENT_NOT_EXIST.code,
         }
 
+    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
     try:
         new_constants = task.modify_constants(constants)
     except Exception as e:
         return {"result": False, "message": str(e), "code": err_code.UNKNOWN_ERROR.code}
+
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
+        resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
 
     return {"result": True, "data": new_constants, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/modify_constants_for_periodic_task.py
+++ b/gcloud/apigw/views/modify_constants_for_periodic_task.py
@@ -20,7 +20,7 @@ from django.views.decorators.http import require_POST
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_periodic_task_audit_snapshot
 from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import PeriodicTaskEditInterceptor
@@ -53,7 +53,7 @@ def modify_constants_for_periodic_task(request, task_id, project_id):
             "code": err_code.CONTENT_NOT_EXIST.code,
         }
 
-    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
+    origin_data = get_periodic_task_audit_snapshot(task)
     try:
         new_constants = task.modify_constants(constants)
     except Exception as e:
@@ -65,6 +65,7 @@ def modify_constants_for_periodic_task(request, task_id, project_id):
         resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
         instance=task,
         origin_data=origin_data,
+        data=get_periodic_task_audit_snapshot(task),
     )
 
     return {"result": True, "data": new_constants, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/modify_constants_for_task.py
+++ b/gcloud/apigw/views/modify_constants_for_task.py
@@ -13,17 +13,18 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
-from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.apigw.decorators import project_inject
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskEditInterceptor
 from gcloud.taskflow3.models import TaskFlowInstance
-from apigw_manager.apigw.decorators import apigw_require
 
 
 @login_exempt
@@ -49,10 +50,19 @@ def modify_constants_for_task(request, task_id, project_id):
     if task.is_finished:
         return {"result": False, "message": "task is finished", "code": err_code.REQUEST_PARAM_INVALID.code}
 
+    origin_data = get_audit_snapshot(IAMMeta.TASK_RESOURCE, task)
     constants = params.get("constants", {})
     reset_result = task.set_task_constants(constants)
 
     if reset_result["result"] is False:
         return {"result": False, "message": reset_result["message"], "code": err_code.REQUEST_PARAM_INVALID.code}
+
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.TASK_EDIT_ACTION,
+        resource_id=IAMMeta.TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
 
     return {"result": True, "data": reset_result["data"], "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/modify_cron_for_periodic_task.py
+++ b/gcloud/apigw/views/modify_cron_for_periodic_task.py
@@ -13,17 +13,18 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
-from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.apigw.decorators import project_inject
-from gcloud.periodictask.models import PeriodicTask
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import PeriodicTaskEditInterceptor
-from apigw_manager.apigw.decorators import apigw_require
+from gcloud.periodictask.models import PeriodicTask
 
 
 @login_exempt
@@ -53,9 +54,18 @@ def modify_cron_for_periodic_task(request, task_id, project_id):
             "code": err_code.CONTENT_NOT_EXIST.code,
         }
 
+    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
     try:
         task.modify_cron(cron, tz)
     except Exception as e:
         return {"result": False, "message": str(e), "code": err_code.UNKNOWN_ERROR.code}
+
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
+        resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
 
     return {"result": True, "data": {"cron": task.cron}, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/modify_cron_for_periodic_task.py
+++ b/gcloud/apigw/views/modify_cron_for_periodic_task.py
@@ -20,7 +20,7 @@ from django.views.decorators.http import require_POST
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_periodic_task_audit_snapshot
 from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import PeriodicTaskEditInterceptor
@@ -54,7 +54,7 @@ def modify_cron_for_periodic_task(request, task_id, project_id):
             "code": err_code.CONTENT_NOT_EXIST.code,
         }
 
-    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
+    origin_data = get_periodic_task_audit_snapshot(task)
     try:
         task.modify_cron(cron, tz)
     except Exception as e:
@@ -66,6 +66,7 @@ def modify_cron_for_periodic_task(request, task_id, project_id):
         resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
         instance=task,
         origin_data=origin_data,
+        data=get_periodic_task_audit_snapshot(task),
     )
 
     return {"result": True, "data": {"cron": task.cron}, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/modify_project_executor_proxy.py
+++ b/gcloud/apigw/views/modify_project_executor_proxy.py
@@ -12,18 +12,20 @@ specific language governing permissions and limitations under the License.
 """
 
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from rest_framework import serializers
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
-from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.apigw.decorators import project_inject
+from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.instances import AuditSnapshot
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.core.models import ProjectConfig
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw.project_edit import ProjectEditInterceptor
-from gcloud.core.models import ProjectConfig
-from apigw_manager.apigw.decorators import apigw_require
-from rest_framework import serializers
 
 
 class ProjectExecutorProxySerializer(serializers.ModelSerializer):
@@ -74,25 +76,43 @@ def modify_project_executor_proxy(request, project_id):
     try:
         project_config, created = ProjectConfig.objects.get_or_create(project_id=project.id)
     except Exception as e:
-        return {"result": False, "message": f"Failed to get project config: {str(e)}",
-                "code": err_code.UNKNOWN_ERROR.code}
+        return {
+            "result": False,
+            "message": f"Failed to get project config: {str(e)}",
+            "code": err_code.UNKNOWN_ERROR.code,
+        }
 
     # 使用专用序列化器进行参数校验和更新（仅允许修改 executor_proxy / executor_proxy_exempts）
     serializer = ProjectExecutorProxySerializer(
         instance=project_config,
         data=params,
-        context={'request': request},
+        context={"request": request},
     )
 
     if not serializer.is_valid():
-        return {
-            "result": False,
-            "message": serializer.errors,
-            "code": err_code.REQUEST_PARAM_INVALID.code
-        }
+        return {"result": False, "message": serializer.errors, "code": err_code.REQUEST_PARAM_INVALID.code}
 
     # 更新配置
+    origin_data = AuditSnapshot(
+        {
+            "executor_proxy": project_config.executor_proxy,
+            "executor_proxy_exempts": project_config.executor_proxy_exempts,
+        }
+    )
     serializer.save()
     data = dict(serializer.validated_data)
     data["project_id"] = project.id
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PROJECT_EDIT_ACTION,
+        resource_id=IAMMeta.PROJECT_RESOURCE,
+        instance=project,
+        origin_data=origin_data,
+        data=AuditSnapshot(
+            {
+                "executor_proxy": project_config.executor_proxy,
+                "executor_proxy_exempts": project_config.executor_proxy_exempts,
+            }
+        ),
+    )
     return {"result": True, "data": data, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/modify_template_executor_proxy.py
+++ b/gcloud/apigw/views/modify_template_executor_proxy.py
@@ -23,7 +23,7 @@ from rest_framework import serializers
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.signal import operate_record_signal
 from gcloud.iam_auth import IAMMeta
@@ -32,7 +32,6 @@ from gcloud.iam_auth.view_interceptors.apigw import TemplateEditInterceptor
 from gcloud.tasktmpl3.models import TaskTemplate
 from gcloud.tasktmpl3.signals import post_template_save_commit
 from gcloud.template_base.domains.template_manager import TemplateManager
-
 
 manager = TemplateManager(template_model_cls=TaskTemplate)
 
@@ -43,9 +42,7 @@ class ExecutorProxySerializer(serializers.Serializer):
     走完整的 required/type 校验，避免手动 params.get 绕过
     """
 
-    executor_proxy = serializers.CharField(
-        help_text="执行代理人", required=True, allow_blank=True, allow_null=False
-    )
+    executor_proxy = serializers.CharField(help_text="执行代理人", required=True, allow_blank=True, allow_null=False)
 
     def validate_executor_proxy(self, value):
         user = getattr(self.context.get("request"), "user", None)
@@ -93,6 +90,7 @@ def modify_template_executor_proxy(request, template_id, project_id):
         }
 
     editor = request.user.username
+    origin_data = get_audit_snapshot(IAMMeta.FLOW_RESOURCE, template)
 
     # 走模板正常更新链路：
     with transaction.atomic():
@@ -100,7 +98,8 @@ def modify_template_executor_proxy(request, template_id, project_id):
         template.save(update_fields=["executor_proxy"])
 
         update_result = manager.update_pipeline(
-            pipeline_template=template.pipeline_template, editor=editor,
+            pipeline_template=template.pipeline_template,
+            editor=editor,
         )
         if not update_result["result"]:
             return {
@@ -128,11 +127,12 @@ def modify_template_executor_proxy(request, template_id, project_id):
     )
 
     # 审计上报
-    bk_audit_add_event(
+    bk_audit_add_event_on_commit(
         username=editor,
         action_id=IAMMeta.FLOW_EDIT_ACTION,
         resource_id=IAMMeta.FLOW_RESOURCE,
         instance=template,
+        origin_data=origin_data,
     )
 
     return {

--- a/gcloud/apigw/views/modify_template_notify.py
+++ b/gcloud/apigw/views/modify_template_notify.py
@@ -22,17 +22,17 @@ from rest_framework import serializers
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
 from gcloud.common_template.models import CommonTemplate
+from gcloud.conf import settings
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
+from gcloud.contrib.operate_record.signal import operate_record_signal
 from gcloud.core.apis.drf.serilaziers.staff_group import StaffGroupSetSerializer
 from gcloud.core.models import StaffGroupSet
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw.modify_template_notify import NotifyTemplateInterceptor
 from gcloud.tasktmpl3.models import TaskTemplate
-from gcloud.conf import settings
 from gcloud.tasktmpl3.signals import post_template_save_commit
-from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
-from gcloud.contrib.operate_record.signal import operate_record_signal
-from gcloud.iam_auth import IAMMeta
-from gcloud.contrib.audit.utils import bk_audit_add_event
 from gcloud.template_base.domains.template_manager import TemplateManager
 
 get_client_by_user = settings.ESB_GET_CLIENT_BY_USER
@@ -46,6 +46,7 @@ class TemplateNotifyUpdateSerializer(serializers.Serializer):
     专门用于更新模板通知设置的序列化器
     只处理notify_type和notify_receivers字段，避免pipeline_tree校验
     """
+
     notify_type = serializers.CharField(required=True, allow_blank=False)
     notify_receivers = serializers.CharField(required=True, allow_blank=False)
 
@@ -55,14 +56,14 @@ class TemplateNotifyUpdateSerializer(serializers.Serializer):
             return value
 
         # 获取支持的通知类型
-        request = self.context.get('request')
+        request = self.context.get("request")
         if not request:
             return value
 
         client = get_client_by_user(request.user.username)
         result = client.cmsi.get_msg_type()
         if result.get("result"):
-            supported_notify_types = [item['type'] for item in result['data']]
+            supported_notify_types = [item["type"] for item in result["data"]]
         else:
             raise serializers.ValidationError("获取通知类型失败")
 
@@ -84,7 +85,7 @@ class TemplateNotifyUpdateSerializer(serializers.Serializer):
 
         notify_data = json.loads(value)
 
-        request = self.context.get('request')
+        request = self.context.get("request")
         if not request:
             return value
 
@@ -121,11 +122,11 @@ class TemplateNotifyUpdateSerializer(serializers.Serializer):
         queryset = StaffGroupSet.objects.filter(is_deleted=False, project_id=request.project.id)
         serializer = StaffGroupSetSerializer(queryset, many=True)
         # 统一转换为字符串类型，兼容客户端传入整型 ID 或字符串 ID 的情况
-        supported_groups = [str(item['id']) for item in serializer.data]
+        supported_groups = [str(item["id"]) for item in serializer.data]
         supported_groups.extend(DEFAULT_NOTIFY_GROUPS)
 
         # 将客户端传入的 receiver_group 元素也统一转换为字符串再做子集判断
-        receiver_group = [str(group) for group in notify_data.get('receiver_group', [])]
+        receiver_group = [str(group) for group in notify_data.get("receiver_group", [])]
         if not set(receiver_group).issubset(set(supported_groups)):
             raise serializers.ValidationError(f"receiver_group必须包含在支持的用户组中: {supported_groups}")
         return value
@@ -135,25 +136,19 @@ class TemplateNotifyUpdateSerializer(serializers.Serializer):
         更新模板的通知设置
         """
         # 更新notify_type字段
-        if 'notify_type' in validated_data:
-            instance.notify_type = validated_data['notify_type']
+        if "notify_type" in validated_data:
+            instance.notify_type = validated_data["notify_type"]
 
         # 更新notify_receivers字段
-        if 'notify_receivers' in validated_data:
-            instance.notify_receivers = validated_data['notify_receivers']
+        if "notify_receivers" in validated_data:
+            instance.notify_receivers = validated_data["notify_receivers"]
 
-        request = self.context.get('request')
+        request = self.context.get("request")
         editor = request.user.username
         if self.context.get("common", False):
-            result = common_manager.update_pipeline(
-                pipeline_template=instance.pipeline_template,
-                editor=editor
-            )
+            result = common_manager.update_pipeline(pipeline_template=instance.pipeline_template, editor=editor)
         else:
-            result = task_manager.update_pipeline(
-                pipeline_template=instance.pipeline_template,
-                editor=editor
-            )
+            result = task_manager.update_pipeline(pipeline_template=instance.pipeline_template, editor=editor)
         if not result["result"]:
             message = result["message"]
             raise serializers.ValidationError(message)
@@ -196,7 +191,7 @@ def modify_template_notify(request, template_id, project_id):
         return {
             "result": False,
             "message": "Invalid notify_type, expected a dictionary",
-            "code": err_code.REQUEST_PARAM_INVALID.code
+            "code": err_code.REQUEST_PARAM_INVALID.code,
         }
 
     # 顶层类型校验 - notify_receivers必须是字典
@@ -204,7 +199,7 @@ def modify_template_notify(request, template_id, project_id):
         return {
             "result": False,
             "message": "Invalid notify_receivers, expected a dictionary",
-            "code": err_code.REQUEST_PARAM_INVALID.code
+            "code": err_code.REQUEST_PARAM_INVALID.code,
         }
 
     # 详细的字段校验将在序列化器中完成
@@ -227,31 +222,27 @@ def modify_template_notify(request, template_id, project_id):
         return {
             "result": False,
             "message": "(%s) template not found" % template_id,
-            "code": err_code.CONTENT_NOT_EXIST.code
+            "code": err_code.CONTENT_NOT_EXIST.code,
         }
 
     # 使用专门的通知更新序列化器
-    update_data = {
-        "notify_type": json.dumps(param_notify_type),
-        "notify_receivers": json.dumps(param_notify_receivers)
-    }
+    update_data = {"notify_type": json.dumps(param_notify_type), "notify_receivers": json.dumps(param_notify_receivers)}
 
     # 使用TemplateNotifyUpdateSerializer进行部分更新
     serializer = TemplateNotifyUpdateSerializer(
-        template,
-        data=update_data,
-        partial=True,
-        context={"request": request, "common": is_common}
+        template, data=update_data, partial=True, context={"request": request, "common": is_common}
     )
     if not serializer.is_valid():
         return {
             "result": False,
             "message": "Invalid update data",
             "code": err_code.REQUEST_PARAM_INVALID.code,
-            "errors": serializer.errors
+            "errors": serializer.errors,
         }
 
     # 保存更新
+    resource_id = IAMMeta.COMMON_FLOW_RESOURCE if is_common else IAMMeta.FLOW_RESOURCE
+    origin_data = get_audit_snapshot(resource_id, template)
     serializer.save()
 
     # 发送信号和记录操作流水
@@ -266,11 +257,12 @@ def modify_template_notify(request, template_id, project_id):
             operate_source=OperateSource.api.name,
             instance_id=template.id,
         )
-        bk_audit_add_event(
+        bk_audit_add_event_on_commit(
             username=request.user.username,
             action_id=IAMMeta.COMMON_FLOW_EDIT_ACTION,
             resource_id=IAMMeta.COMMON_FLOW_RESOURCE,
             instance=template,
+            origin_data=origin_data,
         )
     else:
         post_template_save_commit.send(
@@ -288,18 +280,19 @@ def modify_template_notify(request, template_id, project_id):
             instance_id=template.id,
             project_id=template.project.id,
         )
-        bk_audit_add_event(
+        bk_audit_add_event_on_commit(
             username=request.user.username,
             action_id=IAMMeta.FLOW_EDIT_ACTION,
             resource_id=IAMMeta.FLOW_RESOURCE,
             instance=template,
+            origin_data=origin_data,
         )
     return {
         "result": True,
         "data": {
             "notify_type": param_notify_type,
             "notify_receivers": param_notify_receivers,
-            "template_id": int(template_id)
+            "template_id": int(template_id),
         },
-        "code": err_code.SUCCESS.code
+        "code": err_code.SUCCESS.code,
     }

--- a/gcloud/apigw/views/node_callback.py
+++ b/gcloud/apigw/views/node_callback.py
@@ -21,7 +21,9 @@ from django.views.decorators.http import require_POST
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
 from gcloud.apigw.views.utils import logger
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.core.trace import CallFrom, trace_view
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskOperateInterceptor
 from gcloud.taskflow3.models import TaskFlowInstance
@@ -62,5 +64,12 @@ def node_callback(request, task_id, project_id):
 
     logger.info("[apigw][node_callback] node_callback start, task_id={}".format(task_id))
     result = task.callback(node_id, callback_data, version)
+    if result.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     logger.info("[apigw][node_callback] node_callback finished, task_id={}".format(task_id))
     return result

--- a/gcloud/apigw/views/operate_node.py
+++ b/gcloud/apigw/views/operate_node.py
@@ -20,9 +20,11 @@ from django.views.decorators.http import require_POST
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskOperateInterceptor
 from gcloud.taskflow3.models import TaskFlowInstance
@@ -75,5 +77,12 @@ def operate_node(request, project_id, task_id):
     }
     task = TaskFlowInstance.objects.get(pk=task_id)
     result = task.nodes_action(action, node_id, username, **kwargs)
+    if result.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     result["code"] = err_code.SUCCESS.code if result["result"] else err_code.UNKNOWN_ERROR.code
     return result

--- a/gcloud/apigw/views/operate_task.py
+++ b/gcloud/apigw/views/operate_task.py
@@ -66,7 +66,9 @@ def operate_task(request, task_id, project_id):
             return {"result": False, "code": err_code.INVALID_OPERATION.code, "message": "task already started"}
 
         task = (
-            TaskFlowInstance.objects.get(pk=task_id, project_id=project.id, is_deleted=False)
+            TaskFlowInstance.objects.filter(pk=task_id, project_id=project.id)
+            .select_related("pipeline_instance")
+            .first()
             if settings.ENABLE_BK_AUDIT
             else None
         )

--- a/gcloud/apigw/views/operate_task.py
+++ b/gcloud/apigw/views/operate_task.py
@@ -22,9 +22,11 @@ from django.views.decorators.http import require_POST
 import env
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskOperateInterceptor
 from gcloud.taskflow3.celery.tasks import prepare_and_start_task
@@ -63,12 +65,24 @@ def operate_task(request, task_id, project_id):
         if TaskFlowInstance.objects.is_task_started(project_id=project.id, id=task_id):
             return {"result": False, "code": err_code.INVALID_OPERATION.code, "message": "task already started"}
 
+        task = (
+            TaskFlowInstance.objects.get(pk=task_id, project_id=project.id, is_deleted=False)
+            if settings.ENABLE_BK_AUDIT
+            else None
+        )
+
         queue, routing_key = PrepareAndStartTaskQueueResolver(
             settings.API_TASK_QUEUE_NAME_V2
         ).resolve_task_queue_and_routing_key()
 
         prepare_and_start_task.apply_async(
             kwargs=dict(task_id=task_id, project_id=project.id, username=username), queue=queue, routing_key=routing_key
+        )
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
         )
 
         return {
@@ -79,4 +93,11 @@ def operate_task(request, task_id, project_id):
 
     task = TaskFlowInstance.objects.get(pk=task_id, project_id=project.id, is_deleted=False)
     ctx = task.task_action(action, username)
+    if ctx.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     return ctx

--- a/gcloud/apigw/views/register_project.py
+++ b/gcloud/apigw/views/register_project.py
@@ -12,17 +12,20 @@ specific language governing permissions and limitations under the License.
 """
 
 import logging
+
 import ujson as json
+from apigw_manager.apigw.decorators import apigw_require
+from blueapps.account.decorators import login_exempt
 from django.http import JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from blueapps.account.decorators import login_exempt
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, return_json_response
-from gcloud.core.models import EnvironmentVariables, Business, Project
-from apigw_manager.apigw.decorators import apigw_require
 from gcloud.conf import settings
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.core.models import Business, EnvironmentVariables, Project
+from gcloud.iam_auth import IAMMeta
 
 logger = logging.getLogger("root")
 get_client_by_user = settings.ESB_GET_CLIENT_BY_USER
@@ -99,6 +102,13 @@ def register_project(request):
         message = "[api register_project] Error exists when create object: {}".format(e)
         logger.exception(message)
         return JsonResponse({"result": False, "message": message, "code": err_code.UNKNOWN_ERROR.code})
+
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PROJECT_EDIT_ACTION,
+        resource_id=IAMMeta.PROJECT_RESOURCE,
+        instance=project,
+    )
 
     return JsonResponse(
         {

--- a/gcloud/apigw/views/set_periodic_task_enabled.py
+++ b/gcloud/apigw/views/set_periodic_task_enabled.py
@@ -20,6 +20,8 @@ from django.views.decorators.http import require_POST
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import PeriodicTaskEditInterceptor
 from gcloud.periodictask.models import PeriodicTask
@@ -51,7 +53,15 @@ def set_periodic_task_enabled(request, task_id, project_id):
             "code": err_code.CONTENT_NOT_EXIST.code,
         }
 
+    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
     task.set_enabled(enabled)
     task.editor = request.user.username
     task.save(update_fields=["editor", "edit_time"])
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
+        resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
     return {"result": True, "data": {"enabled": task.enabled}, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/set_periodic_task_enabled.py
+++ b/gcloud/apigw/views/set_periodic_task_enabled.py
@@ -20,7 +20,7 @@ from django.views.decorators.http import require_POST
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_periodic_task_audit_snapshot
 from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import PeriodicTaskEditInterceptor
@@ -53,7 +53,7 @@ def set_periodic_task_enabled(request, task_id, project_id):
             "code": err_code.CONTENT_NOT_EXIST.code,
         }
 
-    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
+    origin_data = get_periodic_task_audit_snapshot(task)
     task.set_enabled(enabled)
     task.editor = request.user.username
     task.save(update_fields=["editor", "edit_time"])
@@ -63,5 +63,6 @@ def set_periodic_task_enabled(request, task_id, project_id):
         resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
         instance=task,
         origin_data=origin_data,
+        data=get_periodic_task_audit_snapshot(task),
     )
     return {"result": True, "data": {"enabled": task.enabled}, "code": err_code.SUCCESS.code}

--- a/gcloud/apigw/views/start_task.py
+++ b/gcloud/apigw/views/start_task.py
@@ -20,9 +20,11 @@ from django.views.decorators.http import require_POST
 import env
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.apigw import TaskOperateInterceptor
 from gcloud.taskflow3.celery.tasks import prepare_and_start_task
@@ -55,12 +57,24 @@ def start_task(request, task_id, project_id):
     if TaskFlowInstance.objects.is_task_started(project_id=project.id, id=task_id):
         return {"result": False, "code": err_code.INVALID_OPERATION.code, "message": "task already started"}
 
+    task = (
+        TaskFlowInstance.objects.get(pk=task_id, project_id=project.id, is_deleted=False)
+        if settings.ENABLE_BK_AUDIT
+        else None
+    )
+
     queue, routing_key = PrepareAndStartTaskQueueResolver(
         settings.API_TASK_QUEUE_NAME_V2
     ).resolve_task_queue_and_routing_key()
 
     prepare_and_start_task.apply_async(
         kwargs=dict(task_id=task_id, project_id=project.id, username=username), queue=queue, routing_key=routing_key
+    )
+    bk_audit_add_event_on_commit(
+        username=username,
+        action_id=IAMMeta.TASK_OPERATE_ACTION,
+        resource_id=IAMMeta.TASK_RESOURCE,
+        instance=task,
     )
 
     task_url = TaskFlowInstance.task_url(project_id=project.id, task_id=task_id)

--- a/gcloud/apigw/views/start_task.py
+++ b/gcloud/apigw/views/start_task.py
@@ -58,7 +58,7 @@ def start_task(request, task_id, project_id):
         return {"result": False, "code": err_code.INVALID_OPERATION.code, "message": "task already started"}
 
     task = (
-        TaskFlowInstance.objects.get(pk=task_id, project_id=project.id, is_deleted=False)
+        TaskFlowInstance.objects.filter(pk=task_id, project_id=project.id).select_related("pipeline_instance").first()
         if settings.ENABLE_BK_AUDIT
         else None
     )

--- a/gcloud/clocked_task/viewset.py
+++ b/gcloud/clocked_task/viewset.py
@@ -12,15 +12,16 @@ specific language governing permissions and limitations under the License.
 """
 
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import viewsets, permissions, status
+from rest_framework import permissions, status, viewsets
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.response import Response
 
 from gcloud.clocked_task.models import ClockedTask
 from gcloud.clocked_task.permissions import ClockedTaskPermissions
-from gcloud.clocked_task.serializer import ClockedTaskSerializer, ClockedTaskPatchSerializer
+from gcloud.clocked_task.serializer import ClockedTaskPatchSerializer, ClockedTaskSerializer
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.core.apis.drf.viewsets import ApiMixin, IAMMixin
-from gcloud.iam_auth import get_iam_client, IAMMeta
+from gcloud.iam_auth import IAMMeta, get_iam_client
 from gcloud.iam_auth.resource_helpers.clocked_task import ClockedTaskResourceHelper
 from gcloud.iam_auth.utils import get_flow_allowed_actions_for_user
 
@@ -82,6 +83,12 @@ class ClockedTaskViewSet(ApiMixin, IAMMixin, viewsets.ModelViewSet):
         auth_actions = self.iam_get_instance_auth_actions(request, instance)
         if auth_actions:
             deserialized_instance["auth_actions"] = auth_actions
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=IAMMeta.CLOCKED_TASK_VIEW_ACTION,
+            resource_id=IAMMeta.CLOCKED_TASK_RESOURCE,
+            instance=instance,
+        )
         return Response(deserialized_instance)
 
     def create(self, request, *args, **kwargs):
@@ -91,10 +98,17 @@ class ClockedTaskViewSet(ApiMixin, IAMMixin, viewsets.ModelViewSet):
         validated_data["creator"] = request.user.username
         task = ClockedTask.objects.create_task(**validated_data)
         response_serializer = self.serializer_class(instance=task)
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=IAMMeta.FLOW_CREATE_CLOCKED_TASK_ACTION,
+            resource_id=IAMMeta.CLOCKED_TASK_RESOURCE,
+            instance=task,
+        )
         return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
+        origin_data = get_audit_snapshot(IAMMeta.CLOCKED_TASK_RESOURCE, instance)
         if "plan_start_time" in request.data:
             serializer = self.get_serializer(
                 instance, data={"plan_start_time": request.data.pop("plan_start_time")}, partial=True
@@ -106,4 +120,26 @@ class ClockedTaskViewSet(ApiMixin, IAMMixin, viewsets.ModelViewSet):
         serializer = ClockedTaskPatchSerializer(instance, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
         self.perform_update(serializer)
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=IAMMeta.CLOCKED_TASK_EDIT_ACTION,
+            resource_id=IAMMeta.CLOCKED_TASK_RESOURCE,
+            instance=instance,
+            origin_data=origin_data,
+        )
         return Response(serializer.data)
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        instance_id = instance.id
+        origin_data = get_audit_snapshot(IAMMeta.CLOCKED_TASK_RESOURCE, instance)
+        response = super(ClockedTaskViewSet, self).destroy(request, *args, **kwargs)
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=IAMMeta.CLOCKED_TASK_DELETE_ACTION,
+            resource_id=IAMMeta.CLOCKED_TASK_RESOURCE,
+            instance=instance,
+            origin_data=origin_data,
+            data={"id": instance_id, "is_deleted": True},
+        )
+        return response

--- a/gcloud/contrib/audit/instances.py
+++ b/gcloud/contrib/audit/instances.py
@@ -18,16 +18,31 @@ from gcloud.core.apis.drf.serilaziers import CreateTaskTemplateSerializer, Proje
 from gcloud.core.apis.drf.serilaziers.common_template import CreateCommonTemplateSerializer
 
 
+class AuditSnapshot(dict):
+    """Marker for already serialized and sanitized origin data."""
+
+
 class BaseInstance:
-    def __init__(self, inst, origin_data: dict = None):
+    def __init__(self, inst, origin_data: dict = None, data: dict = None):
         self.inst = inst
         self.origin_data = copy.deepcopy(origin_data)
+        self.data = copy.deepcopy(data)
+
+    def prepared_snapshot_origin_data(self):
+        if isinstance(self.origin_data, AuditSnapshot):
+            return dict(self.origin_data)
+        return None
 
     def prepare_origin_data(self):
+        snapshot = self.prepared_snapshot_origin_data()
+        if snapshot is not None:
+            return snapshot
         return self.origin_data
 
     @property
     def instance_id(self):
+        if self.inst.id is None and isinstance(self.data, dict):
+            return self.data.get("id")
         return self.inst.id
 
     @property
@@ -44,6 +59,8 @@ class BaseInstance:
 
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return model_to_dict(self.inst)
 
     @property
@@ -53,6 +70,9 @@ class BaseInstance:
 
 class TaskTemplateInstance(BaseInstance):
     def prepare_origin_data(self):
+        snapshot = self.prepared_snapshot_origin_data()
+        if snapshot is not None:
+            return snapshot
         if not self.origin_data:
             return {}
         ser = CreateTaskTemplateSerializer(data=self.origin_data)
@@ -67,11 +87,16 @@ class TaskTemplateInstance(BaseInstance):
 
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return TaskTemplateSerializer(self.inst).data
 
 
 class CommonTaskTemplateInstance(BaseInstance):
     def prepare_origin_data(self):
+        snapshot = self.prepared_snapshot_origin_data()
+        if snapshot is not None:
+            return snapshot
         if not self.origin_data:
             return {}
         ser = CreateCommonTemplateSerializer(data=self.origin_data)
@@ -86,11 +111,16 @@ class CommonTaskTemplateInstance(BaseInstance):
 
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return CommonTaskTemplateSerializer(self.inst).data
 
 
 class ProjectInstance(BaseInstance):
     def prepare_origin_data(self):
+        snapshot = self.prepared_snapshot_origin_data()
+        if snapshot is not None:
+            return snapshot
         if not self.origin_data:
             return {}
         ser = ProjectSerializer(data=self.origin_data)
@@ -99,11 +129,16 @@ class ProjectInstance(BaseInstance):
 
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return ProjectSerializer(self.inst).data
 
 
 class TaskInstance(BaseInstance):
     def prepare_origin_data(self):
+        snapshot = self.prepared_snapshot_origin_data()
+        if snapshot is not None:
+            return snapshot
         if not self.origin_data:
             return {}
         ser = TaskSerializer(data=self.origin_data)
@@ -112,17 +147,24 @@ class TaskInstance(BaseInstance):
 
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return TaskSerializer(self.inst).data
 
 
 class MiniAppInstance(BaseInstance):
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return AppmakerSerializer(self.inst).data
 
 
 class PeriodicTaskInstance(BaseInstance):
     def prepare_origin_data(self):
+        snapshot = self.prepared_snapshot_origin_data()
+        if snapshot is not None:
+            return snapshot
         if not self.origin_data:
             return {}
         self.origin_data["task_id"] = self.origin_data["taskId"]
@@ -132,11 +174,16 @@ class PeriodicTaskInstance(BaseInstance):
 
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return PeriodicTaskSerializer(self.inst).data
 
 
 class ClockedTaskInstance(BaseInstance):
     def prepare_origin_data(self):
+        snapshot = self.prepared_snapshot_origin_data()
+        if snapshot is not None:
+            return snapshot
         if not self.origin_data:
             return {}
         ser = UpdateClockedTaskSerializer(data=self.origin_data)
@@ -145,6 +192,8 @@ class ClockedTaskInstance(BaseInstance):
 
     @property
     def instance_data(self):
+        if self.data is not None:
+            return self.data
         return ClockedTaskSerializer(self.inst).data
 
     @property
@@ -163,11 +212,20 @@ INSTANCE_MAP = {
 }
 
 
-def build_instance(instance_type, instance, origin_data=None):
+def build_instance_data(instance_type, instance, data=None):
     instance_cls = INSTANCE_MAP.get(instance_type, None)
     if not instance_cls:
         return None
     if not instance:
         return None
-    instance = instance_cls(instance, origin_data).instance
+    return instance_cls(instance, data=data).instance_data
+
+
+def build_instance(instance_type, instance, origin_data=None, data=None):
+    instance_cls = INSTANCE_MAP.get(instance_type, None)
+    if not instance_cls:
+        return None
+    if not instance:
+        return None
+    instance = instance_cls(instance, origin_data, data).instance
     return instance

--- a/gcloud/contrib/audit/mappings.py
+++ b/gcloud/contrib/audit/mappings.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from gcloud.common_template.models import CommonTemplate
+from gcloud.constants import BUSINESS, COMMON, ONETIME, PROJECT
+from gcloud.iam_auth import IAMMeta
+from gcloud.tasktmpl3.models import TaskTemplate
+
+
+def get_task_create_action(template_source, create_method=None):
+    if create_method == "app_maker":
+        return IAMMeta.MINI_APP_CREATE_TASK_ACTION
+    return {
+        PROJECT: IAMMeta.FLOW_CREATE_TASK_ACTION,
+        BUSINESS: IAMMeta.FLOW_CREATE_TASK_ACTION,
+        COMMON: IAMMeta.COMMON_FLOW_CREATE_TASK_ACTION,
+        ONETIME: IAMMeta.PROJECT_FAST_CREATE_TASK_ACTION,
+    }.get(template_source)
+
+
+def get_periodic_task_create_action(template_source):
+    return {
+        PROJECT: IAMMeta.FLOW_CREATE_PERIODIC_TASK_ACTION,
+        COMMON: IAMMeta.COMMON_FLOW_CREATE_PERIODIC_TASK_ACTION,
+    }.get(template_source)
+
+
+def get_template_audit_meta(template_model_cls):
+    if template_model_cls is TaskTemplate:
+        return IAMMeta.FLOW_CREATE_ACTION, IAMMeta.FLOW_DELETE_ACTION, IAMMeta.FLOW_RESOURCE
+    if template_model_cls is CommonTemplate:
+        return (
+            IAMMeta.COMMON_FLOW_CREATE_ACTION,
+            IAMMeta.COMMON_FLOW_DELETE_ACTION,
+            IAMMeta.COMMON_FLOW_RESOURCE,
+        )
+    raise ValueError("unsupported template model: {}".format(template_model_cls))

--- a/gcloud/contrib/audit/operations.py
+++ b/gcloud/contrib/audit/operations.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from django.conf import settings
+
+from gcloud.contrib.audit.mappings import get_template_audit_meta
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+
+logger = logging.getLogger("root")
+
+
+def audit_imported_templates(username, template_model_cls, import_result):
+    if not settings.ENABLE_BK_AUDIT or import_result.get("result") is not True:
+        return
+    try:
+        create_action, _, resource_id = get_template_audit_meta(template_model_cls)
+        flows = (import_result.get("data") or {}).get("flows") or {}
+        template_ids = [int(template_id) for template_id in flows]
+        for instance in template_model_cls.objects.filter(id__in=template_ids):
+            bk_audit_add_event_on_commit(
+                username=username,
+                action_id=create_action,
+                resource_id=resource_id,
+                instance=instance,
+            )
+    except Exception:
+        logger.exception("bk_audit_import_templates_failed")
+
+
+def audit_deleted_templates(username, template_model_cls, instances_by_id, success_ids):
+    if not settings.ENABLE_BK_AUDIT:
+        return
+    try:
+        _, delete_action, resource_id = get_template_audit_meta(template_model_cls)
+        for template_id in success_ids:
+            try:
+                normalized_template_id = int(template_id)
+            except (TypeError, ValueError):
+                continue
+            instance = instances_by_id.get(normalized_template_id)
+            if instance is None:
+                continue
+            bk_audit_add_event_on_commit(
+                username=username,
+                action_id=delete_action,
+                resource_id=resource_id,
+                instance=instance,
+                origin_data=get_audit_snapshot(resource_id, instance),
+                data={"id": normalized_template_id, "is_deleted": True},
+            )
+    except Exception:
+        logger.exception("bk_audit_delete_templates_failed")

--- a/gcloud/contrib/audit/serializers.py
+++ b/gcloud/contrib/audit/serializers.py
@@ -75,11 +75,31 @@ class TaskSerializer(serializers.ModelSerializer):
     is_revoked = serializers.BooleanField(source="pipeline_instance.is_revoked", read_only=True)
     is_started = serializers.BooleanField(source="pipeline_instance.is_started", read_only=True)
     executor_name = serializers.CharField(help_text="执行者名称", read_only=True)
+    creator_name = serializers.CharField(help_text="创建者名称", read_only=True)
     name = serializers.CharField(source="pipeline_instance.name", read_only=True)
 
     class Meta:
         model = TaskFlowInstance
-        fields = "__all__"
+        fields = [
+            "id",
+            "name",
+            "project",
+            "category",
+            "template_id",
+            "template_source",
+            "create_method",
+            "creator_name",
+            "executor_name",
+            "flow_type",
+            "current_flow",
+            "is_started",
+            "is_finished",
+            "is_revoked",
+            "is_expired",
+            "create_time",
+            "start_time",
+            "finish_time",
+        ]
 
 
 class AppmakerSerializer(serializers.ModelSerializer):
@@ -129,7 +149,6 @@ class PeriodicTaskSerializer(serializers.ModelSerializer):
             "template_id",
             "template_source",
             "total_run_count",
-            "form",
             "is_latest",
             "template_scheme_ids",
             "template_version",

--- a/gcloud/contrib/audit/utils.py
+++ b/gcloud/contrib/audit/utils.py
@@ -10,18 +10,34 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+import json
 import logging
+from functools import partial
 
 import six
 from bk_audit.contrib.bk_audit.client import bk_audit_client
 from bk_audit.log.models import AuditContext
 from django.conf import settings
+from django.db import transaction
+from iam import Action
 from iam.auth.models import BaseObject
 
-from gcloud.contrib.audit.instances import build_instance
-from iam import Action
+from gcloud.contrib.audit.instances import AuditSnapshot, build_instance, build_instance_data
 
 logger = logging.getLogger("root")
+
+REMOVED_AUDIT_FIELDS = {
+    "constants",
+    "extra_info",
+    "form",
+    "headers",
+    "inputs",
+    "outputs",
+    "pipeline_tree",
+    "task_parameters",
+    "task_params",
+}
+SENSITIVE_AUDIT_KEYWORDS = ("authorization", "credential", "password", "secret", "token")
 
 
 class ResourceType(BaseObject):
@@ -43,18 +59,88 @@ class ResourceType(BaseObject):
         return {"id": self.id}
 
 
-def bk_audit_add_event(username, action_id, resource_id=None, instance=None, origin_data=None, *args, **kwargs):
+def sanitize_audit_data(data):
+    """Remove large payloads and redact secret-like values from audit snapshots."""
+    if isinstance(data, dict):
+        sanitized = {}
+        for key, value in data.items():
+            normalized_key = str(key).lower()
+            if normalized_key in REMOVED_AUDIT_FIELDS:
+                continue
+            if any(keyword in normalized_key for keyword in SENSITIVE_AUDIT_KEYWORDS):
+                sanitized[key] = "******"
+            else:
+                sanitized[key] = sanitize_audit_data(value)
+        return AuditSnapshot(sanitized) if isinstance(data, AuditSnapshot) else sanitized
+    if isinstance(data, (list, tuple)):
+        return [sanitize_audit_data(item) for item in data]
+    if isinstance(data, six.string_types):
+        stripped_data = data.strip()
+        if stripped_data.startswith(("{", "[")):
+            try:
+                decoded_data = json.loads(stripped_data)
+            except (TypeError, ValueError):
+                return data
+            return json.dumps(sanitize_audit_data(decoded_data), ensure_ascii=False, sort_keys=True)
+    return data
+
+
+def get_audit_snapshot(resource_id, instance, data=None):
+    """Build a safe before-change snapshot without affecting the business path."""
+    if not settings.ENABLE_BK_AUDIT or not resource_id or not instance:
+        return None
+    try:
+        snapshot = data if data is not None else build_instance_data(resource_id, instance)
+        return AuditSnapshot(sanitize_audit_data(snapshot or {}))
+    except Exception:
+        logger.exception(
+            "bk_audit_snapshot_failed resource_id=%s instance_id=%s",
+            resource_id,
+            getattr(instance, "id", None),
+        )
+        return None
+
+
+def bk_audit_add_event_on_commit(
+    username, action_id, resource_id=None, instance=None, origin_data=None, *args, data=None, **kwargs
+):
+    """Register a success event only after the surrounding transaction commits."""
     if not settings.ENABLE_BK_AUDIT:
         return
+    transaction.on_commit(
+        partial(
+            bk_audit_add_event,
+            username=username,
+            action_id=action_id,
+            resource_id=resource_id,
+            instance=instance,
+            origin_data=origin_data,
+            data=data,
+        )
+    )
+
+
+def bk_audit_add_event(
+    username, action_id, resource_id=None, instance=None, origin_data=None, *args, data=None, **kwargs
+):
+    if not settings.ENABLE_BK_AUDIT:
+        return
+    instance_id = getattr(instance, "id", None)
+    if instance_id is None and isinstance(data, dict):
+        instance_id = data.get("id")
     try:
         logger.info(
-            "bk_audit add_event: username: %s, action_id: %s, resource_id: %s, instance: %s",
+            "bk_audit add_event: username: %s, action_id: %s, resource_id: %s, instance_id: %s",
             username,
             action_id,
             resource_id,
-            instance,
+            instance_id,
         )
-        instance = build_instance(resource_id, instance, origin_data)
+        if instance is not None and data is None:
+            data = build_instance_data(resource_id, instance)
+        safe_origin_data = sanitize_audit_data(origin_data)
+        safe_data = sanitize_audit_data(data)
+        instance = build_instance(resource_id, instance, safe_origin_data, safe_data)
         context = AuditContext(username=username)
         bk_audit_client.add_event(
             action=Action(action_id),
@@ -63,5 +149,10 @@ def bk_audit_add_event(username, action_id, resource_id=None, instance=None, ori
             instance=instance,
         )
         logger.info("bk_audit add_event: success")
-    except Exception as e:
-        logger.exception(f"bk_audit error: {e}")
+    except Exception:
+        logger.exception(
+            "bk_audit_add_event_failed action_id=%s resource_id=%s instance_id=%s",
+            action_id,
+            resource_id,
+            instance_id,
+        )

--- a/gcloud/contrib/audit/utils.py
+++ b/gcloud/contrib/audit/utils.py
@@ -90,7 +90,9 @@ def get_audit_snapshot(resource_id, instance, data=None):
     if not settings.ENABLE_BK_AUDIT or not resource_id or not instance:
         return None
     try:
-        snapshot = data if data is not None else build_instance_data(resource_id, instance)
+        snapshot = data() if callable(data) else data
+        if snapshot is None:
+            snapshot = build_instance_data(resource_id, instance)
         return AuditSnapshot(sanitize_audit_data(snapshot or {}))
     except Exception:
         logger.exception(
@@ -99,6 +101,24 @@ def get_audit_snapshot(resource_id, instance, data=None):
             getattr(instance, "id", None),
         )
         return None
+
+
+def get_periodic_task_audit_snapshot(instance):
+    return get_audit_snapshot(
+        "periodic_task",
+        instance,
+        data=lambda: {
+            "id": instance.id,
+            "name": instance.name,
+            "cron": instance.cron,
+            "enabled": instance.enabled,
+            "template_id": instance.template_id,
+            "template_source": instance.template_source,
+            "template_version": instance.template_version,
+            "creator": instance.creator,
+            "editor": instance.editor,
+        },
+    )
 
 
 def bk_audit_add_event_on_commit(
@@ -125,10 +145,11 @@ def bk_audit_add_event(
 ):
     if not settings.ENABLE_BK_AUDIT:
         return
-    instance_id = getattr(instance, "id", None)
-    if instance_id is None and isinstance(data, dict):
-        instance_id = data.get("id")
+    instance_id = None
     try:
+        instance_id = getattr(instance, "id", None)
+        if instance_id is None and isinstance(data, dict):
+            instance_id = data.get("id")
         logger.info(
             "bk_audit add_event: username: %s, action_id: %s, resource_id: %s, instance_id: %s",
             username,

--- a/gcloud/contrib/function/api.py
+++ b/gcloud/contrib/function/api.py
@@ -1,23 +1,29 @@
 # -*- coding: utf-8 -*-
+import logging
+
+from django.utils.translation import ugettext_lazy as _
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.contrib.function.models import FunctionTask
-from gcloud.contrib.function.serializers import FunctionTaskClaimantTransferRequestSerializer, \
-    FunctionTaskClaimantTransferResponse
+from gcloud.contrib.function.serializers import (
+    FunctionTaskClaimantTransferRequestSerializer,
+    FunctionTaskClaimantTransferResponse,
+)
 from gcloud.core.api_adapter.user_role import is_user_role
 from gcloud.iam_auth import IAMMeta
-from django.utils.translation import ugettext_lazy as _
-import logging
 
 logger = logging.getLogger("root")
 
 
 class FunctionTaskClaimantTransferView(APIView):
     @swagger_auto_schema(
-        method="POST", operation_summary="职能转交", request_body=FunctionTaskClaimantTransferRequestSerializer,
+        method="POST",
+        operation_summary="职能转交",
+        request_body=FunctionTaskClaimantTransferRequestSerializer,
         responses={200: FunctionTaskClaimantTransferResponse},
     )
     @action(methods=["POST"], detail=False)
@@ -35,14 +41,15 @@ class FunctionTaskClaimantTransferView(APIView):
 
         # 查询传进来的id职能化任务是否有效
         serializer_data = serializer.data
-        function_task_query = FunctionTask.objects.filter(id=serializer_data["id"]).values("claimant")
+        function_task_query = FunctionTask.objects.filter(id=serializer_data["id"]).select_related("task")
         if not function_task_query.count():
             message = _("任务转交失败: 当前转交的任务已不存在, 请检查任务是否存在")
             logger.error(message)
             return Response({"result": False, "message": message})
 
         # 查询当前任务是否有认领人判断是否已认领,并且请求的用户是否是认领人
-        claimant = function_task_query.first().get("claimant")
+        function_task = function_task_query.first()
+        claimant = function_task.claimant
         if not claimant:
             message = _("任务转交失败: 未查询到任务认领人, 请检查任务后重试")
             logger.error(message)
@@ -53,5 +60,13 @@ class FunctionTaskClaimantTransferView(APIView):
             return Response({"result": False, "message": message})
 
         # 修改并返回结果
+        origin_data = get_audit_snapshot(IAMMeta.TASK_RESOURCE, function_task.task)
         FunctionTask.objects.filter(id=serializer_data["id"]).update(claimant=serializer_data["claimant"])
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.TASK_CLAIM_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=function_task.task,
+            origin_data=origin_data,
+        )
         return Response({"result": True, "data": None})

--- a/gcloud/core/apis/drf/viewsets/appmaker.py
+++ b/gcloud/core/apis/drf/viewsets/appmaker.py
@@ -15,7 +15,7 @@ from rest_framework import mixins, permissions
 from rest_framework.pagination import LimitOffsetPagination
 
 from gcloud.contrib.appmaker.models import AppMaker
-from gcloud.contrib.audit.utils import bk_audit_add_event
+from gcloud.contrib.audit.utils import bk_audit_add_event, bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.core.apis.drf.permission import HAS_OBJECT_PERMISSION, IamPermission, IamPermissionInfo
 from gcloud.core.apis.drf.resource_helpers import ViewSetResourceHelper
 from gcloud.core.apis.drf.serilaziers.appmaker import AppmakerSerializer
@@ -65,10 +65,14 @@ class AppmakerListViewSet(GcloudReadOnlyViewSet, mixins.DestroyModelMixin):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        bk_audit_add_event(
+        origin_data = get_audit_snapshot(IAMMeta.MINI_APP_RESOURCE, instance)
+        response = super(AppmakerListViewSet, self).destroy(request, *args, **kwargs)
+        bk_audit_add_event_on_commit(
             username=request.user.username,
             action_id=IAMMeta.MINI_APP_DELETE_ACTION,
             resource_id=IAMMeta.MINI_APP_RESOURCE,
             instance=instance,
+            origin_data=origin_data,
+            data={"id": instance.id, "is_deleted": True},
         )
-        return super(AppmakerListViewSet, self).destroy(request, *args, **kwargs)
+        return response

--- a/gcloud/core/apis/drf/viewsets/periodic_task.py
+++ b/gcloud/core/apis/drf/viewsets/periodic_task.py
@@ -27,7 +27,8 @@ from rest_framework.response import Response
 from gcloud import err_code
 from gcloud.common_template.models import CommonTemplate
 from gcloud.constants import COMMON, NON_COMMON_TEMPLATE_TYPES, PERIOD_TASK_NAME_MAX_LENGTH, PROJECT
-from gcloud.contrib.audit.utils import bk_audit_add_event
+from gcloud.contrib.audit.mappings import get_periodic_task_create_action
+from gcloud.contrib.audit.utils import bk_audit_add_event, bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.contrib.collection.models import Collection
 from gcloud.core.apis.drf.exceptions import ValidationException
 from gcloud.core.apis.drf.filtersets import AllLookupSupportFilterSet
@@ -97,7 +98,7 @@ class PeriodicTaskPermission(IamPermission):
 
 
 class PeriodicTaskFilter(AllLookupSupportFilterSet):
-    template_expired = django_filters.BooleanFilter(method='filter_template_expired')
+    template_expired = django_filters.BooleanFilter(method="filter_template_expired")
 
     class Meta:
         model = PeriodicTask
@@ -281,13 +282,18 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
-        bk_audit_add_event(
+        instance_id = instance.id
+        origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, instance)
+        response = super(PeriodicTaskViewSet, self).destroy(request, *args, **kwargs)
+        bk_audit_add_event_on_commit(
             username=request.user.username,
             action_id=IAMMeta.PERIODIC_TASK_DELETE_ACTION,
             resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
             instance=instance,
+            origin_data=origin_data,
+            data={"id": instance_id, "is_deleted": True},
         )
-        return super(PeriodicTaskViewSet, self).destroy(request, *args, **kwargs)
+        return response
 
     def create(self, request, *args, **kwargs):
         serializer = CreatePeriodicTaskSerializer(data=request.data, context={"request": request})
@@ -299,16 +305,19 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
             raise ValidationException(e)
         instance.set_enabled(True)
         headers = self.get_success_headers(serializer.data)
-        bk_audit_add_event(
-            username=request.user.username,
-            action_id=IAMMeta.FLOW_CREATE_PERIODIC_TASK_ACTION,
-            resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
-            instance=instance,
-        )
+        action_id = get_periodic_task_create_action(instance.template_source)
+        if action_id:
+            bk_audit_add_event_on_commit(
+                username=request.user.username,
+                action_id=action_id,
+                resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+                instance=instance,
+            )
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
+        origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, instance)
         serializer = CreatePeriodicTaskSerializer(instance, data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         try:
@@ -316,16 +325,18 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
             instance = PeriodicTask.objects.update(instance, **serializer.validated_data)
         except (PipelineException, APIException) as e:
             raise ValidationException(e)
-        bk_audit_add_event(
+        bk_audit_add_event_on_commit(
             username=request.user.username,
             action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
             resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
             instance=instance,
+            origin_data=origin_data,
         )
         return Response(PeriodicTaskReadOnlySerializer(instance=instance).data)
 
     def partial_update(self, request, *args, **kwargs):
         instance = self.get_object()
+        origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, instance)
         serializer = PatchUpdatePeriodicTaskSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
 
@@ -343,11 +354,12 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
             instance.task.creator = request.user.username
             instance.task.save()
 
-        bk_audit_add_event(
+        bk_audit_add_event_on_commit(
             username=request.user.username,
             action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
             resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
             instance=instance,
+            origin_data=origin_data,
         )
 
         return Response(PeriodicTaskReadOnlySerializer(instance=instance).data)

--- a/gcloud/core/apis/drf/viewsets/periodic_task.py
+++ b/gcloud/core/apis/drf/viewsets/periodic_task.py
@@ -28,7 +28,11 @@ from gcloud import err_code
 from gcloud.common_template.models import CommonTemplate
 from gcloud.constants import COMMON, NON_COMMON_TEMPLATE_TYPES, PERIOD_TASK_NAME_MAX_LENGTH, PROJECT
 from gcloud.contrib.audit.mappings import get_periodic_task_create_action
-from gcloud.contrib.audit.utils import bk_audit_add_event, bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.contrib.audit.utils import (
+    bk_audit_add_event,
+    bk_audit_add_event_on_commit,
+    get_periodic_task_audit_snapshot,
+)
 from gcloud.contrib.collection.models import Collection
 from gcloud.core.apis.drf.exceptions import ValidationException
 from gcloud.core.apis.drf.filtersets import AllLookupSupportFilterSet
@@ -283,7 +287,7 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
         instance_id = instance.id
-        origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, instance)
+        origin_data = get_periodic_task_audit_snapshot(instance)
         response = super(PeriodicTaskViewSet, self).destroy(request, *args, **kwargs)
         bk_audit_add_event_on_commit(
             username=request.user.username,
@@ -317,7 +321,7 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
 
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
-        origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, instance)
+        origin_data = get_periodic_task_audit_snapshot(instance)
         serializer = CreatePeriodicTaskSerializer(instance, data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
         try:
@@ -331,12 +335,13 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
             resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
             instance=instance,
             origin_data=origin_data,
+            data=get_periodic_task_audit_snapshot(instance),
         )
         return Response(PeriodicTaskReadOnlySerializer(instance=instance).data)
 
     def partial_update(self, request, *args, **kwargs):
         instance = self.get_object()
-        origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, instance)
+        origin_data = get_periodic_task_audit_snapshot(instance)
         serializer = PatchUpdatePeriodicTaskSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
 
@@ -360,6 +365,7 @@ class PeriodicTaskViewSet(GcloudModelViewSet):
             resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
             instance=instance,
             origin_data=origin_data,
+            data=get_periodic_task_audit_snapshot(instance),
         )
 
         return Response(PeriodicTaskReadOnlySerializer(instance=instance).data)

--- a/gcloud/core/apis/drf/viewsets/project.py
+++ b/gcloud/core/apis/drf/viewsets/project.py
@@ -10,9 +10,10 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from django.conf import settings
 from rest_framework import permissions
 
-from gcloud.contrib.audit.utils import bk_audit_add_event
+from gcloud.contrib.audit.utils import bk_audit_add_event, bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.core.apis.drf.filtersets import ALL_LOOKUP, AllLookupSupportFilterSet
 from gcloud.core.apis.drf.permission import HAS_OBJECT_PERMISSION, IamPermission, IamPermissionInfo
 from gcloud.core.apis.drf.resource_helpers import ViewSetResourceHelper
@@ -77,10 +78,15 @@ class ProjectSetViewSet(GcloudUpdateViewSet, GcloudListViewSet):
 
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
-        bk_audit_add_event(
-            username=request.user.username,
-            action_id=IAMMeta.PROJECT_EDIT_ACTION,
-            resource_id=IAMMeta.PROJECT_RESOURCE,
-            instance=instance,
-        )
-        return super(ProjectSetViewSet, self).update(request, *args, **kwargs)
+        origin_data = get_audit_snapshot(IAMMeta.PROJECT_RESOURCE, instance)
+        response = super(ProjectSetViewSet, self).update(request, *args, **kwargs)
+        if settings.ENABLE_BK_AUDIT:
+            instance.refresh_from_db()
+            bk_audit_add_event_on_commit(
+                username=request.user.username,
+                action_id=IAMMeta.PROJECT_EDIT_ACTION,
+                resource_id=IAMMeta.PROJECT_RESOURCE,
+                instance=instance,
+                origin_data=origin_data,
+            )
+        return response

--- a/gcloud/core/apis/drf/viewsets/project_config.py
+++ b/gcloud/core/apis/drf/viewsets/project_config.py
@@ -11,18 +11,19 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+from django.conf import settings
+from iam import Action, Subject
+from iam.shortcuts import allow_or_raise_auth_failed
 from rest_framework import mixins, permissions, viewsets
 from rest_framework.permissions import IsAdminUser
 
-from gcloud.core.models import Project, ProjectConfig
+from gcloud.contrib.audit.instances import AuditSnapshot
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.core.apis.drf.exceptions import ObjectDoesNotExistException
 from gcloud.core.apis.drf.serilaziers import ProjectConfigSerializer
 from gcloud.core.apis.drf.viewsets.utils import ApiMixin
-from gcloud.core.apis.drf.exceptions import ObjectDoesNotExistException
-
-from iam import Action, Subject
-from iam.shortcuts import allow_or_raise_auth_failed
-
-from gcloud.iam_auth import get_iam_client, IAMMeta, res_factory
+from gcloud.core.models import Project, ProjectConfig
+from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
 
 iam = get_iam_client()
 
@@ -55,3 +56,29 @@ class ProjectConfigViewSet(ApiMixin, mixins.RetrieveModelMixin, mixins.UpdateMod
         obj, _ = ProjectConfig.objects.get_or_create(project_id=project_id)
 
         return obj
+
+    @staticmethod
+    def _audit_data(config):
+        return AuditSnapshot(
+            {
+                "executor_proxy": config.executor_proxy,
+                "executor_proxy_exempts": config.executor_proxy_exempts,
+            }
+        )
+
+    def update(self, request, *args, **kwargs):
+        config = self.get_object()
+        project = Project.objects.get(id=config.project_id) if settings.ENABLE_BK_AUDIT else None
+        origin_data = self._audit_data(config) if settings.ENABLE_BK_AUDIT else None
+        response = super(ProjectConfigViewSet, self).update(request, *args, **kwargs)
+        if settings.ENABLE_BK_AUDIT:
+            config.refresh_from_db()
+            bk_audit_add_event_on_commit(
+                username=request.user.username,
+                action_id=IAMMeta.PROJECT_EDIT_ACTION,
+                resource_id=IAMMeta.PROJECT_RESOURCE,
+                instance=project,
+                origin_data=origin_data,
+                data=self._audit_data(config),
+            )
+        return response

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -32,9 +32,10 @@ from rest_framework.response import Response
 from gcloud import err_code
 from gcloud.analysis_statistics.models import TaskflowExecutedNodeStatistics
 from gcloud.common_template.models import CommonTemplate
-from gcloud.constants import COMMON, ONETIME, PROJECT, TASK_NAME_MAX_LENGTH, TaskCreateMethod
+from gcloud.constants import TASK_NAME_MAX_LENGTH, TaskCreateMethod
 from gcloud.contrib.appmaker.models import AppMaker
-from gcloud.contrib.audit.utils import bk_audit_add_event
+from gcloud.contrib.audit.mappings import get_task_create_action
+from gcloud.contrib.audit.utils import bk_audit_add_event, bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.contrib.function.models import FunctionTask
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.signal import operate_record_signal
@@ -498,22 +499,13 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
             project_id=serializer.instance.project.id,
             extra_info=extra_info,
         )
-        action_id_mappings = {
-            PROJECT: IAMMeta.FLOW_CREATE_TASK_ACTION,
-            COMMON: IAMMeta.COMMON_FLOW_CREATE_TASK_ACTION,
-            ONETIME: IAMMeta.PROJECT_FAST_CREATE_TASK_ACTION,
-        }
-        if serializer.validated_data.get("create_method") == "app_maker":
-            bk_audit_add_event(
+        action_id = get_task_create_action(
+            serializer.validated_data.get("template_source"), serializer.validated_data.get("create_method")
+        )
+        if action_id:
+            bk_audit_add_event_on_commit(
                 username=creator,
-                action_id=IAMMeta.MINI_APP_CREATE_TASK_ACTION,
-                resource_id=IAMMeta.TASK_RESOURCE,
-                instance=serializer.instance,
-            )
-        elif serializer.validated_data.get("template_source") in action_id_mappings:
-            bk_audit_add_event(
-                username=creator,
-                action_id=action_id_mappings[serializer.validated_data["template_source"]],
+                action_id=action_id,
                 resource_id=IAMMeta.TASK_RESOURCE,
                 instance=serializer.instance,
             )
@@ -525,6 +517,7 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
                 message = _("任务删除失败: 仅允许删除[未执行]任务, 请检查任务状态")
                 logger.error(message)
                 return Response({"detail": ErrorDetail(message, err_code.REQUEST_PARAM_INVALID.code)}, exception=True)
+        origin_data = get_audit_snapshot(IAMMeta.TASK_RESOURCE, instance)
         self.perform_destroy(instance)
         # 记录操作流水
         operate_record_signal.send(
@@ -535,11 +528,13 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
             instance_id=instance.id,
             project_id=instance.project.id,
         )
-        bk_audit_add_event(
+        bk_audit_add_event_on_commit(
             username=request.user.username,
             action_id=IAMMeta.TASK_DELETE_ACTION,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=instance,
+            origin_data=origin_data,
+            data={"id": instance.id, "is_deleted": True},
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -781,9 +776,17 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
                     "the number of corresponding function task should be 1. ",
                 }
             )
+        origin_data = get_audit_snapshot(IAMMeta.TASK_RESOURCE, task)
         with transaction.atomic():
             task.flow_type = "common"
             task.current_flow = "execute_task"
             task.save(update_fields=["flow_type", "current_flow"])
             FunctionTask.objects.filter(task_id=task.id).delete()
+            bk_audit_add_event_on_commit(
+                username=request.user.username,
+                action_id=IAMMeta.TASK_EDIT_ACTION,
+                resource_id=IAMMeta.TASK_RESOURCE,
+                instance=task,
+                origin_data=origin_data,
+            )
         return Response({"result": True, "message": "convert to common task success", "data": None})

--- a/gcloud/periodictask/api.py
+++ b/gcloud/periodictask/api.py
@@ -18,7 +18,7 @@ from django.views.decorators.http import require_GET, require_POST
 from gcloud import err_code
 from gcloud.common_template.models import CommonTemplate
 from gcloud.constants import COMMON, NON_COMMON_TEMPLATE_TYPES
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_periodic_task_audit_snapshot
 from gcloud.core.models import Project
 from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
@@ -45,7 +45,7 @@ def set_enabled_for_periodic_task(request, project_id, task_id):
     data = json.loads(request.body)
 
     task = PeriodicTask.objects.get(id=task_id)
-    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
+    origin_data = get_periodic_task_audit_snapshot(task)
     task.set_enabled(data["enabled"])
     task.editor = request.user.username
     task.save(update_fields=["editor", "edit_time"])
@@ -55,6 +55,7 @@ def set_enabled_for_periodic_task(request, project_id, task_id):
         resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
         instance=task,
         origin_data=origin_data,
+        data=get_periodic_task_audit_snapshot(task),
     )
 
     return JsonResponse({"result": True, "message": "success"})
@@ -68,7 +69,7 @@ def modify_cron(request, project_id, task_id):
 
     task = PeriodicTask.objects.get(id=task_id)
     project = Project.objects.get(id=project_id)
-    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
+    origin_data = get_periodic_task_audit_snapshot(task)
 
     try:
         task.modify_cron(data["cron"], project.time_zone)
@@ -83,6 +84,7 @@ def modify_cron(request, project_id, task_id):
         resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
         instance=task,
         origin_data=origin_data,
+        data=get_periodic_task_audit_snapshot(task),
     )
 
     return JsonResponse({"result": True, "message": "success", "data": None, "code": err_code.SUCCESS.code})
@@ -95,7 +97,7 @@ def modify_constants(request, project_id, task_id):
     data = json.loads(request.body)
 
     task = PeriodicTask.objects.get(id=task_id)
-    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
+    origin_data = get_periodic_task_audit_snapshot(task)
 
     try:
         new_constants = task.modify_constants(data["constants"])
@@ -110,6 +112,7 @@ def modify_constants(request, project_id, task_id):
         resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
         instance=task,
         origin_data=origin_data,
+        data=get_periodic_task_audit_snapshot(task),
     )
 
     return JsonResponse({"result": True, "message": "success", "data": new_constants, "code": err_code.SUCCESS.code})

--- a/gcloud/periodictask/api.py
+++ b/gcloud/periodictask/api.py
@@ -17,8 +17,10 @@ from django.views.decorators.http import require_GET, require_POST
 
 from gcloud import err_code
 from gcloud.common_template.models import CommonTemplate
-from gcloud.constants import NON_COMMON_TEMPLATE_TYPES, COMMON
+from gcloud.constants import COMMON, NON_COMMON_TEMPLATE_TYPES
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
 from gcloud.core.models import Project
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.periodic_task import (
     ModifyConstantsInterceptor,
@@ -43,9 +45,17 @@ def set_enabled_for_periodic_task(request, project_id, task_id):
     data = json.loads(request.body)
 
     task = PeriodicTask.objects.get(id=task_id)
+    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
     task.set_enabled(data["enabled"])
     task.editor = request.user.username
     task.save(update_fields=["editor", "edit_time"])
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
+        resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
 
     return JsonResponse({"result": True, "message": "success"})
 
@@ -58,6 +68,7 @@ def modify_cron(request, project_id, task_id):
 
     task = PeriodicTask.objects.get(id=task_id)
     project = Project.objects.get(id=project_id)
+    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
 
     try:
         task.modify_cron(data["cron"], project.time_zone)
@@ -65,6 +76,14 @@ def modify_cron(request, project_id, task_id):
         return JsonResponse(
             {"result": False, "message": str(e), "data": None, "code": err_code.REQUEST_PARAM_INVALID.code}
         )
+
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
+        resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
 
     return JsonResponse({"result": True, "message": "success", "data": None, "code": err_code.SUCCESS.code})
 
@@ -76,6 +95,7 @@ def modify_constants(request, project_id, task_id):
     data = json.loads(request.body)
 
     task = PeriodicTask.objects.get(id=task_id)
+    origin_data = get_audit_snapshot(IAMMeta.PERIODIC_TASK_RESOURCE, task)
 
     try:
         new_constants = task.modify_constants(data["constants"])
@@ -83,6 +103,14 @@ def modify_constants(request, project_id, task_id):
         return JsonResponse(
             {"result": False, "message": str(e), "data": None, "code": err_code.REQUEST_PARAM_INVALID.code}
         )
+
+    bk_audit_add_event_on_commit(
+        username=request.user.username,
+        action_id=IAMMeta.PERIODIC_TASK_EDIT_ACTION,
+        resource_id=IAMMeta.PERIODIC_TASK_RESOURCE,
+        instance=task,
+        origin_data=origin_data,
+    )
 
     return JsonResponse({"result": True, "message": "success", "data": new_constants, "code": err_code.SUCCESS.code})
 
@@ -95,8 +123,9 @@ def get_period_tasks_with_expired_template(request, project_id):
     """
 
     periodic_tasks = list(
-        PeriodicTask.objects.filter(project__id=project_id).only("id", "template_id", "template_version",
-                                                                 "template_source")
+        PeriodicTask.objects.filter(project__id=project_id).only(
+            "id", "template_id", "template_version", "template_source"
+        )
     )
 
     # 按 template_source 分组，批量查询模板以避免 N+1 查询
@@ -120,5 +149,4 @@ def get_period_tasks_with_expired_template(request, project_id):
             if task.template_version != template_version_map.get(int(task.template_id)):
                 expired_task_ids.append(task.id)
 
-    return JsonResponse(
-        {"result": True, "data": expired_task_ids, "code": err_code.SUCCESS.code, "message": ""})
+    return JsonResponse({"result": True, "data": expired_task_ids, "code": err_code.SUCCESS.code, "message": ""})

--- a/gcloud/taskflow3/apis/django/api.py
+++ b/gcloud/taskflow3/apis/django/api.py
@@ -33,7 +33,7 @@ from gcloud import err_code
 from gcloud.conf import settings
 from gcloud.constants import PROJECT, TASK_CREATE_METHOD, JobBizScopeType
 from gcloud.contrib.analysis.analyse_items import task_flow_instance
-from gcloud.contrib.audit.utils import bk_audit_add_event
+from gcloud.contrib.audit.utils import bk_audit_add_event, bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.models import EngineConfig
@@ -242,9 +242,7 @@ def get_job_instance_log(request, biz_cc_id):
     job_result = client.job.get_job_instance_log(log_kwargs)
 
     if not job_result["result"]:
-        message = _(
-            f"执行历史请求失败: 请求[作业平台ID: {biz_cc_id}] 异常信息: {job_result['message']} | get_job_instance_log"
-        )
+        message = _(f"执行历史请求失败: 请求[作业平台ID: {biz_cc_id}] 异常信息: {job_result['message']} | get_job_instance_log")
 
         if job_result.get("code", 0) == HTTP_AUTH_FORBIDDEN_CODE:
             logger.warning(message)
@@ -275,12 +273,13 @@ def task_action(request, action, project_id):
         return JsonResponse({"result": False, "message": message, "code": err_code.INVALID_OPERATION.code})
 
     ctx = task.task_action(action, username)
-    bk_audit_add_event(
-        username=request.user.username,
-        action_id=IAMMeta.TASK_OPERATE_ACTION,
-        resource_id=IAMMeta.TASK_RESOURCE,
-        instance=task,
-    )
+    if ctx.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     return JsonResponse(ctx)
 
 
@@ -325,6 +324,13 @@ def nodes_action(request, action, project_id):
     }
     task = TaskFlowInstance.objects.get(pk=task_id, project_id=project_id)
     ctx = task.nodes_action(action, node_id, username, **kwargs)
+    if ctx.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     return JsonResponse(ctx)
 
 
@@ -342,6 +348,13 @@ def spec_nodes_timer_reset(request, project_id):
 
     task = TaskFlowInstance.objects.get(pk=task_id, project_id=project_id)
     ctx = task.spec_nodes_timer_reset(node_id, username, inputs)
+    if ctx.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     return JsonResponse(ctx)
 
 
@@ -396,12 +409,13 @@ def task_func_claim(request, project_id):
 
     task = TaskFlowInstance.objects.get(pk=task_id, project_id=project_id)
     ctx = task.task_claim(request.user.username, constants, name)
-    bk_audit_add_event(
-        username=request.user.username,
-        action_id=IAMMeta.TASK_CLAIM_ACTION,
-        resource_id=IAMMeta.TASK_RESOURCE,
-        instance=task,
-    )
+    if ctx.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=request.user.username,
+            action_id=IAMMeta.TASK_CLAIM_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     return JsonResponse(ctx)
 
 
@@ -424,9 +438,7 @@ def preview_task_tree(request, project_id):
     try:
         data = preview_template_tree(project_id, template_source, template_id, version, exclude_task_nodes_id)
     except Exception as e:
-        message = _(
-            f"任务数据请求失败: 请求任务数据发生异常: {e}. 请重试, 如多次失败可联系管理员处理 | preview_task_tree"
-        )
+        message = _(f"任务数据请求失败: 请求任务数据发生异常: {e}. 请重试, 如多次失败可联系管理员处理 | preview_task_tree")
         logger.exception(message)
         return JsonResponse({"result": False, "message": message})
 
@@ -550,9 +562,7 @@ def get_node_log(request, project_id, node_id):
 
     task = TaskFlowInstance.objects.get(pk=task_id, project_id=project_id)
     if not task.has_node(node_id):
-        message = _(
-            f"节点状态请求失败: 任务[ID: {task.id}]中未找到节点[ID: {node_id}]. 请重试. 如持续失败可联系管理员处理 | get_node_log"
-        )
+        message = _(f"节点状态请求失败: 任务[ID: {task.id}]中未找到节点[ID: {node_id}]. 请重试. 如持续失败可联系管理员处理 | get_node_log")
         logger.error(message)
         return JsonResponse({"result": False, "data": None, "message": message})
 
@@ -587,9 +597,7 @@ def node_callback(request, token):
     try:
         callback_data = json.loads(request.body)
     except Exception:
-        message = _(
-            f"节点回调失败: 无效的请求, 请重试. 如持续失败可联系管理员处理. {traceback.format_exc()} | api node_callback"
-        )
+        message = _(f"节点回调失败: 无效的请求, 请重试. 如持续失败可联系管理员处理. {traceback.format_exc()} | api node_callback")
         logger.error(message)
         return JsonResponse({"result": False, "message": message}, status=400)
 

--- a/gcloud/taskflow3/apis/django/v4/node_action.py
+++ b/gcloud/taskflow3/apis/django/v4/node_action.py
@@ -15,9 +15,11 @@ import ujson as json
 from django.http.response import JsonResponse
 from django.views.decorators.http import require_POST
 
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
 from gcloud.contrib.operate_record.constants import OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
+from gcloud.iam_auth import IAMMeta
 from gcloud.iam_auth.intercept import iam_intercept
 from gcloud.iam_auth.view_interceptors.taskflow import NodeActionV2Inpterceptor
 from gcloud.taskflow3.apis.django.validators import NodeActionV2Validator
@@ -42,4 +44,11 @@ def node_action(request, project_id, task_id, node_id):
     }
     task = TaskFlowInstance.objects.get(pk=task_id, project_id=project_id)
     ctx = task.nodes_action(action, node_id, username, **kwargs)
+    if ctx.get("result") is True:
+        bk_audit_add_event_on_commit(
+            username=username,
+            action_id=IAMMeta.TASK_OPERATE_ACTION,
+            resource_id=IAMMeta.TASK_RESOURCE,
+            instance=task,
+        )
     return JsonResponse(ctx)

--- a/gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py
+++ b/gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py
@@ -10,6 +10,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from django.conf import settings
 from drf_yasg.utils import swagger_auto_schema
 from iam import Action, Subject
 from iam.shortcuts import allow_or_raise_auth_failed
@@ -83,7 +84,12 @@ class UpdateTaskConstantsView(APIView):
         except serializers.ValidationError as e:
             return Response({"result": False, "message": e.detail, "data": ""})
 
-        task = TaskFlowInstance.objects.filter(id=task_id).only("project_id", "engine_ver", "pipeline_instance").first()
+        task_query = TaskFlowInstance.objects.filter(id=task_id)
+        task = (
+            task_query.select_related("pipeline_instance").first()
+            if settings.ENABLE_BK_AUDIT
+            else task_query.only("project_id", "engine_ver", "pipeline_instance").first()
+        )
         origin_data = get_audit_snapshot(IAMMeta.TASK_RESOURCE, task)
         set_result = task.set_task_constants(serializer.data["constants"], serializer.data["meta_constants"])
 

--- a/gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py
+++ b/gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py
@@ -10,21 +10,21 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
-from rest_framework import permissions
-from rest_framework import serializers
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework.decorators import action
-from iam import Subject, Action
-from iam.shortcuts import allow_or_raise_auth_failed
 from drf_yasg.utils import swagger_auto_schema
-from gcloud.contrib.operate_record.constants import OperateType, OperateSource
-from gcloud.taskflow3.domains.task_constants import TaskConstantsHandler
+from iam import Action, Subject
+from iam.shortcuts import allow_or_raise_auth_failed
+from rest_framework import permissions, serializers
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from gcloud.taskflow3.models import TaskFlowInstance
-from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_snapshot
+from gcloud.contrib.operate_record.constants import OperateSource, OperateType
 from gcloud.contrib.operate_record.models import TaskOperateRecord
 from gcloud.contrib.operate_record.utils import extract_extra_info
+from gcloud.iam_auth import IAMMeta, get_iam_client, res_factory
+from gcloud.taskflow3.domains.task_constants import TaskConstantsHandler
+from gcloud.taskflow3.models import TaskFlowInstance
 
 iam = get_iam_client()
 
@@ -84,6 +84,7 @@ class UpdateTaskConstantsView(APIView):
             return Response({"result": False, "message": e.detail, "data": ""})
 
         task = TaskFlowInstance.objects.filter(id=task_id).only("project_id", "engine_ver", "pipeline_instance").first()
+        origin_data = get_audit_snapshot(IAMMeta.TASK_RESOURCE, task)
         set_result = task.set_task_constants(serializer.data["constants"], serializer.data["meta_constants"])
 
         if set_result["result"]:
@@ -98,11 +99,20 @@ class UpdateTaskConstantsView(APIView):
                 project_id=task.project_id,
                 extra_info=extra_info,
             )
+            bk_audit_add_event_on_commit(
+                username=request.user.username,
+                action_id=IAMMeta.TASK_EDIT_ACTION,
+                resource_id=IAMMeta.TASK_RESOURCE,
+                instance=task,
+                origin_data=origin_data,
+            )
 
         return Response(set_result)
 
     @swagger_auto_schema(
-        method="GET", operation_summary="查看任务参数的使用信息", responses={200: TaskConstantsResponseSerializer},
+        method="GET",
+        operation_summary="查看任务参数的使用信息",
+        responses={200: TaskConstantsResponseSerializer},
     )
     @action(methods=["GET"], detail=True)
     def get(self, request, task_id, *args, **kwargs):

--- a/gcloud/template_base/apis/django/api.py
+++ b/gcloud/template_base/apis/django/api.py
@@ -29,13 +29,11 @@ from rest_framework.request import Request
 
 from gcloud import err_code
 from gcloud.conf import settings
+from gcloud.contrib.audit.operations import audit_imported_templates
 from gcloud.core.models import Project
 from gcloud.exceptions import FlowExportError
 from gcloud.iam_auth.intercept import iam_intercept
-from gcloud.iam_auth.view_interceptors.base_template import (
-    YamlExportInterceptor,
-    YamlImportInterceptor,
-)
+from gcloud.iam_auth.view_interceptors.base_template import YamlExportInterceptor, YamlImportInterceptor
 from gcloud.openapi.schema import AnnotationAutoSchema
 from gcloud.template_base.apis.django.validators import (
     FileValidator,
@@ -45,10 +43,7 @@ from gcloud.template_base.apis.django.validators import (
 from gcloud.template_base.domains import TEMPLATE_TYPE_MODEL
 from gcloud.template_base.domains.converter_handler import YamlSchemaConverterHandler
 from gcloud.template_base.domains.importer import TemplateImporter
-from gcloud.template_base.utils import (
-    format_import_result_to_response_data,
-    read_template_data_file,
-)
+from gcloud.template_base.utils import format_import_result_to_response_data, read_template_data_file
 from gcloud.utils.dates import time_now_str
 from gcloud.utils.decorators import request_validate
 from gcloud.utils.strings import string_to_boolean
@@ -195,6 +190,7 @@ def base_import_templates(request: Request, template_model_cls: object, import_k
             }
         )
 
+    audit_imported_templates(request.user.username, template_model_cls, import_result)
     return JsonResponse(format_import_result_to_response_data(import_result))
 
 

--- a/gcloud/template_base/apis/drf/viewsets/template.py
+++ b/gcloud/template_base/apis/drf/viewsets/template.py
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 """
 import logging
 
+from django.conf import settings
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -19,6 +20,7 @@ from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 
 from gcloud.common_template.models import CommonTemplate
+from gcloud.contrib.audit.operations import audit_deleted_templates
 from gcloud.core.apis.drf.viewsets import ApiMixin
 from gcloud.tasktmpl3.models import TaskTemplate
 from gcloud.template_base.apis.drf.permission import CommonTemplatePermission, ProjectTemplatePermission
@@ -40,6 +42,11 @@ class TemplateViewSet(ApiMixin, viewsets.GenericViewSet):
         body_serializer = self.template_ids_serializer(data=data)
         body_serializer.is_valid(raise_exception=True)
         template_ids = body_serializer.validated_data.get("template_ids")
+        instances_by_id = (
+            {instance.id: instance for instance in self.tmpl_model.objects.filter(id__in=template_ids)}
+            if settings.ENABLE_BK_AUDIT
+            else {}
+        )
         clear_result = clear_scope_webhooks(template_ids)
         if not clear_result["result"]:
             raise APIException(f'[batch_delete] clear_webhooks False: {clear_result["message"]}')
@@ -48,6 +55,12 @@ class TemplateViewSet(ApiMixin, viewsets.GenericViewSet):
         result = manager.batch_delete(template_ids)
         if not result["result"]:
             raise APIException(f'[batch_delete] result False: {result["message"]}')
+        audit_deleted_templates(
+            request.user.username,
+            self.tmpl_model,
+            instances_by_id,
+            result["data"].get("success", []),
+        )
         return Response(result["data"])
 
 

--- a/gcloud/tests/apigw/views/test_apply_webhook_configs.py
+++ b/gcloud/tests/apigw/views/test_apply_webhook_configs.py
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 """
 
 import ujson as json
+from django.urls import resolve
 
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
@@ -65,6 +66,7 @@ class ApplyWebhookConfigsAPITest(APITest):
         ]
 
         # Mock IAM拦截器中的模板验证
+        resolve(self.url().format(project_id=TEST_PROJECT_ID))
         with mock.patch(
             "gcloud.iam_auth.view_interceptors.apigw.apply_webhook_configs.TaskTemplate.objects.filter"
         ) as mock_task_filter:

--- a/gcloud/tests/apigw/views/test_modify_template_executor_proxy.py
+++ b/gcloud/tests/apigw/views/test_modify_template_executor_proxy.py
@@ -29,7 +29,7 @@ VIEW_PATH = "gcloud.apigw.views.modify_template_executor_proxy"
 MANAGER_PATH = VIEW_PATH + ".manager"
 POST_SAVE_SIGNAL_PATH = VIEW_PATH + ".post_template_save_commit"
 OPERATE_RECORD_SIGNAL_PATH = VIEW_PATH + ".operate_record_signal"
-BK_AUDIT_ADD_EVENT_PATH = VIEW_PATH + ".bk_audit_add_event"
+BK_AUDIT_ADD_EVENT_PATH = VIEW_PATH + ".bk_audit_add_event_on_commit"
 TRANSACTION_ATOMIC_PATH = VIEW_PATH + ".transaction.atomic"
 
 
@@ -65,11 +65,13 @@ class ModifyTemplateExecutorProxyAPITest(APITest):
     def test_modify_template_executor_proxy__success(self):
         template = _build_mock_template(executor_proxy="old_proxy")
 
-        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), \
-                mock.patch(MANAGER_PATH) as mock_manager, \
-                mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, \
-                mock.patch(OPERATE_RECORD_SIGNAL_PATH) as mock_operate_record_signal, \
-                mock.patch(BK_AUDIT_ADD_EVENT_PATH) as mock_audit:
+        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), mock.patch(
+            MANAGER_PATH
+        ) as mock_manager, mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, mock.patch(
+            OPERATE_RECORD_SIGNAL_PATH
+        ) as mock_operate_record_signal, mock.patch(
+            BK_AUDIT_ADD_EVENT_PATH
+        ) as mock_audit:
             mock_manager.update_pipeline.return_value = {"result": True, "data": None, "message": "success"}
 
             response = self.client.post(
@@ -131,11 +133,13 @@ class ModifyTemplateExecutorProxyAPITest(APITest):
         original_proxy = "original_owner"
         template = _build_mock_template(executor_proxy=original_proxy)
 
-        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), \
-                mock.patch(MANAGER_PATH) as mock_manager, \
-                mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, \
-                mock.patch(OPERATE_RECORD_SIGNAL_PATH) as mock_operate_record_signal, \
-                mock.patch(BK_AUDIT_ADD_EVENT_PATH) as mock_audit:
+        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), mock.patch(
+            MANAGER_PATH
+        ) as mock_manager, mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, mock.patch(
+            OPERATE_RECORD_SIGNAL_PATH
+        ) as mock_operate_record_signal, mock.patch(
+            BK_AUDIT_ADD_EVENT_PATH
+        ) as mock_audit:
             response = self.client.post(
                 path=self.url().format(template_id=TEST_TEMPLATE_ID, project_id=TEST_PROJECT_ID),
                 data=json.dumps({}),  # 不携带 executor_proxy 字段
@@ -179,11 +183,13 @@ class ModifyTemplateExecutorProxyAPITest(APITest):
         for payload in illegal_payloads:
             template = _build_mock_template(executor_proxy="original_owner")
 
-            with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), \
-                    mock.patch(MANAGER_PATH) as mock_manager, \
-                    mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, \
-                    mock.patch(OPERATE_RECORD_SIGNAL_PATH) as mock_operate_record_signal, \
-                    mock.patch(BK_AUDIT_ADD_EVENT_PATH) as mock_audit:
+            with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), mock.patch(
+                MANAGER_PATH
+            ) as mock_manager, mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, mock.patch(
+                OPERATE_RECORD_SIGNAL_PATH
+            ) as mock_operate_record_signal, mock.patch(
+                BK_AUDIT_ADD_EVENT_PATH
+            ) as mock_audit:
                 response = self.client.post(
                     path=self.url().format(template_id=TEST_TEMPLATE_ID, project_id=TEST_PROJECT_ID),
                     data=json.dumps(payload),
@@ -228,11 +234,13 @@ class ModifyTemplateExecutorProxyAPITest(APITest):
             pipeline_template.edit_time = "new_edit_time"
             return {"result": True, "data": pipeline_template, "message": "success"}
 
-        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), \
-                mock.patch(MANAGER_PATH) as mock_manager, \
-                mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, \
-                mock.patch(OPERATE_RECORD_SIGNAL_PATH) as mock_operate_record_signal, \
-                mock.patch(BK_AUDIT_ADD_EVENT_PATH) as mock_audit:
+        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), mock.patch(
+            MANAGER_PATH
+        ) as mock_manager, mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, mock.patch(
+            OPERATE_RECORD_SIGNAL_PATH
+        ) as mock_operate_record_signal, mock.patch(
+            BK_AUDIT_ADD_EVENT_PATH
+        ) as mock_audit:
             mock_manager.update_pipeline.side_effect = _update_pipeline_side_effect
 
             response = self.client.post(
@@ -291,11 +299,13 @@ class ModifyTemplateExecutorProxyAPITest(APITest):
         ),
     )
     def test_modify_template_executor_proxy__template_does_not_exist(self):
-        with mock.patch(TASKTEMPLATE_GET, MagicMock(side_effect=TaskTemplate.DoesNotExist)), \
-                mock.patch(MANAGER_PATH) as mock_manager, \
-                mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, \
-                mock.patch(OPERATE_RECORD_SIGNAL_PATH) as mock_operate_record_signal, \
-                mock.patch(BK_AUDIT_ADD_EVENT_PATH) as mock_audit:
+        with mock.patch(TASKTEMPLATE_GET, MagicMock(side_effect=TaskTemplate.DoesNotExist)), mock.patch(
+            MANAGER_PATH
+        ) as mock_manager, mock.patch(POST_SAVE_SIGNAL_PATH) as mock_post_save_signal, mock.patch(
+            OPERATE_RECORD_SIGNAL_PATH
+        ) as mock_operate_record_signal, mock.patch(
+            BK_AUDIT_ADD_EVENT_PATH
+        ) as mock_audit:
             response = self.client.post(
                 path=self.url().format(template_id=TEST_TEMPLATE_ID, project_id=TEST_PROJECT_ID),
                 data=json.dumps({"executor_proxy": TEST_USERNAME}),
@@ -328,8 +338,7 @@ class ModifyTemplateExecutorProxyAPITest(APITest):
     def test_modify_template_executor_proxy__proxy_must_be_self(self):
         template = _build_mock_template(executor_proxy="original_owner")
 
-        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), \
-                mock.patch(MANAGER_PATH) as mock_manager:
+        with mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)), mock.patch(MANAGER_PATH) as mock_manager:
             response = self.client.post(
                 path=self.url().format(template_id=TEST_TEMPLATE_ID, project_id=TEST_PROJECT_ID),
                 data=json.dumps({"executor_proxy": "someone_else"}),

--- a/gcloud/tests/apigw/views/test_modify_template_notify.py
+++ b/gcloud/tests/apigw/views/test_modify_template_notify.py
@@ -11,9 +11,10 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-import json
-import mock
 import contextlib
+import json
+
+import mock
 from mock import MagicMock
 
 from gcloud import err_code
@@ -120,7 +121,7 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
                 operate_record if operate_record is not None else MagicMock(),
             ),
             mock.patch(
-                "{}.bk_audit_add_event".format(view_module),
+                "{}.bk_audit_add_event_on_commit".format(view_module),
                 audit if audit is not None else MagicMock(),
             ),
         ]
@@ -213,11 +214,13 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
                 audit=mock_audit,
             ):
                 stack.enter_context(patcher)
-            response = self._post({
-                "notify_type": notify_type,
-                "notify_receivers": notify_receivers,
-                "common": False,
-            })
+            response = self._post(
+                {
+                    "notify_type": notify_type,
+                    "notify_receivers": notify_receivers,
+                    "common": False,
+                }
+            )
 
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.content)
@@ -256,17 +259,18 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
             stack.enter_context(mock.patch(TASKTEMPLATE_GET, MagicMock(return_value=template)))
             for patcher in self._common_patches():
                 stack.enter_context(patcher)
-            response = self._post({
-                "notify_type": notify_type,
-                "notify_receivers": notify_receivers,
-                "common": False,
-            })
+            response = self._post(
+                {
+                    "notify_type": notify_type,
+                    "notify_receivers": notify_receivers,
+                    "common": False,
+                }
+            )
 
         data = json.loads(response.content)
         self.assertEqual(response.status_code, 200)
         self.assertTrue(data["result"], msg=data)
-        self.assertEqual(data["data"]["notify_receivers"]["receiver_group"],
-                         ["Maintainers", 100, 101])
+        self.assertEqual(data["data"]["notify_receivers"]["receiver_group"], ["Maintainers", 100, 101])
 
     # # -------------------- 3. notify_type / notify_receivers 顶层类型错误受控失败 --------------------
     def test_modify_template_notify__notify_type_top_level_type_error_controlled_fail(self):
@@ -280,11 +284,13 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
         proj = self._build_project()
 
         with mock.patch(PROJECT_GET, MagicMock(return_value=proj)):
-            response = self._post({
-                "notify_type": "invalid_string",  # 类型错误
-                "notify_receivers": {},
-                "common": False,
-            })
+            response = self._post(
+                {
+                    "notify_type": "invalid_string",  # 类型错误
+                    "notify_receivers": {},
+                    "common": False,
+                }
+            )
 
         # 不得是 5xx
         self.assertLess(response.status_code, 500)
@@ -300,11 +306,13 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
         proj = self._build_project()
 
         with mock.patch(PROJECT_GET, MagicMock(return_value=proj)):
-            response = self._post({
-                "notify_type": {},
-                "notify_receivers": "invalid_string",  # 类型错误
-                "common": False,
-            })
+            response = self._post(
+                {
+                    "notify_type": {},
+                    "notify_receivers": "invalid_string",  # 类型错误
+                    "common": False,
+                }
+            )
 
         self.assertLess(response.status_code, 500)
         data = json.loads(response.content)
@@ -319,7 +327,7 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
             - update_pipeline 被调用（editor 即当前请求用户，推动 pipeline_template.editor/edit_time 的更新）
             - post_template_save_commit.send 被正确参数触发（sender=TaskTemplate）
             - operate_record_signal.send 被调用
-            - bk_audit_add_event 被调用（FLOW_EDIT_ACTION / FLOW_RESOURCE）
+            - bk_audit_add_event_on_commit 被调用（FLOW_EDIT_ACTION / FLOW_RESOURCE）
             - instance.save 被调用
         """
         proj = self._build_project()
@@ -343,11 +351,13 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
                 update_pipeline=mock_update_pipeline,
             ):
                 stack.enter_context(patcher)
-            response = self._post({
-                "notify_type": notify_type,
-                "notify_receivers": notify_receivers,
-                "common": False,
-            })
+            response = self._post(
+                {
+                    "notify_type": notify_type,
+                    "notify_receivers": notify_receivers,
+                    "common": False,
+                }
+            )
 
         data = json.loads(response.content)
         self.assertTrue(data["result"], msg=data)
@@ -426,11 +436,13 @@ class ModifyTemplateNotifyTmpAPITest(APITest):
                 audit=mock_audit,
             ):
                 stack.enter_context(patcher)
-            response = self._post({
-                "notify_type": notify_type,
-                "notify_receivers": notify_receivers,
-                "common": True,
-            })
+            response = self._post(
+                {
+                    "notify_type": notify_type,
+                    "notify_receivers": notify_receivers,
+                    "common": True,
+                }
+            )
 
         data = json.loads(response.content)
         self.assertTrue(data["result"], msg=data)

--- a/gcloud/tests/apigw/views/test_operate_task.py
+++ b/gcloud/tests/apigw/views/test_operate_task.py
@@ -13,8 +13,9 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
+from django.test import override_settings
 
-
+from gcloud.taskflow3.models import TaskFlowInstance
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
 
@@ -34,7 +35,10 @@ class OperateTaskAPITest(APITest):
         PROJECT_GET,
         MagicMock(
             return_value=MockProject(
-                project_id=TEST_PROJECT_ID, name=TEST_PROJECT_NAME, bk_biz_id=TEST_BIZ_CC_ID, from_cmdb=True,
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
             )
         ),
     )
@@ -60,7 +64,10 @@ class OperateTaskAPITest(APITest):
         PROJECT_GET,
         MagicMock(
             return_value=MockProject(
-                project_id=TEST_PROJECT_ID, name=TEST_PROJECT_NAME, bk_biz_id=TEST_BIZ_CC_ID, from_cmdb=True,
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
             )
         ),
     )
@@ -90,3 +97,44 @@ class OperateTaskAPITest(APITest):
                 data = json.loads(response.content)
 
                 self.assertTrue(data["result"])
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_operate_task__soft_deleted_task_keeps_start_behavior_when_audit_enabled(self):
+        task = MagicMock(id=TEST_TASKFLOW_ID, is_deleted=True)
+        queryset = MagicMock()
+        queryset.select_related.return_value.first.return_value = task
+        taskflow_instance = MagicMock()
+        taskflow_instance.objects.is_task_started.return_value = False
+        taskflow_instance.objects.get.side_effect = TaskFlowInstance.DoesNotExist
+        taskflow_instance.objects.filter.return_value = queryset
+        prepare_and_start_task = MagicMock()
+
+        with mock.patch(APIGW_OPERATE_TASK_TASKFLOW_INSTANCE, taskflow_instance):
+            with mock.patch(APIGW_OPERATE_TASK_PREPARE_AND_START_TASK, prepare_and_start_task):
+                with mock.patch("gcloud.apigw.views.operate_task.bk_audit_add_event_on_commit") as add_event:
+                    response = self.client.post(
+                        path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                        data=json.dumps({"action": "start"}),
+                        content_type="application/json",
+                    )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+        prepare_and_start_task.apply_async.assert_called_once()
+        add_event.assert_called_once_with(
+            username="",
+            action_id="task_operate",
+            resource_id="task",
+            instance=task,
+        )

--- a/gcloud/tests/apigw/views/test_set_periodic_task_enabled.py
+++ b/gcloud/tests/apigw/views/test_set_periodic_task_enabled.py
@@ -13,7 +13,9 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
+from django.test import override_settings
 
+from gcloud.contrib.audit.instances import AuditSnapshot
 from gcloud.periodictask.models import PeriodicTask
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
@@ -73,3 +75,63 @@ class SetPeriodicTaskEnabledAPITest(APITest):
 
         self.assertFalse(data["result"])
         self.assertTrue("message" in data)
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_set_periodic_task_enabled__audit_uses_compact_before_and_after_snapshots(self):
+        task = MockPeriodicTask(enabled=False)
+        task.set_enabled.side_effect = lambda enabled: setattr(task, "enabled", enabled)
+
+        with mock.patch(PERIODIC_TASK_GET, MagicMock(return_value=task)):
+            with mock.patch("gcloud.apigw.views.set_periodic_task_enabled.bk_audit_add_event_on_commit") as add_event:
+                response = self.client.post(
+                    path=self.url().format(task_id=TEST_PERIODIC_TASK_ID, project_id=TEST_PROJECT_ID),
+                    data=json.dumps({"enabled": True}),
+                    content_type="application/json",
+                    HTTP_BK_USERNAME=TEST_USERNAME,
+                )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+        self.assertEqual(
+            add_event.call_args[1]["origin_data"],
+            AuditSnapshot(
+                {
+                    "id": task.id,
+                    "name": task.name,
+                    "cron": task.cron,
+                    "enabled": False,
+                    "template_id": task.template_id,
+                    "template_source": task.template_source,
+                    "template_version": task.template_version,
+                    "creator": task.creator,
+                    "editor": "editor",
+                }
+            ),
+        )
+        self.assertEqual(
+            add_event.call_args[1]["data"],
+            AuditSnapshot(
+                {
+                    "id": task.id,
+                    "name": task.name,
+                    "cron": task.cron,
+                    "enabled": True,
+                    "template_id": task.template_id,
+                    "template_source": task.template_source,
+                    "template_version": task.template_version,
+                    "creator": task.creator,
+                    "editor": TEST_USERNAME,
+                }
+            ),
+        )

--- a/gcloud/tests/apigw/views/test_start_task.py
+++ b/gcloud/tests/apigw/views/test_start_task.py
@@ -13,8 +13,9 @@ specific language governing permissions and limitations under the License.
 
 
 import ujson as json
+from django.test import override_settings
 
-
+from gcloud.taskflow3.models import TaskFlowInstance
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
 
@@ -113,3 +114,46 @@ class StartTaskAPITest(APITest):
                 data.pop("trace_id")
 
             self.assertEqual(data, assert_return)
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_start_task__soft_deleted_task_keeps_business_behavior_when_audit_enabled(self):
+        task = MagicMock(id=TEST_TASKFLOW_ID, is_deleted=True)
+        queryset = MagicMock()
+        queryset.select_related.return_value.first.return_value = task
+        taskflow_instance = MagicMock()
+        taskflow_instance.objects.is_task_started.return_value = False
+        taskflow_instance.objects.get.side_effect = TaskFlowInstance.DoesNotExist
+        taskflow_instance.objects.filter.return_value = queryset
+        taskflow_instance.task_url.return_value = TEST_TASKFLOW_URL
+        prepare_and_start_task = MagicMock()
+
+        with mock.patch(APIGW_START_TASK_TASKFLOW_INSTANCE, taskflow_instance):
+            with mock.patch(APIGW_START_TASK_PREPARE_AND_START_TASK, prepare_and_start_task):
+                with mock.patch("gcloud.apigw.views.start_task.bk_audit_add_event_on_commit") as add_event:
+                    response = self.client.post(
+                        path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                        data=json.dumps({}),
+                        content_type="application/json",
+                        HTTP_BK_APP_CODE=TEST_APP_CODE,
+                    )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+        prepare_and_start_task.apply_async.assert_called_once()
+        add_event.assert_called_once_with(
+            username="",
+            action_id="task_operate",
+            resource_id="task",
+            instance=task,
+        )

--- a/gcloud/tests/contrib/audit/test_api_server_coverage.py
+++ b/gcloud/tests/contrib/audit/test_api_server_coverage.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+AUDITED_API_FILES = {
+    "create_task.py": "bk_audit_add_event_on_commit",
+    "create_and_start_task.py": "bk_audit_add_event_on_commit",
+    "fast_create_task.py": "bk_audit_add_event_on_commit",
+    "start_task.py": "bk_audit_add_event_on_commit",
+    "operate_task.py": "bk_audit_add_event_on_commit",
+    "operate_node.py": "bk_audit_add_event_on_commit",
+    "node_callback.py": "bk_audit_add_event_on_commit",
+    "modify_constants_for_task.py": "bk_audit_add_event_on_commit",
+    "create_periodic_task.py": "bk_audit_add_event_on_commit",
+    "set_periodic_task_enabled.py": "bk_audit_add_event_on_commit",
+    "modify_cron_for_periodic_task.py": "bk_audit_add_event_on_commit",
+    "modify_constants_for_periodic_task.py": "bk_audit_add_event_on_commit",
+    "create_clocked_task.py": "bk_audit_add_event_on_commit",
+    "create_template.py": "bk_audit_add_event_on_commit",
+    "import_project_template.py": "audit_imported_templates",
+    "import_common_template.py": "audit_imported_templates",
+    "copy_template_across_project.py": "audit_imported_templates",
+    "register_project.py": "bk_audit_add_event_on_commit",
+    "claim_functionalization_task.py": "bk_audit_add_event_on_commit",
+    "apply_webhook_configs.py": "bk_audit_add_event_on_commit",
+    "modify_project_executor_proxy.py": "bk_audit_add_event_on_commit",
+    "modify_template_notify.py": "bk_audit_add_event_on_commit",
+    "modify_template_executor_proxy.py": "bk_audit_add_event_on_commit",
+}
+
+AUDITED_PAGE_FILES = {
+    "gcloud/clocked_task/viewset.py": "bk_audit_add_event_on_commit",
+    "gcloud/periodictask/api.py": "bk_audit_add_event_on_commit",
+    "gcloud/contrib/function/api.py": "bk_audit_add_event_on_commit",
+    "gcloud/core/apis/drf/viewsets/appmaker.py": "bk_audit_add_event_on_commit",
+    "gcloud/core/apis/drf/viewsets/periodic_task.py": "bk_audit_add_event_on_commit",
+    "gcloud/core/apis/drf/viewsets/project.py": "bk_audit_add_event_on_commit",
+    "gcloud/core/apis/drf/viewsets/project_config.py": "bk_audit_add_event_on_commit",
+    "gcloud/core/apis/drf/viewsets/taskflow.py": "bk_audit_add_event_on_commit",
+    "gcloud/taskflow3/apis/django/api.py": "bk_audit_add_event_on_commit",
+    "gcloud/taskflow3/apis/django/v4/node_action.py": "bk_audit_add_event_on_commit",
+    "gcloud/taskflow3/apis/drf/viewsets/update_task_constants.py": "bk_audit_add_event_on_commit",
+    "gcloud/template_base/apis/django/api.py": "audit_imported_templates",
+    "gcloud/template_base/apis/drf/viewsets/template.py": "audit_deleted_templates",
+}
+
+
+def _called_names(path):
+    tree = ast.parse(path.read_text())
+    return {node.func.id for node in ast.walk(tree) if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)}
+
+
+@pytest.mark.parametrize("filename,expected_call", sorted(AUDITED_API_FILES.items()))
+def test_api_server_write_endpoint_registers_audit_event(filename, expected_call):
+    path = REPO_ROOT / "gcloud" / "apigw" / "views" / filename
+    assert expected_call in _called_names(path), "{} does not call {}".format(filename, expected_call)
+
+
+@pytest.mark.parametrize("relative_path,expected_call", sorted(AUDITED_PAGE_FILES.items()))
+def test_page_write_endpoint_registers_audit_event(relative_path, expected_call):
+    path = REPO_ROOT / relative_path
+    assert expected_call in _called_names(path), "{} does not call {}".format(relative_path, expected_call)
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        "gcloud/apigw/views/plugin_gateway.py",
+        "gcloud/core/apis/drf/viewsets/package_source.py",
+        "gcloud/core/apis/drf/viewsets/sync_task.py",
+    ],
+)
+def test_deferred_endpoints_do_not_report_audit_events(relative_path):
+    path = REPO_ROOT / relative_path
+    if path.exists():
+        assert "bk_audit_add_event" not in path.read_text()

--- a/gcloud/tests/contrib/audit/test_instances.py
+++ b/gcloud/tests/contrib/audit/test_instances.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+from django.test import SimpleTestCase
+
+from gcloud.contrib.audit.instances import BaseInstance
+
+
+class AuditInstanceTestCase(SimpleTestCase):
+    def test_deleted_instance_uses_explicit_snapshot_id(self):
+        instance = BaseInstance(mock.Mock(id=None, name="deleted"), data={"id": 101, "is_deleted": True})
+
+        self.assertEqual(instance.instance_id, 101)

--- a/gcloud/tests/contrib/audit/test_mappings.py
+++ b/gcloud/tests/contrib/audit/test_mappings.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from django.test import SimpleTestCase
+
+from gcloud.common_template.models import CommonTemplate
+from gcloud.constants import BUSINESS, COMMON, ONETIME, PROJECT
+from gcloud.contrib.audit.mappings import (
+    get_periodic_task_create_action,
+    get_task_create_action,
+    get_template_audit_meta,
+)
+from gcloud.iam_auth import IAMMeta
+from gcloud.tasktmpl3.models import TaskTemplate
+
+
+class AuditMappingsTestCase(SimpleTestCase):
+    def test_task_create_actions_use_existing_actions(self):
+        self.assertEqual(get_task_create_action(PROJECT), IAMMeta.FLOW_CREATE_TASK_ACTION)
+        self.assertEqual(get_task_create_action(BUSINESS), IAMMeta.FLOW_CREATE_TASK_ACTION)
+        self.assertEqual(get_task_create_action(COMMON), IAMMeta.COMMON_FLOW_CREATE_TASK_ACTION)
+        self.assertEqual(get_task_create_action(ONETIME), IAMMeta.PROJECT_FAST_CREATE_TASK_ACTION)
+        self.assertEqual(get_task_create_action(PROJECT, "app_maker"), IAMMeta.MINI_APP_CREATE_TASK_ACTION)
+        self.assertIsNone(get_task_create_action("unknown"))
+
+    def test_periodic_create_actions_distinguish_template_source(self):
+        self.assertEqual(get_periodic_task_create_action(PROJECT), IAMMeta.FLOW_CREATE_PERIODIC_TASK_ACTION)
+        self.assertEqual(get_periodic_task_create_action(COMMON), IAMMeta.COMMON_FLOW_CREATE_PERIODIC_TASK_ACTION)
+        self.assertIsNone(get_periodic_task_create_action("unknown"))
+
+    def test_template_meta_uses_existing_resources(self):
+        self.assertEqual(
+            get_template_audit_meta(TaskTemplate),
+            (IAMMeta.FLOW_CREATE_ACTION, IAMMeta.FLOW_DELETE_ACTION, IAMMeta.FLOW_RESOURCE),
+        )
+        self.assertEqual(
+            get_template_audit_meta(CommonTemplate),
+            (
+                IAMMeta.COMMON_FLOW_CREATE_ACTION,
+                IAMMeta.COMMON_FLOW_DELETE_ACTION,
+                IAMMeta.COMMON_FLOW_RESOURCE,
+            ),
+        )

--- a/gcloud/tests/contrib/audit/test_operations.py
+++ b/gcloud/tests/contrib/audit/test_operations.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from gcloud.contrib.audit import operations
+
+
+@override_settings(ENABLE_BK_AUDIT=True)
+class AuditOperationsTestCase(SimpleTestCase):
+    @mock.patch("gcloud.contrib.audit.operations.bk_audit_add_event_on_commit")
+    @mock.patch(
+        "gcloud.contrib.audit.operations.get_template_audit_meta",
+        return_value=("flow_create", "flow_delete", "flow"),
+    )
+    def test_import_only_reports_real_result_ids(self, get_meta, add_event):
+        instances = [mock.Mock(id=101), mock.Mock(id=102)]
+        model_cls = mock.Mock()
+        model_cls.objects.filter.return_value = instances
+        result = {"result": True, "data": {"flows": {"101": "a", "102": "b"}}}
+
+        operations.audit_imported_templates("admin", model_cls, result)
+
+        model_cls.objects.filter.assert_called_once_with(id__in=[101, 102])
+        self.assertEqual(add_event.call_count, 2)
+        self.assertEqual({call[1]["instance"].id for call in add_event.call_args_list}, {101, 102})
+
+    @mock.patch("gcloud.contrib.audit.operations.bk_audit_add_event_on_commit")
+    def test_failed_import_reports_nothing(self, add_event):
+        operations.audit_imported_templates("admin", mock.Mock(), {"result": False, "data": None})
+
+        add_event.assert_not_called()
+
+    @override_settings(ENABLE_BK_AUDIT=False)
+    @mock.patch("gcloud.contrib.audit.operations.get_template_audit_meta")
+    def test_disabled_import_does_not_build_mapping_or_query(self, get_meta):
+        model_cls = mock.Mock()
+
+        operations.audit_imported_templates("admin", model_cls, {"result": True, "data": {"flows": {"101": "flow"}}})
+
+        get_meta.assert_not_called()
+        model_cls.objects.filter.assert_not_called()
+
+    @mock.patch("gcloud.contrib.audit.operations.bk_audit_add_event_on_commit")
+    @mock.patch(
+        "gcloud.contrib.audit.operations.get_template_audit_meta",
+        return_value=("flow_create", "flow_delete", "flow"),
+    )
+    def test_import_audit_query_error_does_not_affect_business(self, get_meta, add_event):
+        model_cls = mock.Mock()
+        model_cls.objects.filter.side_effect = RuntimeError("audit query failed")
+
+        operations.audit_imported_templates("admin", model_cls, {"result": True, "data": {"flows": {"101": "flow"}}})
+
+        add_event.assert_not_called()
+
+    @mock.patch("gcloud.contrib.audit.operations.get_audit_snapshot", return_value={"id": 101})
+    @mock.patch("gcloud.contrib.audit.operations.bk_audit_add_event_on_commit")
+    @mock.patch(
+        "gcloud.contrib.audit.operations.get_template_audit_meta",
+        return_value=("flow_create", "flow_delete", "flow"),
+    )
+    def test_delete_only_reports_success_ids(self, get_meta, add_event, get_snapshot):
+        success = mock.Mock(id=101)
+        failed = mock.Mock(id=102)
+
+        operations.audit_deleted_templates(
+            username="admin",
+            template_model_cls=mock.Mock(),
+            instances_by_id={101: success, 102: failed},
+            success_ids=["101"],
+        )
+
+        add_event.assert_called_once()
+        self.assertEqual(add_event.call_args[1]["instance"], success)
+        self.assertEqual(add_event.call_args[1]["data"], {"id": 101, "is_deleted": True})

--- a/gcloud/tests/contrib/audit/test_utils.py
+++ b/gcloud/tests/contrib/audit/test_utils.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+import json
+from unittest import mock
+
+from django.db import transaction
+from django.test import SimpleTestCase, TestCase, override_settings
+
+from gcloud.contrib.audit import utils
+
+
+class AuditUtilsTestCase(SimpleTestCase):
+    @override_settings(ENABLE_BK_AUDIT=False)
+    @mock.patch("gcloud.contrib.audit.utils.transaction.on_commit")
+    def test_disabled_event_does_not_register_callback(self, on_commit):
+        utils.bk_audit_add_event_on_commit(
+            username="admin", action_id="task_edit", resource_id="task", instance=mock.Mock(id=1)
+        )
+
+        on_commit.assert_not_called()
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.transaction.on_commit")
+    def test_enabled_event_registers_callback(self, on_commit):
+        utils.bk_audit_add_event_on_commit(
+            username="admin", action_id="task_edit", resource_id="task", instance=mock.Mock(id=1)
+        )
+
+        on_commit.assert_called_once()
+
+    def test_sanitize_audit_data_removes_sensitive_and_large_fields(self):
+        data = {
+            "name": "task",
+            "token": "secret-token",
+            "nested": {"password": "secret-password", "safe": "value"},
+            "pipeline_tree": {"activities": {"node": {}}},
+            "constants": {"${password}": {"value": "secret-value"}},
+            "headers": {"Authorization": "Bearer secret"},
+        }
+
+        sanitized = utils.sanitize_audit_data(data)
+
+        self.assertEqual(sanitized["name"], "task")
+        self.assertEqual(sanitized["token"], "******")
+        self.assertEqual(sanitized["nested"]["password"], "******")
+        self.assertEqual(sanitized["nested"]["safe"], "value")
+        self.assertNotIn("pipeline_tree", sanitized)
+        self.assertNotIn("constants", sanitized)
+        self.assertNotIn("headers", sanitized)
+
+    def test_sanitize_audit_data_redacts_nested_json_strings(self):
+        data = {
+            "notify_receivers": json.dumps(
+                {
+                    "receiver_group": ["Maintainers"],
+                    "extra_info": {"token": "secret-token"},
+                    "webhook_secret": "secret-value",
+                }
+            )
+        }
+
+        sanitized = json.loads(utils.sanitize_audit_data(data)["notify_receivers"])
+
+        self.assertEqual(sanitized["receiver_group"], ["Maintainers"])
+        self.assertNotIn("extra_info", sanitized)
+        self.assertEqual(sanitized["webhook_secret"], "******")
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.build_instance", side_effect=RuntimeError("sdk failed"))
+    def test_client_error_isolated_and_logged_without_instance_body(self, build_instance):
+        instance = mock.Mock(id=1)
+        instance.__str__ = mock.Mock(return_value="secret-instance-body")
+
+        with self.assertLogs("root", level="ERROR") as logs:
+            utils.bk_audit_add_event("admin", "task_edit", "task", instance)
+
+        output = "\n".join(logs.output)
+        self.assertIn("bk_audit_add_event_failed", output)
+        self.assertIn("action_id=task_edit", output)
+        self.assertIn("resource_id=task", output)
+        self.assertIn("instance_id=1", output)
+        self.assertNotIn("secret-instance-body", output)
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.bk_audit_client.add_event")
+    @mock.patch("gcloud.contrib.audit.utils.build_instance", return_value="audit-instance")
+    def test_event_sanitizes_origin_and_current_data(self, build_instance, add_event):
+        instance = mock.Mock(id=1)
+
+        utils.bk_audit_add_event(
+            "admin",
+            "task_edit",
+            "task",
+            instance,
+            origin_data={"password": "origin-secret", "name": "old"},
+            data={"token": "current-secret", "name": "new", "pipeline_tree": {"activities": {}}},
+        )
+
+        origin_data = build_instance.call_args[0][2]
+        current_data = build_instance.call_args[0][3]
+        self.assertEqual(origin_data, {"password": "******", "name": "old"})
+        self.assertEqual(current_data, {"token": "******", "name": "new"})
+        add_event.assert_called_once()
+
+
+class AuditTransactionTestCase(TestCase):
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.bk_audit_add_event")
+    def test_commit_sends_once(self, add_event):
+        with self.captureOnCommitCallbacks(execute=True):
+            utils.bk_audit_add_event_on_commit(
+                username="admin", action_id="task_edit", resource_id="task", instance=mock.Mock(id=1)
+            )
+
+        add_event.assert_called_once()
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.bk_audit_add_event")
+    def test_rollback_does_not_send(self, add_event):
+        with self.captureOnCommitCallbacks(execute=True):
+            try:
+                with transaction.atomic():
+                    utils.bk_audit_add_event_on_commit(
+                        username="admin", action_id="task_edit", resource_id="task", instance=mock.Mock(id=1)
+                    )
+                    raise RuntimeError("rollback")
+            except RuntimeError:
+                pass
+
+        add_event.assert_not_called()

--- a/gcloud/tests/contrib/audit/test_utils.py
+++ b/gcloud/tests/contrib/audit/test_utils.py
@@ -81,6 +81,21 @@ class AuditUtilsTestCase(SimpleTestCase):
         self.assertNotIn("secret-instance-body", output)
 
     @override_settings(ENABLE_BK_AUDIT=True)
+    def test_instance_id_error_isolated(self):
+        class BrokenInstance(object):
+            @property
+            def id(self):
+                raise RuntimeError("id unavailable")
+
+        try:
+            with self.assertLogs("root", level="ERROR") as logs:
+                utils.bk_audit_add_event("admin", "task_edit", "task", BrokenInstance())
+        except RuntimeError as error:
+            self.fail("audit instance id error leaked to caller: {}".format(error))
+
+        self.assertIn("bk_audit_add_event_failed", "\n".join(logs.output))
+
+    @override_settings(ENABLE_BK_AUDIT=True)
     @mock.patch("gcloud.contrib.audit.utils.bk_audit_client.add_event")
     @mock.patch("gcloud.contrib.audit.utils.build_instance", return_value="audit-instance")
     def test_event_sanitizes_origin_and_current_data(self, build_instance, add_event):
@@ -100,6 +115,16 @@ class AuditUtilsTestCase(SimpleTestCase):
         self.assertEqual(origin_data, {"password": "******", "name": "old"})
         self.assertEqual(current_data, {"token": "******", "name": "new"})
         add_event.assert_called_once()
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    def test_snapshot_accepts_lazy_data_builder(self):
+        snapshot = utils.get_audit_snapshot(
+            "periodic_task",
+            mock.Mock(id=1),
+            data=lambda: {"id": 1, "enabled": True},
+        )
+
+        self.assertEqual(snapshot, {"id": 1, "enabled": True})
 
 
 class AuditTransactionTestCase(TestCase):

--- a/gcloud/tests/contrib/audit/test_webhook.py
+++ b/gcloud/tests/contrib/audit/test_webhook.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+from django.test import SimpleTestCase, override_settings
+
+from gcloud.apigw.views.apply_webhook_configs import _audit_webhook_changes, _get_webhook_audit_context
+from gcloud.contrib.audit.instances import AuditSnapshot
+
+
+class WebhookAuditTestCase(SimpleTestCase):
+    @mock.patch("gcloud.apigw.views.apply_webhook_configs.bk_audit_add_event_on_commit")
+    def test_webhook_audit_only_contains_safe_summary(self, add_event):
+        template = mock.Mock(id=101)
+        origins = {"101": AuditSnapshot({"template_id": 101, "webhook_enabled": False, "event_types": []})}
+
+        _audit_webhook_changes(
+            username="admin",
+            templates={"101": template},
+            origins=origins,
+            enabled=True,
+            events_by_template={"101": ["task_finished"]},
+        )
+
+        event_data = add_event.call_args[1]["data"]
+        self.assertEqual(
+            event_data,
+            {
+                "template_id": 101,
+                "webhook_enabled": True,
+                "event_types": ["task_finished"],
+            },
+        )
+        self.assertNotIn("endpoint", event_data)
+        self.assertNotIn("headers", event_data)
+        self.assertNotIn("extra_info", event_data)
+
+    @override_settings(ENABLE_BK_AUDIT=False)
+    @mock.patch("gcloud.apigw.views.apply_webhook_configs.TaskTemplate.objects.filter")
+    def test_disabled_webhook_audit_does_not_query(self, template_filter):
+        self.assertEqual(_get_webhook_audit_context(1, [101]), ({}, {}))
+        template_filter.assert_not_called()
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch(
+        "gcloud.apigw.views.apply_webhook_configs.TaskTemplate.objects.filter",
+        side_effect=RuntimeError("audit query failed"),
+    )
+    def test_webhook_audit_query_error_does_not_affect_business(self, template_filter):
+        self.assertEqual(_get_webhook_audit_context(1, [101]), ({}, {}))

--- a/gcloud/tests/taskflow3/test_update_task_constants_view.py
+++ b/gcloud/tests/taskflow3/test_update_task_constants_view.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+from types import SimpleNamespace
+from unittest import mock
+
+import factory
+from django.db.models import signals
+from django.test import TestCase, override_settings
+from pipeline.models import PipelineInstance, PipelineTemplate, Snapshot
+
+from gcloud.taskflow3.apis.drf.viewsets.update_task_constants import UpdateTaskConstantsView
+from gcloud.taskflow3.models import TaskFlowInstance
+
+
+class UpdateTaskConstantsViewTestCase(TestCase):
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def setUp(self):
+        snapshot = Snapshot.objects.create_snapshot({})
+        template = PipelineTemplate.objects.create(template_id="template", creator="admin", snapshot=snapshot)
+        pipeline_instance = PipelineInstance.objects.create(
+            instance_id="instance",
+            creator="admin",
+            executor="admin",
+            snapshot=snapshot,
+            template=template,
+        )
+        self.task = TaskFlowInstance.objects.create(
+            pipeline_instance=pipeline_instance,
+            template_id=template.id,
+            current_flow="execute_task",
+        )
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch.object(
+        TaskFlowInstance,
+        "set_task_constants",
+        return_value={"result": False, "message": "not changed", "data": ""},
+    )
+    @mock.patch("gcloud.taskflow3.apis.drf.viewsets.update_task_constants.get_audit_snapshot")
+    def test_audit_snapshot_receives_fully_loaded_task(self, get_audit_snapshot, set_task_constants):
+        request = SimpleNamespace(data={"constants": {}, "meta_constants": {}}, user=SimpleNamespace(username="admin"))
+
+        UpdateTaskConstantsView().post(request, self.task.id)
+
+        audit_task = get_audit_snapshot.call_args[0][1]
+        self.assertEqual(audit_task.get_deferred_fields(), set())
+        self.assertIn("pipeline_instance", audit_task._state.fields_cache)


### PR DESCRIPTION
## 背景

一期在不新增蓝鲸审计动作和资源的前提下，补齐页面与 API Server 的 P0 操作审计，并为后续通过部署环境配置 API Server Token 做好代码准备。

TAPD：[136920805 标准运维操作审计一期补漏及 API Server 上报](https://tapd.woa.com/10131351/prong/stories/view/1010131351136920805)

## 主要变更

- 增加事务提交后发送、前后快照、递归脱敏、异常隔离和 Token 关闭时零审计查询的统一底座。
- 集中复用现有任务/周期任务/模板动作映射，导入和批量删除只按真实成功资源逐条上报。
- 修正项目修改、轻应用/周期任务删除、任务操作等首版提前上报或失败误报问题。
- 补齐计划任务、节点操作、任务参数、职能任务、模板导入/删除、项目代理等页面 P0。
- 补齐任务生命周期、调度、流程导入/复制、项目注册、Webhook 和模板配置等 23 个 API Server 写入口。
- Webhook 只记录模板 ID、启用状态和事件类型；不记录 endpoint、headers、extra_info。

## 明确边界

- 未新增 IAM/审计动作或资源。
- 未修改 API 请求/响应、APIGW YAML、config/default.py 或 Token/Endpoint 默认值。
- 插件网关、包源和同步入口仍按设计延期，不做错误资源映射。
- Token 仍由部署环境提供；合入后先保持为空部署，再在预发布和生产少量 API Server 实例灰度开启。

## 验证

- 审计底座/覆盖测试 + API Server 现有回归：`128 passed`。
- 页面扩展回归：`28 passed`；另 13 项为仓库既有测试 patch 污染 DRF 路由扫描导致的 `MagicMock.__name__` 基线问题，设计文档已记录。
- Python 3.6 compileall、Black、Isort、Flake8、merge-conflict、git diff check 均通过。
- `api-resources.yml`、IAMMeta 配置、config/default.py、插件网关、包源/同步文件相对 upstream/master 无差异；密钥模式检查无命中。
- pre-commit 的 check-migrate/check-sensitive-info 因 upstream/master 缺少其引用脚本无法启动，已分别用无模型/schema 变更检查和敏感配置差异检查替代；commitlint 因本机 Node 依赖 ESM 冲突无法启动，提交信息已按仓库约定人工核对。

详细设计与灰度清单见 `docs/specs/2026-08-07-operation-audit-phase1-design.md`。