### PR TITLE
feat: PO 委托操作使用真实用户审计

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -947,6 +947,7 @@ PERIODIC_TASK_ITERATION = env.PERIODIC_TASK_ITERATION
 
 # bk_audit
 ENABLE_BK_AUDIT = True if env.BK_AUDIT_DATA_TOKEN else False
+BK_AUDIT_DELEGATED_OPERATOR_APPS = env.BK_AUDIT_DELEGATED_OPERATOR_APPS
 BK_AUDIT_SETTINGS = {
     "log_queue_limit": 50000,
     "exporters": ["bk_audit.contrib.opentelemetry.exporters.OTLogExporter"],

--- a/docs/plans/2026-08-10-delegated-audit-operator.md
+++ b/docs/plans/2026-08-10-delegated-audit-operator.md
@@ -1,0 +1,580 @@
+# 委托审计操作人 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 PO 登录用户 A 成为标准运维审计中心的最终操作人，同时保持 PO 业务执行代理人 B 负责内部网关认证、IAM 校验和任务执行。
+
+**Architecture:** PO Facade 以 B 创建 BKAPI 客户端，并在三个写入口中由后端添加 `X-BkSops-Audit-Operator: A`。标准运维从已认证的 `request.app`、原始 APIGW JWT 验证状态和专用 app code 白名单中建立可信边界，只在审计调用处使用 A；所有业务调用继续使用 `request.user.username == B`。
+
+**Tech Stack:** Python 3.6/3.10、Django 2.2/3.2、BKAPI Client Core、APIGW Manager、`bk-audit==1.1.1`、pytest/Django TestCase、TAPD 需求 `136920805`。
+
+## Global Constraints
+
+- 设计规格：`docs/specs/2026-08-10-delegated-audit-operator-design.md`。
+- 标准运维基线：最新 `upstream/master`，分支 `feat/delegated-audit-operator`。
+- PO Facade 基线：`origin/release`，独立分支 `ai/delegated-audit-operator`。
+- 不新增审计动作、资源、公开请求 body 字段、响应字段或 operationId。
+- `request.user.username` 始终保留为 B，只有审计事件 username 可以解析为 A。
+- 专用可信应用配置默认空集合；不硬编码 PO 内部 app code。
+- 非可信、未验证、缺失或非法委托身份必须回退 B，且不得阻断业务。
+- Facade 不能透传浏览器提供的同名头，必须由后端认证用户重新生成。
+- 所有生产代码必须先有预期失败的测试，再写最小实现。
+
+---
+
+### Task 1: 标准运维委托审计身份解析底座
+
+**Files:**
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/env.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/config/default.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/contrib/audit/utils.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/tests/contrib/audit/test_utils.py`
+
+**Interfaces:**
+- Consumes: Django request with `request.user.username`, authenticated `request.app`, `_apigw_jwt_user_verified`, `META`, and optional `trace_id`.
+- Produces: `get_audit_username(request) -> str` and deployment setting `BK_AUDIT_DELEGATED_OPERATOR_APPS: Set[str]`.
+
+- [ ] **Step 1: Write failing resolver tests**
+
+Append a focused test class to `gcloud/tests/contrib/audit/test_utils.py`. Build requests with `SimpleNamespace`, use `override_settings`, and assert literal results:
+
+```python
+class DelegatedAuditUsernameTestCase(SimpleTestCase):
+    def request(self, app_code="bk-sops-facade", proxy="executor", operator=None, verified=True):
+        meta = {}
+        if operator is not None:
+            meta["HTTP_X_BKSOPS_AUDIT_OPERATOR"] = operator
+        return SimpleNamespace(
+            user=SimpleNamespace(username=proxy),
+            app=SimpleNamespace(bk_app_code=app_code),
+            META=meta,
+            _apigw_jwt_user_verified=verified,
+            trace_id="trace-1",
+        )
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_trusted_verified_request_uses_delegated_operator(self):
+        self.assertEqual(utils.get_audit_username(self.request(operator="alice@tai")), "alice@tai")
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_untrusted_or_unverified_request_falls_back_to_proxy(self):
+        self.assertEqual(
+            utils.get_audit_username(self.request(app_code="other-app", operator="alice")),
+            "executor",
+        )
+        self.assertEqual(
+            utils.get_audit_username(self.request(operator="alice", verified=False)),
+            "executor",
+        )
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_missing_or_invalid_operator_falls_back_to_proxy(self):
+        for operator in (None, "", "has space", "bad/value", "x" * 65):
+            with self.subTest(operator=operator):
+                self.assertEqual(utils.get_audit_username(self.request(operator=operator)), "executor")
+```
+
+The production mutation caught is accepting an untrusted/unverified or malformed asserted identity, or failing to use a valid trusted A.
+
+- [ ] **Step 2: Run resolver tests and verify RED**
+
+Run:
+
+```bash
+pytest -q gcloud/tests/contrib/audit/test_utils.py
+```
+
+Expected: FAIL because `gcloud.contrib.audit.utils.get_audit_username` does not exist.
+
+- [ ] **Step 3: Add the deployment setting**
+
+In `env.py`, parse a comma-separated OS environment variable into a set, dropping whitespace and empty entries:
+
+```python
+BK_AUDIT_DELEGATED_OPERATOR_APPS = {
+    app_code.strip()
+    for app_code in os.getenv("BK_AUDIT_DELEGATED_OPERATOR_APPS", "").split(",")
+    if app_code.strip()
+}
+```
+
+In `config/default.py`, expose it through Django settings:
+
+```python
+BK_AUDIT_DELEGATED_OPERATOR_APPS = env.BK_AUDIT_DELEGATED_OPERATOR_APPS
+```
+
+- [ ] **Step 4: Implement the minimal resolver**
+
+In `gcloud/contrib/audit/utils.py`, add:
+
+```python
+DELEGATED_AUDIT_OPERATOR_META_KEY = "HTTP_X_BKSOPS_AUDIT_OPERATOR"
+DELEGATED_AUDIT_OPERATOR_PATTERN = re.compile(r"^[A-Za-z0-9_.@-]{1,64}$")
+
+
+def get_audit_username(request):
+    proxy_username = getattr(getattr(request, "user", None), "username", "")
+    operator = getattr(request, "META", {}).get(DELEGATED_AUDIT_OPERATOR_META_KEY)
+    if not operator:
+        return proxy_username
+
+    app_code = getattr(
+        getattr(request, "app", None),
+        settings.APIGW_MANAGER_APP_CODE_KEY,
+        "",
+    )
+    trusted_apps = getattr(settings, "BK_AUDIT_DELEGATED_OPERATOR_APPS", set())
+    trace_id = getattr(request, "trace_id", "")
+    if app_code not in trusted_apps or getattr(request, "_apigw_jwt_user_verified", False) is not True:
+        logger.warning(
+            "bk_audit delegated_operator_ignored app_code=%s proxy_username=%s trace_id=%s",
+            app_code,
+            proxy_username,
+            trace_id,
+        )
+        return proxy_username
+
+    if not DELEGATED_AUDIT_OPERATOR_PATTERN.fullmatch(operator):
+        logger.warning(
+            "bk_audit delegated_operator_invalid app_code=%s proxy_username=%s trace_id=%s",
+            app_code,
+            proxy_username,
+            trace_id,
+        )
+        return proxy_username
+
+    logger.info(
+        "bk_audit delegated_operator_resolved audit_username=%s proxy_username=%s app_code=%s trace_id=%s",
+        operator,
+        proxy_username,
+        app_code,
+        trace_id,
+    )
+    return operator
+```
+
+- [ ] **Step 5: Run resolver tests and verify GREEN**
+
+Run:
+
+```bash
+pytest -q gcloud/tests/contrib/audit/test_utils.py
+```
+
+Expected: PASS with the new trusted, fallback, and validation cases plus all existing audit utility tests.
+
+- [ ] **Step 6: Commit the resolver**
+
+```bash
+git add env.py config/default.py gcloud/contrib/audit/utils.py gcloud/tests/contrib/audit/test_utils.py
+git commit -m "feat: 支持可信委托审计操作人 --story=136920805"
+```
+
+---
+
+### Task 2: 标准运维三个 PO 写入口分离业务用户和审计用户
+
+**Files:**
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/apigw/views/create_task.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/apigw/views/operate_task.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/apigw/views/operate_node.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/tests/apigw/views/test_create_task.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/tests/apigw/views/test_operate_task.py`
+- Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/tests/apigw/views/test_operate_node.py`
+
+**Interfaces:**
+- Consumes: `get_audit_username(request) -> str` from Task 1.
+- Produces: task creation/operation behavior under B with audit calls under A.
+
+- [ ] **Step 1: Write failing view wiring tests**
+
+For each view, patch `get_audit_username` to return literal `"alice"` and patch `bk_audit_add_event_on_commit`. Send the business request as `HTTP_BK_USERNAME="executor"`.
+
+Assertions must cover both sides of the split:
+
+```python
+create_pipeline_kwargs["creator"] == "executor"
+audit_event.call_args.kwargs["username"] == "alice"
+```
+
+```python
+prepare_and_start_task.apply_async.call_args.kwargs["kwargs"]["username"] == "executor"
+audit_event.call_args.kwargs["username"] == "alice"
+```
+
+```python
+task.nodes_action.assert_called_once_with(
+    action,
+    node_id,
+    "executor",
+    data=data,
+    inputs=inputs,
+    flow_id=flow_id,
+)
+audit_event.call_args.kwargs["username"] == "alice"
+```
+
+Add a real POST success test for `operate_node`; do not reuse the existing misspelled `trest_operate_node__success` GET method because it is not collected and violates `@require_POST`.
+
+The production mutation caught is replacing B with A in business execution, or continuing to report B in audit.
+
+- [ ] **Step 2: Run the three view test files and verify RED**
+
+Run:
+
+```bash
+pytest -q \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+```
+
+Expected: FAIL because the views do not import/call `get_audit_username`, and audit still receives B.
+
+- [ ] **Step 3: Implement minimal view changes**
+
+In each view, import `get_audit_username` alongside `bk_audit_add_event_on_commit`. Keep the existing business `username` unchanged and replace only the audit argument. The three audit calls must be:
+
+```python
+# create_task.py
+bk_audit_add_event_on_commit(
+    username=get_audit_username(request),
+    action_id=action_id,
+    resource_id=IAMMeta.TASK_RESOURCE,
+    instance=task,
+)
+
+# operate_task.py
+bk_audit_add_event_on_commit(
+    username=get_audit_username(request),
+    action_id=IAMMeta.TASK_OPERATE_ACTION,
+    resource_id=IAMMeta.TASK_RESOURCE,
+    instance=task,
+)
+
+# operate_node.py
+bk_audit_add_event_on_commit(
+    username=get_audit_username(request),
+    action_id=IAMMeta.TASK_OPERATE_ACTION,
+    resource_id=IAMMeta.TASK_RESOURCE,
+    instance=task,
+)
+```
+
+Do not change pipeline instance creator, Celery kwargs, `task_action`, `nodes_action`, permission decorators, request/response bodies, or operation records.
+
+- [ ] **Step 4: Run the three view test files and verify GREEN**
+
+Run the same three-file pytest command.
+
+Expected: PASS; tests demonstrate B for business operations and A for audit calls.
+
+- [ ] **Step 5: Run standard-ops audit regression**
+
+Run:
+
+```bash
+pytest -q \
+  gcloud/tests/contrib/audit \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+```
+
+Expected: PASS with no request/response regressions.
+
+- [ ] **Step 6: Commit the view integration**
+
+```bash
+git add \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+git commit -m "feat: PO 委托操作使用真实用户审计 --story=136920805"
+```
+
+---
+
+### Task 3: 建立 PO Facade 独立工作树和请求头契约
+
+**Files:**
+- Create worktree: `/Users/dengyh/Projects/bk-sops-facade/.worktrees/delegated-audit-operator`
+- Modify: `backend/utils/bkapi.py`
+- Modify: `backend/tests/test_task_create_service.py`
+
+**Interfaces:**
+- Consumes: PO authenticated username A.
+- Produces: `build_sops_audit_headers(username) -> Dict[str, str]` with exact HTTP header `X-BkSops-Audit-Operator`.
+
+- [ ] **Step 1: Create the isolated Facade branch from production release**
+
+Verify `.worktrees` is ignored, then create:
+
+```bash
+git -C /Users/dengyh/Projects/bk-sops-facade check-ignore -q .worktrees
+git -C /Users/dengyh/Projects/bk-sops-facade worktree add \
+  /Users/dengyh/Projects/bk-sops-facade/.worktrees/delegated-audit-operator \
+  -b ai/delegated-audit-operator origin/release
+```
+
+Do not modify the existing `ai/saas-create-unexposed-template` worktree or its untracked `docs/.DS_Store`.
+
+- [ ] **Step 2: Write a failing task-create header assertion**
+
+In `CreateSopsTaskServiceTest.test_create_sops_task_updates_record`, assert the real outbound operation receives a backend-generated header:
+
+```python
+self.assertEqual(
+    create_call[1]["headers"],
+    {"X-BkSops-Audit-Operator": "alice"},
+)
+```
+
+The production mutation caught is dropping A before the internal gateway call.
+
+- [ ] **Step 3: Run the focused Facade test and verify RED**
+
+Run:
+
+```bash
+/Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  backend.tests.test_task_create_service.CreateSopsTaskServiceTest.test_create_sops_task_updates_record \
+  -v 2
+```
+
+Expected: FAIL with missing `headers` in the BKAPI operation call.
+
+- [ ] **Step 4: Add the Facade header builder and task-create integration**
+
+In `backend/utils/bkapi.py`, add:
+
+```python
+BK_SOPS_AUDIT_OPERATOR_HEADER = "X-BkSops-Audit-Operator"
+
+
+def build_sops_audit_headers(username):
+    return {BK_SOPS_AUDIT_OPERATOR_HEADER: username}
+```
+
+Import the helper in `backend/services/task_create.py` and change only the outbound call:
+
+```python
+response = client.api.create_task(
+    path_params={
+        "bk_biz_id": task_record.bk_biz_id,
+        "template_id": task_record.bk_sops_template_id,
+    },
+    json=request_body,
+    headers=build_sops_audit_headers(creator),
+)
+```
+
+Keep `get_sops_client_by_username(business_proxy)` unchanged.
+
+- [ ] **Step 5: Run task-create tests and verify GREEN**
+
+Run:
+
+```bash
+/Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  backend.tests.test_task_create_service.CreateSopsTaskServiceTest \
+  -v 2
+```
+
+Expected: PASS; the record still stores A while the client remains B and the outbound header carries A.
+
+- [ ] **Step 6: Commit the Facade task-create contract**
+
+Use the Facade repository's existing commit style and the shared TAPD story:
+
+```bash
+git add backend/utils/bkapi.py backend/services/task_create.py backend/tests/test_task_create_service.py
+git commit -m "feat: forward delegated audit operator --story=136920805"
+```
+
+---
+
+### Task 4: PO Facade 任务与节点操作传递真实操作人
+
+**Files:**
+- Modify: `/Users/dengyh/Projects/bk-sops-facade/.worktrees/delegated-audit-operator/backend/views/operate_task.py`
+- Modify: `/Users/dengyh/Projects/bk-sops-facade/.worktrees/delegated-audit-operator/backend/views/operate_node.py`
+- Create: `/Users/dengyh/Projects/bk-sops-facade/.worktrees/delegated-audit-operator/backend/tests/test_delegated_audit_operator.py`
+
+**Interfaces:**
+- Consumes: `build_sops_audit_headers(request.user.username)` from Task 3.
+- Produces: task/node BKAPI calls authenticated as B with header asserted from A.
+
+- [ ] **Step 1: Write failing task and node view tests**
+
+Use `RequestFactory`, a real `request.user = SimpleNamespace(username="alice")`, and patch only database/upstream boundaries. Include a spoofed browser header `HTTP_X_BKSOPS_AUDIT_OPERATOR="mallory"` in the request, then assert both outbound calls use literal `alice`:
+
+```python
+client.api.operate_task.assert_called_once_with(
+    path_params={"task_id": 456, "bk_biz_id": 2},
+    json={"action": "pause"},
+    headers={"X-BkSops-Audit-Operator": "alice"},
+)
+```
+
+```python
+client.api.operate_node.assert_called_once_with(
+    path_params={"task_id": 456, "bk_biz_id": 2},
+    json={"node_id": "node-1", "action": "retry"},
+    headers={"X-BkSops-Audit-Operator": "alice"},
+)
+```
+
+Also assert `get_sops_client_by_username` receives literal `"executor"`. These tests catch both identity swapping and browser-header passthrough.
+
+- [ ] **Step 2: Run the new test file and verify RED**
+
+Run:
+
+```bash
+/Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  backend.tests.test_delegated_audit_operator \
+  -v 2
+```
+
+Expected: FAIL because `operate_task` and `operate_node` do not pass headers.
+
+- [ ] **Step 3: Implement minimal task/node header forwarding**
+
+Import `build_sops_audit_headers` from `backend.utils.bkapi` in both views and add:
+
+```python
+headers=build_sops_audit_headers(request.user.username)
+```
+
+to the existing `client.api.operate_task` and `client.api.operate_node` calls. Do not read `HTTP_X_BKSOPS_AUDIT_OPERATOR` from the incoming browser request.
+
+- [ ] **Step 4: Run the new test file and verify GREEN**
+
+Run the same Django test command.
+
+Expected: PASS; spoofed `mallory` is ignored and backend-authenticated `alice` is sent.
+
+- [ ] **Step 5: Run complete Facade backend regression**
+
+Run:
+
+```bash
+/Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test backend.tests -v 2
+```
+
+Expected: PASS with no PO task creation, approval, query, task operation, or node operation regressions.
+
+- [ ] **Step 6: Commit the Facade operation integration**
+
+```bash
+git add backend/views/operate_task.py backend/views/operate_node.py backend/tests/test_delegated_audit_operator.py
+git commit -m "feat: forward task audit operator --story=136920805"
+```
+
+---
+
+### Task 5: Cross-repository verification and delivery
+
+**Files:**
+- Verify all files committed in both feature branches.
+- No new production files beyond Tasks 1-4.
+
+**Interfaces:**
+- Consumes: Facade `X-BkSops-Audit-Operator` contract and standard-ops resolver.
+- Produces: two independently reviewable branches with a matching identity contract.
+
+- [ ] **Step 1: Run standard-ops format and tests**
+
+```bash
+black --check \
+  gcloud/contrib/audit/utils.py \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/contrib/audit/test_utils.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+isort --check-only \
+  gcloud/contrib/audit/utils.py \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/contrib/audit/test_utils.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+flake8 \
+  gcloud/contrib/audit/utils.py \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/contrib/audit/test_utils.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+pytest -q \
+  gcloud/tests/contrib/audit \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Run Facade format and tests**
+
+Use the repository's configured formatter/linter if available, then run:
+
+```bash
+/Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test backend.tests -v 2
+```
+
+Expected: all backend tests pass.
+
+- [ ] **Step 3: Verify the exact cross-repo contract**
+
+Confirm both repositories use the exact case-insensitive wire header spelling `X-BkSops-Audit-Operator`, corresponding to Django META key `HTTP_X_BKSOPS_AUDIT_OPERATOR`. Confirm Facade clients remain initialized with B and standard-ops business calls still consume B.
+
+- [ ] **Step 4: Review diffs and repository state**
+
+For the standard-ops worktree:
+
+```bash
+git diff upstream/master...HEAD --check
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+For the Facade worktree:
+
+```bash
+git diff origin/release...HEAD --check
+git status --short --branch
+git log --oneline --decorate -5
+```
+
+Expected: clean working trees containing only intentional commits.
+
+- [ ] **Step 5: Push and create review requests only after local verification**
+
+Standard-ops:
+
+```bash
+git push -u origin feat/delegated-audit-operator
+gh pr create \
+  --repo TencentBlueKing/bk-sops \
+  --base master \
+  --head dengyh:feat/delegated-audit-operator
+```
+
+Facade: push `ai/delegated-audit-operator` to the repository's normal writable remote and create an MR targeting `release`. Do not push to an upstream/protected branch directly.
+
+- [ ] **Step 6: Record deployment configuration**
+
+In the delivery summary, explicitly state that production behavior remains B until API Server configures `BK_AUDIT_DELEGATED_OPERATOR_APPS` to the verified PO Facade deployment app code. Do not guess or hardcode the production app code; retrieve it from the PO deployment configuration before rollout.

--- a/docs/plans/2026-08-10-delegated-audit-operator.md
+++ b/docs/plans/2026-08-10-delegated-audit-operator.md
@@ -4,7 +4,7 @@
 
 **Goal:** 让 PO 登录用户 A 成为标准运维审计中心的最终操作人，同时保持 PO 业务执行代理人 B 负责内部网关认证、IAM 校验和任务执行。
 
-**Architecture:** PO Facade 以 B 创建 BKAPI 客户端，并在三个写入口中由后端添加 `X-BkSops-Audit-Operator: A`。标准运维从已认证的 `request.app`、原始 APIGW JWT 验证状态和专用 app code 白名单中建立可信边界，只在审计调用处使用 A；所有业务调用继续使用 `request.user.username == B`。
+**Architecture:** PO Facade 以 B 创建 BKAPI 客户端，并在三个写入口中由后端添加 `X-BkSops-Audit-Operator: A`。标准运维从已验证的 `request.app`、原始 APIGW JWT 用户验证状态和专用 app code 白名单中建立可信边界，只在审计调用处使用 A；所有业务调用继续使用 `request.user.username == B`。
 
 **Tech Stack:** Python 3.6/3.10、Django 2.2/3.2、BKAPI Client Core、APIGW Manager、`bk-audit==1.1.1`、pytest/Django TestCase、TAPD 需求 `136920805`。
 
@@ -31,7 +31,7 @@
 - Modify: `/Users/dengyh/Projects/bk-sops/.worktrees/operation-audit-phase1/gcloud/tests/contrib/audit/test_utils.py`
 
 **Interfaces:**
-- Consumes: Django request with `request.user.username`, authenticated `request.app`, `_apigw_jwt_user_verified`, `META`, and optional `trace_id`.
+- Consumes: Django request with `request.user.username`, verified `request.app`, `_apigw_jwt_user_verified`, `META`, and optional `trace_id`.
 - Produces: `get_audit_username(request) -> str` and deployment setting `BK_AUDIT_DELEGATED_OPERATOR_APPS: Set[str]`.
 
 - [ ] **Step 1: Write failing resolver tests**
@@ -40,13 +40,20 @@ Append a focused test class to `gcloud/tests/contrib/audit/test_utils.py`. Build
 
 ```python
 class DelegatedAuditUsernameTestCase(SimpleTestCase):
-    def request(self, app_code="bk-sops-facade", proxy="executor", operator=None, verified=True):
+    def request(
+        self,
+        app_code="bk-sops-facade",
+        app_verified=True,
+        proxy="executor",
+        operator=None,
+        verified=True,
+    ):
         meta = {}
         if operator is not None:
             meta["HTTP_X_BKSOPS_AUDIT_OPERATOR"] = operator
         return SimpleNamespace(
             user=SimpleNamespace(username=proxy),
-            app=SimpleNamespace(bk_app_code=app_code),
+            app=SimpleNamespace(bk_app_code=app_code, verified=app_verified),
             META=meta,
             _apigw_jwt_user_verified=verified,
             trace_id="trace-1",
@@ -64,6 +71,10 @@ class DelegatedAuditUsernameTestCase(SimpleTestCase):
         )
         self.assertEqual(
             utils.get_audit_username(self.request(operator="alice", verified=False)),
+            "executor",
+        )
+        self.assertEqual(
+            utils.get_audit_username(self.request(operator="alice", app_verified=False)),
             "executor",
         )
 
@@ -119,14 +130,15 @@ def get_audit_username(request):
     if not operator:
         return proxy_username
 
-    app_code = getattr(
-        getattr(request, "app", None),
-        settings.APIGW_MANAGER_APP_CODE_KEY,
-        "",
-    )
+    app = getattr(request, "app", None)
+    app_code = getattr(app, settings.APIGW_MANAGER_APP_CODE_KEY, "")
     trusted_apps = getattr(settings, "BK_AUDIT_DELEGATED_OPERATOR_APPS", set())
     trace_id = getattr(request, "trace_id", "")
-    if app_code not in trusted_apps or getattr(request, "_apigw_jwt_user_verified", False) is not True:
+    if (
+        app_code not in trusted_apps
+        or getattr(app, "verified", False) is not True
+        or getattr(request, "_apigw_jwt_user_verified", False) is not True
+    ):
         logger.warning(
             "bk_audit delegated_operator_ignored app_code=%s proxy_username=%s trace_id=%s",
             app_code,

--- a/docs/specs/2026-08-10-delegated-audit-operator-design.md
+++ b/docs/specs/2026-08-10-delegated-audit-operator-design.md
@@ -1,0 +1,167 @@
+# 标准运维委托调用审计操作人设计
+
+## 背景
+
+PO 环境通过 `bk-sops-facade` 调用标准运维 API Server。用户 A 在 PO 登录、完成业务权限校验和审批后，Facade 会读取 `BusinessConfig.task_executor` 得到业务执行代理人 B，并通过 `get_sops_client_by_username(B)` 调用标准运维。
+
+现有链路中，内部网关认证用户、标准运维 `request.user`、任务创建人及审计操作人均为 B。PO 登录用户 A 只保存在 Facade 本地记录中，没有进入标准运维请求，因此审计中心无法回答“谁在 PO 发起了操作”。
+
+## 目标
+
+- PO 发起的任务创建、任务操作和节点操作在审计中心以 A 作为最终操作人。
+- 内部网关认证、标准运维 IAM 校验、任务创建与任务操作继续使用 B。
+- 标准运维任务实例的 `creator`、运行时执行身份及现有本地操作记录语义保持不变。
+- 非可信应用、缺失委托身份或非法委托身份一律回退为网关认证用户 B。
+- 不新增审计动作、资源或公开 API 请求/响应字段。
+- 审计身份解析失败不得阻断业务请求。
+
+## 非目标
+
+- 不让 A 直接承担标准运维 IAM 权限校验。
+- 不改变 PO 的审批、业务权限和 `BusinessConfig.task_executor` 配置方式。
+- 不改变标准运维任务实例的创建人或执行代理逻辑。
+- 不允许普通 API 调用方自行指定审计操作人。
+- 本期不引入共享密钥、JWS/HMAC、时间戳或 nonce；如后续合规要求提高，再在本设计的可信应用边界上增加签名和防重放。
+
+## 方案选择
+
+### 采用：可信应用声明委托审计操作人
+
+Facade 继续以 B 创建标准运维网关客户端，并由后端添加专用请求头：
+
+```text
+X-BkSops-Audit-Operator: A
+```
+
+标准运维仅在以下条件全部成立时接受该值：
+
+1. 请求由 API Gateway 注入应用身份和用户身份。
+2. 原始网关 JWT 中的用户 B 已验证。
+3. 调用应用 app code 位于专用配置 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 中。
+4. 请求头中的 A 非空、长度不超过 64，并且只包含允许的账号字符。
+
+接受后，仅审计事件的 `AuditContext.username` 使用 A。业务代码继续使用 `request.user.username`，因此 IAM、任务创建、异步启动、任务/节点操作均保持 B。
+
+### 不采用：把网关用户改成 A
+
+该方案会使标准运维 IAM 和任务操作权限同时切换到 A。PO 外部用户通常没有目标业务和模板权限，与“B 继续作为实际执行身份”的目标冲突。
+
+### 暂不采用：每个请求独立签名
+
+签名能增强跨代理链路的不可篡改性，但需要新增密钥分发、轮换和防重放机制。当前内部网关已经认证调用应用和代理用户，本期使用专用 app code 白名单建立最小可信边界；签名作为后续增强项。
+
+## 身份与数据流
+
+| 环节 | 身份 | 用途 |
+| --- | --- | --- |
+| PO 登录与业务权限校验 | A | 判断谁可以在 PO 发起操作 |
+| Facade 本地 `created_by` / `operator` / `task_creator` | A | PO 自身留痕 |
+| Facade 网关客户端 | B | 获取标准运维权限并发起请求 |
+| API Gateway 已验证用户 | B | 生成标准运维请求用户 |
+| 标准运维 `request.user.username` | B | IAM、任务创建和任务/节点操作 |
+| 标准运维审计 `username` | A | 审计中心最终操作人 |
+| 标准运维审计资源快照 | 任务真实数据 | 可继续体现任务 creator/executor 为 B |
+
+完整链路：
+
+```text
+PO 用户 A
+  -> PO 鉴权和审批
+  -> Facade 读取任务执行人 B
+  -> 以 B 调用 API Gateway，并由 Facade 后端添加 A 的审计头
+  -> API Gateway 验证 app code 和 B
+  -> 标准运维以 B 完成 IAM 与业务操作
+  -> 标准运维仅在可信条件满足时以 A 上报审计
+```
+
+## PO Facade 改造
+
+以 `origin/release` 为生产基线建立独立功能分支。
+
+### 请求头生成
+
+在 `backend/utils/bkapi.py` 定义统一头名称和构造函数，输入 PO 已认证的用户名 A，输出传给 BKAPI SDK 的 headers。Facade 后端必须覆盖该请求头，不能从浏览器请求头透传。
+
+### 覆盖入口
+
+- `backend/services/task_create.py::create_sops_task`：使用现有 `creator` 参数传递 A。
+- `backend/views/operate_task.py::operate_task`：使用 `request.user.username` 传递 A。
+- `backend/views/operate_node.py::operate_node`：使用 `request.user.username` 传递 A。
+
+以上入口继续使用 `BusinessConfig.task_executor` 创建客户端。BKAPI SDK 的 `headers` 参数只增加委托审计声明，不修改 `bk_username` 和 access token。
+
+## 标准运维改造
+
+以最新 `upstream/master` 为基线建立 `feat/delegated-audit-operator`。
+
+### 配置
+
+新增部署配置 `BK_AUDIT_DELEGATED_OPERATOR_APPS`，内容为逗号分隔的 app code，默认空集合。默认关闭委托身份解析，避免代码部署后自动信任任何调用应用。
+
+生产启用时配置 PO Facade 的真实 app code；不在社区代码中硬编码内部应用标识。
+
+### 身份解析
+
+在 `gcloud/contrib/audit/utils.py` 增加公共解析函数，输入 Django request，返回最终审计用户名：
+
+- 默认返回 `request.user.username`，即 B。
+- 只有 app code 在专用白名单、原始 APIGW JWT 用户已验证且委托头合法时，返回 A。
+- 接受委托身份时记录 A、B、app code 和 trace ID 的结构化日志。
+- 请求头存在但不可信或非法时记录不包含原始非法值的告警，并回退 B。
+- 函数不得修改 `request.user`。
+
+### 覆盖入口
+
+- `gcloud/apigw/views/create_task.py`
+- `gcloud/apigw/views/operate_task.py`
+- `gcloud/apigw/views/operate_node.py`
+
+三个入口分别计算 `audit_username` 并仅传给 `bk_audit_add_event_on_commit`。原有 `username=request.user.username` 继续用于任务创建、Celery 参数、`task_action` 和 `nodes_action`。
+
+## 安全与失败处理
+
+- app code 必须来自 APIGW 认证后的 `request.app`，不能读取普通业务请求参数。
+- 必须检查 `_apigw_jwt_user_verified is True`，防止未验证用户名与委托头组合。
+- 专用白名单不得复用现有 `APP_WHITELIST`，避免把其他信任应用自动扩展为审计身份代理。
+- 委托头只接受 ASCII 账号字符 `A-Z`、`a-z`、`0-9`、`_`、`-`、`.`、`@`，长度为 1 到 64。
+- 委托头缺失、非法、调用应用不可信或网关用户未验证时均回退 B，不返回错误响应。
+- 日志不得记录 token、cookie、请求体或其他敏感信息。
+
+## API 与审计中心边界
+
+- 不修改公开请求 body、response、operationId、动作或资源定义。
+- 专用请求头是 Facade 与标准运维之间的内部可信契约，不在公开 APIGW 申请文档中开放给普通调用方。
+- 审计中心主操作人显示 A；任务资源快照仍可显示 creator/executor 为 B。这是“谁发起”与“以谁执行”的预期分离，不是数据不一致。
+- 当前 `bk-audit==1.1.1` 已允许调用方独立设置 `AuditContext.username`，无需升级 SDK。
+
+## 测试设计
+
+### PO Facade
+
+- 创建标准运维任务时，网关客户端仍以 B 创建，请求 headers 携带 A。
+- 创建请求失败和响应异常时，headers 传递行为不改变错误处理。
+- 任务操作和节点操作均携带当前 PO 登录用户 A，业务请求内容保持不变。
+- 浏览器传入同名请求头不会被透传；最终值始终由后端 `request.user.username` 生成。
+
+### 标准运维
+
+- 可信 app、已验证 B、合法 A：解析结果和审计操作人为 A。
+- 非可信 app：忽略 A，审计操作人为 B。
+- B 未验证：忽略 A，审计操作人为 B。
+- A 缺失、空白、超长或包含非法字符：审计操作人为 B。
+- `create_task` 的任务 creator 仍为 B，审计 username 为 A。
+- `operate_task` 的 Celery/`task_action` 用户仍为 B，审计 username 为 A。
+- `operate_node` 的 `nodes_action` 用户仍为 B，审计 username 为 A。
+- 现有无委托头调用全部保持 B，原 API 响应不变。
+
+## 发布与验收
+
+1. 先发布标准运维代码，保持 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 为空，确认所有调用仍记录 B。
+2. 发布 PO Facade，使三个入口开始发送由后端生成的委托头；此时标准运维仍因白名单为空而记录 B。
+3. 在标准运维 API Server 配置 PO Facade 的真实 app code 并滚动发布。
+4. 使用 PO 用户 A、业务执行人 B 创建并启动测试任务。
+5. 验证标准运维业务日志中 IAM/任务操作用户为 B，委托映射日志为 A/B，审计中心操作人为 A。
+6. 验证任务实例 creator/executor 和 PO 本地记录符合身份映射表。
+7. 使用非白名单应用伪造委托头，确认审计仍记录其网关认证用户。
+
+回滚时只需清空 `BK_AUDIT_DELEGATED_OPERATOR_APPS`，即可立即恢复“审计操作人等于网关认证用户”的原行为，无需回滚 PO 请求头。

--- a/docs/specs/2026-08-10-delegated-audit-operator-design.md
+++ b/docs/specs/2026-08-10-delegated-audit-operator-design.md
@@ -105,7 +105,7 @@ PO 用户 A
 在 `gcloud/contrib/audit/utils.py` 增加公共解析函数，输入 Django request，返回最终审计用户名：
 
 - 默认返回 `request.user.username`，即 B。
-- 只有 app code 在专用白名单、原始 APIGW JWT 用户已验证且委托头合法时，返回 A。
+- 只有 APIGW JWT 应用已验证、app code 在专用白名单、原始 APIGW JWT 用户已验证且委托头合法时，返回 A。
 - 接受委托身份时记录 A、B、app code 和 trace ID 的结构化日志。
 - 请求头存在但不可信或非法时记录不包含原始非法值的告警，并回退 B。
 - 函数不得修改 `request.user`。
@@ -120,11 +120,11 @@ PO 用户 A
 
 ## 安全与失败处理
 
-- app code 必须来自 APIGW 认证后的 `request.app`，不能读取普通业务请求参数。
+- app code 必须来自 APIGW 认证后的 `request.app`，且 `request.app.verified is True`，不能读取普通业务请求参数。
 - 必须检查 `_apigw_jwt_user_verified is True`，防止未验证用户名与委托头组合。
 - 专用白名单不得复用现有 `APP_WHITELIST`，避免把其他信任应用自动扩展为审计身份代理。
 - 委托头只接受 ASCII 账号字符 `A-Z`、`a-z`、`0-9`、`_`、`-`、`.`、`@`，长度为 1 到 64。
-- 委托头缺失、非法、调用应用不可信或网关用户未验证时均回退 B，不返回错误响应。
+- 委托头缺失、非法、调用应用未验证或不可信、网关用户未验证时均回退 B，不返回错误响应。
 - 日志不得记录 token、cookie、请求体或其他敏感信息。
 
 ## API 与审计中心边界
@@ -146,7 +146,7 @@ PO 用户 A
 ### 标准运维
 
 - 可信 app、已验证 B、合法 A：解析结果和审计操作人为 A。
-- 非可信 app：忽略 A，审计操作人为 B。
+- 未验证或非可信 app：忽略 A，审计操作人为 B。
 - B 未验证：忽略 A，审计操作人为 B。
 - A 缺失、空白、超长或包含非法字符：审计操作人为 B。
 - `create_task` 的任务 creator 仍为 B，审计 username 为 A。

--- a/env.py
+++ b/env.py
@@ -201,6 +201,9 @@ PERIODIC_TASK_ITERATION = int(os.getenv("PERIODIC_TASK_ITERATION", 10))
 # bk_audit
 BK_AUDIT_ENDPOINT = os.getenv("BK_AUDIT_ENDPOINT", None)
 BK_AUDIT_DATA_TOKEN = os.getenv("BK_AUDIT_DATA_TOKEN", None)
+BK_AUDIT_DELEGATED_OPERATOR_APPS = {
+    app_code.strip() for app_code in os.getenv("BK_AUDIT_DELEGATED_OPERATOR_APPS", "").split(",") if app_code.strip()
+}
 
 # bk_chat通知渠道
 ENABLE_BK_CHAT_CHANNEL = False if os.getenv("BKAPP_ENABLE_BK_CHAT_CHANNEL") is None else True

--- a/gcloud/apigw/views/create_task.py
+++ b/gcloud/apigw/views/create_task.py
@@ -35,7 +35,7 @@ from gcloud.common_template.models import CommonTemplate
 from gcloud.conf import settings
 from gcloud.constants import NON_COMMON_TEMPLATE_TYPES, PROJECT, TaskCreateMethod
 from gcloud.contrib.audit.mappings import get_task_create_action
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_username
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.models import EngineConfig
@@ -246,7 +246,7 @@ def create_task(request, template_id, project_id):
     action_id = get_task_create_action(template_source, create_method)
     if action_id:
         bk_audit_add_event_on_commit(
-            username=request.user.username,
+            username=get_audit_username(request),
             action_id=action_id,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=task,

--- a/gcloud/apigw/views/operate_node.py
+++ b/gcloud/apigw/views/operate_node.py
@@ -20,7 +20,7 @@ from django.views.decorators.http import require_POST
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_username
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
@@ -79,7 +79,7 @@ def operate_node(request, project_id, task_id):
     result = task.nodes_action(action, node_id, username, **kwargs)
     if result.get("result") is True:
         bk_audit_add_event_on_commit(
-            username=username,
+            username=get_audit_username(request),
             action_id=IAMMeta.TASK_OPERATE_ACTION,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=task,

--- a/gcloud/apigw/views/operate_task.py
+++ b/gcloud/apigw/views/operate_task.py
@@ -22,7 +22,7 @@ from django.views.decorators.http import require_POST
 import env
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_username
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
@@ -81,7 +81,7 @@ def operate_task(request, task_id, project_id):
             kwargs=dict(task_id=task_id, project_id=project.id, username=username), queue=queue, routing_key=routing_key
         )
         bk_audit_add_event_on_commit(
-            username=username,
+            username=get_audit_username(request),
             action_id=IAMMeta.TASK_OPERATE_ACTION,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=task,
@@ -97,7 +97,7 @@ def operate_task(request, task_id, project_id):
     ctx = task.task_action(action, username)
     if ctx.get("result") is True:
         bk_audit_add_event_on_commit(
-            username=username,
+            username=get_audit_username(request),
             action_id=IAMMeta.TASK_OPERATE_ACTION,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=task,

--- a/gcloud/contrib/audit/utils.py
+++ b/gcloud/contrib/audit/utils.py
@@ -12,6 +12,7 @@ specific language governing permissions and limitations under the License.
 """
 import json
 import logging
+import re
 from functools import partial
 
 import six
@@ -38,6 +39,8 @@ REMOVED_AUDIT_FIELDS = {
     "task_params",
 }
 SENSITIVE_AUDIT_KEYWORDS = ("authorization", "credential", "password", "secret", "token")
+DELEGATED_AUDIT_OPERATOR_META_KEY = "HTTP_X_BKSOPS_AUDIT_OPERATOR"
+DELEGATED_AUDIT_OPERATOR_PATTERN = re.compile(r"^[A-Za-z0-9_.@-]{1,64}$")
 
 
 class ResourceType(BaseObject):
@@ -57,6 +60,47 @@ class ResourceType(BaseObject):
 
     def to_dict(self):
         return {"id": self.id}
+
+
+def get_audit_username(request):
+    proxy_username = getattr(getattr(request, "user", None), "username", "")
+    operator = getattr(request, "META", {}).get(DELEGATED_AUDIT_OPERATOR_META_KEY)
+    if not operator:
+        return proxy_username
+
+    app_code = getattr(
+        getattr(request, "app", None),
+        settings.APIGW_MANAGER_APP_CODE_KEY,
+        "",
+    )
+    trusted_apps = getattr(settings, "BK_AUDIT_DELEGATED_OPERATOR_APPS", set())
+    trace_id = getattr(request, "trace_id", "")
+    if app_code not in trusted_apps or getattr(request, "_apigw_jwt_user_verified", False) is not True:
+        logger.warning(
+            "bk_audit delegated_operator_ignored app_code=%s proxy_username=%s trace_id=%s",
+            app_code,
+            proxy_username,
+            trace_id,
+        )
+        return proxy_username
+
+    if not DELEGATED_AUDIT_OPERATOR_PATTERN.fullmatch(operator):
+        logger.warning(
+            "bk_audit delegated_operator_invalid app_code=%s proxy_username=%s trace_id=%s",
+            app_code,
+            proxy_username,
+            trace_id,
+        )
+        return proxy_username
+
+    logger.info(
+        "bk_audit delegated_operator_resolved audit_username=%s proxy_username=%s app_code=%s trace_id=%s",
+        operator,
+        proxy_username,
+        app_code,
+        trace_id,
+    )
+    return operator
 
 
 def sanitize_audit_data(data):

--- a/gcloud/contrib/audit/utils.py
+++ b/gcloud/contrib/audit/utils.py
@@ -68,14 +68,15 @@ def get_audit_username(request):
     if not operator:
         return proxy_username
 
-    app_code = getattr(
-        getattr(request, "app", None),
-        settings.APIGW_MANAGER_APP_CODE_KEY,
-        "",
-    )
+    app = getattr(request, "app", None)
+    app_code = getattr(app, settings.APIGW_MANAGER_APP_CODE_KEY, "")
     trusted_apps = getattr(settings, "BK_AUDIT_DELEGATED_OPERATOR_APPS", set())
     trace_id = getattr(request, "trace_id", "")
-    if app_code not in trusted_apps or getattr(request, "_apigw_jwt_user_verified", False) is not True:
+    if (
+        app_code not in trusted_apps
+        or getattr(app, "verified", False) is not True
+        or getattr(request, "_apigw_jwt_user_verified", False) is not True
+    ):
         logger.warning(
             "bk_audit delegated_operator_ignored app_code=%s proxy_username=%s trace_id=%s",
             app_code,

--- a/gcloud/tests/apigw/views/test_create_task.py
+++ b/gcloud/tests/apigw/views/test_create_task.py
@@ -44,6 +44,51 @@ class CreateTaskAPITest(APITest):
     def url(self):
         return "/apigw/create_task/{template_id}/{project_id}/"
 
+    @mock.patch(TASKINSTANCE_CREATE_PIPELINE, MagicMock(return_value=TEST_DATA))
+    @mock.patch(
+        TASKINSTANCE_CREATE,
+        MagicMock(return_value=MockTaskFlowInstance(id=TEST_TASKFLOW_ID)),
+    )
+    @mock.patch(APIGW_CREATE_TASK_VALIDATE_WEB_PIPELINE_TREE, MagicMock())
+    @mock.patch(APIGW_CREATE_TASK_JSON_SCHEMA_VALIDATE, MagicMock())
+    def test_create_task_uses_proxy_for_business_and_delegated_operator_for_audit(self):
+        tmpl = MockTaskTemplate(id=1, pipeline_template=MockPipelineTemplate(id=1, name="pt1"))
+        project = MockProject(
+            project_id=TEST_PROJECT_ID,
+            name=TEST_PROJECT_NAME,
+            bk_biz_id=TEST_BIZ_CC_ID,
+            from_cmdb=True,
+        )
+
+        with mock.patch(PROJECT_GET, MagicMock(return_value=project)):
+            with mock.patch(
+                TASKTEMPLATE_SELECT_RELATE,
+                MagicMock(return_value=MockQuerySet(get_result=tmpl)),
+            ):
+                with mock.patch(
+                    "gcloud.apigw.views.create_task.get_audit_username",
+                    return_value="alice",
+                    create=True,
+                ) as get_audit_username:
+                    with mock.patch("gcloud.apigw.views.create_task.bk_audit_add_event_on_commit") as add_event:
+                        response = self.client.post(
+                            path=self.url().format(template_id=TEST_TEMPLATE_ID, project_id=TEST_PROJECT_ID),
+                            data=json.dumps({"name": "name", "constants": {}, "flow_type": "common"}),
+                            content_type="application/json",
+                            HTTP_BK_APP_CODE=TEST_APP_CODE,
+                            HTTP_BK_USERNAME="executor",
+                        )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+        pipeline_kwargs = TaskFlowInstance.objects.create_pipeline_instance_exclude_task_nodes.call_args[0][1]
+        self.assertEqual(pipeline_kwargs["creator"], "executor")
+        get_audit_username.assert_called_once()
+        self.assertEqual(add_event.call_args.kwargs["username"], "alice")
+
+        TaskFlowInstance.objects.create_pipeline_instance_exclude_task_nodes.reset_mock()
+        TaskFlowInstance.objects.create.reset_mock()
+
     def test_create_task_schema_accepts_template_schemes_id(self):
         jsonschema.validate(
             {"name": "name", "template_schemes_id": ["scheme_1"]},

--- a/gcloud/tests/apigw/views/test_create_task.py
+++ b/gcloud/tests/apigw/views/test_create_task.py
@@ -84,7 +84,7 @@ class CreateTaskAPITest(APITest):
         pipeline_kwargs = TaskFlowInstance.objects.create_pipeline_instance_exclude_task_nodes.call_args[0][1]
         self.assertEqual(pipeline_kwargs["creator"], "executor")
         get_audit_username.assert_called_once()
-        self.assertEqual(add_event.call_args.kwargs["username"], "alice")
+        self.assertEqual(add_event.call_args[1]["username"], "alice")
 
         TaskFlowInstance.objects.create_pipeline_instance_exclude_task_nodes.reset_mock()
         TaskFlowInstance.objects.create.reset_mock()

--- a/gcloud/tests/apigw/views/test_operate_node.py
+++ b/gcloud/tests/apigw/views/test_operate_node.py
@@ -84,7 +84,7 @@ class OperateNodeAPITest(APITest):
             flow_id=TEST_FLOW_ID,
         )
         get_audit_username.assert_called_once()
-        self.assertEqual(add_event.call_args.kwargs["username"], "alice")
+        self.assertEqual(add_event.call_args[1]["username"], "alice")
 
     @patch(
         PROJECT_GET,

--- a/gcloud/tests/apigw/views/test_operate_node.py
+++ b/gcloud/tests/apigw/views/test_operate_node.py
@@ -14,10 +14,9 @@ specific language governing permissions and limitations under the License.
 
 import ujson as json
 
-
+from gcloud import err_code
 from gcloud.tests.mock import *  # noqa
 from gcloud.tests.mock_settings import *  # noqa
-from gcloud import err_code
 
 from .utils import APITest
 
@@ -48,15 +47,63 @@ class OperateNodeAPITest(APITest):
             )
         ),
     )
+    def test_operate_node_uses_proxy_for_business_and_delegated_operator_for_audit(self):
+        task_instance = MagicMock(id=TEST_TASKFLOW_ID)
+        task_instance.nodes_action.return_value = {"result": True, "data": "success"}
+
+        with patch(TASKINSTANCE_GET, MagicMock(return_value=task_instance)):
+            with patch(
+                "gcloud.apigw.views.operate_node.get_audit_username",
+                return_value="alice",
+                create=True,
+            ) as get_audit_username:
+                with patch("gcloud.apigw.views.operate_node.bk_audit_add_event_on_commit") as add_event:
+                    response = self.client.post(
+                        path=self.url().format(project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID),
+                        data=json.dumps(
+                            {
+                                "node_id": TEST_NODE_ID,
+                                "action": TEST_ACTION,
+                                "data": TEST_DATA,
+                                "inputs": TEST_INPUTS,
+                                "flow_id": TEST_FLOW_ID,
+                            }
+                        ),
+                        content_type="application/json",
+                        HTTP_BK_USERNAME="executor",
+                    )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+        task_instance.nodes_action.assert_called_once_with(
+            TEST_ACTION,
+            TEST_NODE_ID,
+            "executor",
+            data=TEST_DATA,
+            inputs=TEST_INPUTS,
+            flow_id=TEST_FLOW_ID,
+        )
+        get_audit_username.assert_called_once()
+        self.assertEqual(add_event.call_args.kwargs["username"], "alice")
+
+    @patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
     @patch(
         TASKINSTANCE_GET,
         MagicMock(return_value=MockTaskFlowInstance(id=TEST_TASKFLOW_ID)),
     )
     def test_opearte_node__invalid_req(self):
         response = self.client.post(
-            path=self.url().format(
-                project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID
-            ),
+            path=self.url().format(project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID),
             data="invalid_json",
             content_type="application/json",
         )
@@ -84,9 +131,7 @@ class OperateNodeAPITest(APITest):
     )
     def test_operate_node__invalid_data(self):
         response = self.client.post(
-            path=self.url().format(
-                project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID
-            ),
+            path=self.url().format(project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID),
             data=json.dumps({"data": "data"}),
             content_type="application/json",
         )
@@ -114,9 +159,7 @@ class OperateNodeAPITest(APITest):
     )
     def test_operate_node__invalid_inputs(self):
         response = self.client.post(
-            path=self.url().format(
-                project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID
-            ),
+            path=self.url().format(project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID),
             data=json.dumps({"inputs": "inputs"}),
             content_type="application/json",
         )
@@ -144,13 +187,12 @@ class OperateNodeAPITest(APITest):
         task_instance.nodes_action = MagicMock(return_value=NODES_ACTION_RETURN)
 
         with patch(
-            TASKINSTANCE_GET, MagicMock(return_value=task_instance),
+            TASKINSTANCE_GET,
+            MagicMock(return_value=task_instance),
         ):
 
             response = self.client.get(
-                path=self.url().format(
-                    project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID
-                ),
+                path=self.url().format(project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID),
                 data={
                     "node_id": TEST_NODE_ID,
                     "action": TEST_COMPONENT_CODE,

--- a/gcloud/tests/apigw/views/test_operate_task.py
+++ b/gcloud/tests/apigw/views/test_operate_task.py
@@ -70,11 +70,11 @@ class OperateTaskAPITest(APITest):
         data = json.loads(response.content)
         self.assertTrue(data["result"], msg=data)
         self.assertEqual(
-            prepare_and_start_task.apply_async.call_args.kwargs["kwargs"]["username"],
+            prepare_and_start_task.apply_async.call_args[1]["kwargs"]["username"],
             "executor",
         )
         get_audit_username.assert_called_once()
-        self.assertEqual(add_event.call_args.kwargs["username"], "alice")
+        self.assertEqual(add_event.call_args[1]["username"], "alice")
 
     @mock.patch(
         PROJECT_GET,

--- a/gcloud/tests/apigw/views/test_operate_task.py
+++ b/gcloud/tests/apigw/views/test_operate_task.py
@@ -31,6 +31,51 @@ class OperateTaskAPITest(APITest):
     def url(self):
         return "/apigw/operate_task/{task_id}/{project_id}/"
 
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch(
+        PROJECT_GET,
+        MagicMock(
+            return_value=MockProject(
+                project_id=TEST_PROJECT_ID,
+                name=TEST_PROJECT_NAME,
+                bk_biz_id=TEST_BIZ_CC_ID,
+                from_cmdb=True,
+            )
+        ),
+    )
+    def test_start_uses_proxy_for_business_and_delegated_operator_for_audit(self):
+        task = MagicMock(id=TEST_TASKFLOW_ID)
+        queryset = MagicMock()
+        queryset.select_related.return_value.first.return_value = task
+        taskflow_instance = MagicMock()
+        taskflow_instance.objects.is_task_started.return_value = False
+        taskflow_instance.objects.filter.return_value = queryset
+        prepare_and_start_task = MagicMock()
+
+        with mock.patch(APIGW_OPERATE_TASK_TASKFLOW_INSTANCE, taskflow_instance):
+            with mock.patch(APIGW_OPERATE_TASK_PREPARE_AND_START_TASK, prepare_and_start_task):
+                with mock.patch(
+                    "gcloud.apigw.views.operate_task.get_audit_username",
+                    return_value="alice",
+                    create=True,
+                ) as get_audit_username:
+                    with mock.patch("gcloud.apigw.views.operate_task.bk_audit_add_event_on_commit") as add_event:
+                        response = self.client.post(
+                            path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                            data=json.dumps({"action": "start"}),
+                            content_type="application/json",
+                            HTTP_BK_USERNAME="executor",
+                        )
+
+        data = json.loads(response.content)
+        self.assertTrue(data["result"], msg=data)
+        self.assertEqual(
+            prepare_and_start_task.apply_async.call_args.kwargs["kwargs"]["username"],
+            "executor",
+        )
+        get_audit_username.assert_called_once()
+        self.assertEqual(add_event.call_args.kwargs["username"], "alice")
+
     @mock.patch(
         PROJECT_GET,
         MagicMock(

--- a/gcloud/tests/contrib/audit/test_utils.py
+++ b/gcloud/tests/contrib/audit/test_utils.py
@@ -10,13 +10,20 @@ from gcloud.contrib.audit import utils
 
 
 class DelegatedAuditUsernameTestCase(SimpleTestCase):
-    def request(self, app_code="bk-sops-facade", proxy="executor", operator=None, verified=True):
+    def request(
+        self,
+        app_code="bk-sops-facade",
+        app_verified=True,
+        proxy="executor",
+        operator=None,
+        verified=True,
+    ):
         meta = {}
         if operator is not None:
             meta["HTTP_X_BKSOPS_AUDIT_OPERATOR"] = operator
         return SimpleNamespace(
             user=SimpleNamespace(username=proxy),
-            app=SimpleNamespace(bk_app_code=app_code),
+            app=SimpleNamespace(bk_app_code=app_code, verified=app_verified),
             META=meta,
             _apigw_jwt_user_verified=verified,
             trace_id="trace-1",
@@ -34,6 +41,10 @@ class DelegatedAuditUsernameTestCase(SimpleTestCase):
         )
         self.assertEqual(
             utils.get_audit_username(self.request(operator="alice", verified=False)),
+            "executor",
+        )
+        self.assertEqual(
+            utils.get_audit_username(self.request(operator="alice", app_verified=False)),
             "executor",
         )
 

--- a/gcloud/tests/contrib/audit/test_utils.py
+++ b/gcloud/tests/contrib/audit/test_utils.py
@@ -1,11 +1,47 @@
 # -*- coding: utf-8 -*-
 import json
+from types import SimpleNamespace
 from unittest import mock
 
 from django.db import transaction
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from gcloud.contrib.audit import utils
+
+
+class DelegatedAuditUsernameTestCase(SimpleTestCase):
+    def request(self, app_code="bk-sops-facade", proxy="executor", operator=None, verified=True):
+        meta = {}
+        if operator is not None:
+            meta["HTTP_X_BKSOPS_AUDIT_OPERATOR"] = operator
+        return SimpleNamespace(
+            user=SimpleNamespace(username=proxy),
+            app=SimpleNamespace(bk_app_code=app_code),
+            META=meta,
+            _apigw_jwt_user_verified=verified,
+            trace_id="trace-1",
+        )
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_trusted_verified_request_uses_delegated_operator(self):
+        self.assertEqual(utils.get_audit_username(self.request(operator="alice@tai")), "alice@tai")
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_untrusted_or_unverified_request_falls_back_to_proxy(self):
+        self.assertEqual(
+            utils.get_audit_username(self.request(app_code="other-app", operator="alice")),
+            "executor",
+        )
+        self.assertEqual(
+            utils.get_audit_username(self.request(operator="alice", verified=False)),
+            "executor",
+        )
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_missing_or_invalid_operator_falls_back_to_proxy(self):
+        for operator in (None, "", "has space", "bad/value", "x" * 65):
+            with self.subTest(operator=operator):
+                self.assertEqual(utils.get_audit_username(self.request(operator=operator)), "executor")
 
 
 class AuditUtilsTestCase(SimpleTestCase):


### PR DESCRIPTION
## 背景

PO 环境通过业务配置的任务执行人 B 调用标准运维，导致审计中心只能看到代理人 B，无法还原实际在 PO 发起操作的登录用户 A。

## 方案

- PO Facade 继续使用 B 创建 BKAPI 客户端，IAM 校验、任务创建和任务/节点执行身份保持不变。
- Facade 后端在创建任务、操作任务、操作节点三个写入口添加内部请求头 `X-BkSops-Audit-Operator: A`。
- 标准运维仅在以下条件全部满足时将 A 作为审计操作人：
  - APIGW JWT 应用已验证；
  - app code 命中专用配置 `BK_AUDIT_DELEGATED_OPERATOR_APPS`；
  - APIGW JWT 用户已验证；
  - 委托用户名满足 `^[A-Za-z0-9_.@-]{1,64}$`。
- 任一条件不满足时静默回退 B，不阻断业务，也不记录非法头原始值。
- 不新增审计动作、资源、公开请求字段、响应字段或 operationId。

## 覆盖范围

- `create_task`
- `operate_task`（开始及其他成功操作）
- `operate_node`
- 可信身份解析、默认空白名单、日志与回退路径

PO Facade 配套分支：`bkapps/bk-sops-facade:ai/delegated-audit-operator`，目标分支为 `release`。

## 验证

- Black / isort / Flake8：本 PR 修改的 Python 文件通过。
- 审计工具与三个网关入口目标回归：87 passed。
- PO Facade 后端完整测试：40 passed。
- 标准运维本地扩大全量：1153 passed；另有 11 个与本分支无差异的存量测试失败，以及 2 个节点管理插件测试因导入基线中不存在的 Component 类而收集失败。本 PR 未修改这些失败文件。

## 发布顺序

1. 先发布本 PR，保持 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 为空，此时行为仍为 B。
2. 发布 PO Facade 配套分支，开始发送由后端认证用户生成的委托头；标准运维仍回退 B。
3. 确认 API Server 的 `BK_AUDIT_DATA_TOKEN` 已启用，并将 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 配置为核实后的 PO Facade 实际部署 app code。
4. 分别验证 A/B 双身份链路、非白名单应用伪造头回退、非法用户名回退。

关联 TAPD：136920805
