### PR TITLE
fix: 兼容免登录网关委托审计 --story=136920805

### DIFF
--- a/docs/plans/2026-08-10-delegated-audit-passwordless-gateway-fix.md
+++ b/docs/plans/2026-08-10-delegated-audit-passwordless-gateway-fix.md
@@ -49,7 +49,9 @@ def test_trusted_app_uses_delegated_operator_for_unverified_gateway_user(self):
 Run:
 
 ```bash
-pytest gcloud/tests/contrib/audit/test_utils.py::DelegatedAuditUsernameTestCase::test_trusted_app_uses_delegated_operator_for_unverified_gateway_user -q
+python manage.py test \
+  gcloud.tests.contrib.audit.test_utils.DelegatedAuditUsernameTestCase.test_trusted_app_uses_delegated_operator_for_unverified_gateway_user \
+  -v 2
 ```
 
 Expected: FAIL，实际值为 `executor`、期望值为 `alice`，证明失败由现有 `_apigw_jwt_user_verified` 条件触发。
@@ -71,7 +73,9 @@ if app_code not in trusted_apps or getattr(app, "verified", False) is not True:
 Run:
 
 ```bash
-pytest gcloud/tests/contrib/audit/test_utils.py::DelegatedAuditUsernameTestCase::test_trusted_app_uses_delegated_operator_for_unverified_gateway_user -q
+python manage.py test \
+  gcloud.tests.contrib.audit.test_utils.DelegatedAuditUsernameTestCase.test_trusted_app_uses_delegated_operator_for_unverified_gateway_user \
+  -v 2
 ```
 
 Expected: PASS。
@@ -81,7 +85,10 @@ Expected: PASS。
 Run:
 
 ```bash
-pytest gcloud/tests/contrib/audit/test_utils.py gcloud/tests/apigw/views/test_plugin_gateway.py -q
+python manage.py test \
+  gcloud.tests.contrib.audit.test_utils \
+  gcloud.tests.apigw.views.test_plugin_gateway \
+  -v 2
 ```
 
 Expected: 全部 PASS；非白名单应用和未验证应用仍回退 B，原始 APIGW JWT 用户捕获行为保持不变。

--- a/docs/plans/2026-08-10-delegated-audit-passwordless-gateway-fix.md
+++ b/docs/plans/2026-08-10-delegated-audit-passwordless-gateway-fix.md
@@ -1,0 +1,107 @@
+# 免登录网关委托审计信任修复 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让经过认证且在专用白名单中的 PO Facade 在免登录网关调用中仍可把 A 作为审计操作人，同时保持 B 用于 IAM 和任务执行。
+
+**Architecture:** 保留 API Gateway 应用认证和 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 作为委托身份的信任边界，并继续校验委托头格式。仅从 `get_audit_username()` 的接受条件中移除 `_apigw_jwt_user_verified`，因为 `get_client_by_username(B)` 在没有 access token 时会产生“应用已验证、用户未验证”的合法免登录调用。
+
+**Tech Stack:** Python 3.6、Django 3.2、`unittest` / Django `SimpleTestCase`
+
+## Global Constraints
+
+- 设计规格以 `docs/specs/2026-08-10-delegated-audit-operator-design.md` 为准。
+- 只有 `request.app.verified is True` 且 app code 位于 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 时才接受委托操作人。
+- 委托操作人仍须匹配现有账号格式和长度限制。
+- `request.user.username`、IAM 校验、任务创建和任务执行继续使用 B。
+- 非白名单应用、未验证应用、缺失或非法委托头继续回退 B，且不得阻断业务请求。
+- 提交必须关联 TAPD Story `136920805`。
+
+---
+
+### Task 1: 兼容免登录代理用户的委托审计身份
+
+**Files:**
+- Modify: `gcloud/tests/contrib/audit/test_utils.py`
+- Modify: `gcloud/contrib/audit/utils.py:65-104`
+
+**Interfaces:**
+- Consumes: `get_audit_username(request) -> str`，其中 request 提供 `user`、`app`、`META` 和可选 `trace_id`。
+- Produces: 对已验证白名单应用返回合法委托操作人 A；其余情况返回代理用户 B。
+
+- [ ] **Step 1: 写入免登录网关调用的失败回归测试**
+
+将原有复合回退测试中的应用边界保留，并新增明确的免登录用例：
+
+```python
+@override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+def test_trusted_app_uses_delegated_operator_for_unverified_gateway_user(self):
+    self.assertEqual(
+        utils.get_audit_username(self.request(operator="alice", verified=False)),
+        "alice",
+    )
+```
+
+原有测试继续分别断言 `app_code="other-app"` 和 `app_verified=False` 时返回 `executor`。
+
+- [ ] **Step 2: 运行新增测试并确认红灯**
+
+Run:
+
+```bash
+pytest gcloud/tests/contrib/audit/test_utils.py::DelegatedAuditUsernameTestCase::test_trusted_app_uses_delegated_operator_for_unverified_gateway_user -q
+```
+
+Expected: FAIL，实际值为 `executor`、期望值为 `alice`，证明失败由现有 `_apigw_jwt_user_verified` 条件触发。
+
+- [ ] **Step 3: 实现最小修复**
+
+把 `get_audit_username()` 的不可信条件收敛为应用身份和白名单：
+
+```python
+if app_code not in trusted_apps or getattr(app, "verified", False) is not True:
+    logger.warning(...)
+    return proxy_username
+```
+
+保留 `_capture_original_apigw_jwt_user()` 和相关 request 属性，避免影响 `plugin_gateway` 对原始网关用户名的现有使用。
+
+- [ ] **Step 4: 运行新增测试并确认绿灯**
+
+Run:
+
+```bash
+pytest gcloud/tests/contrib/audit/test_utils.py::DelegatedAuditUsernameTestCase::test_trusted_app_uses_delegated_operator_for_unverified_gateway_user -q
+```
+
+Expected: PASS。
+
+- [ ] **Step 5: 运行委托审计和 APIGW 回归测试**
+
+Run:
+
+```bash
+pytest gcloud/tests/contrib/audit/test_utils.py gcloud/tests/apigw/views/test_plugin_gateway.py -q
+```
+
+Expected: 全部 PASS；非白名单应用和未验证应用仍回退 B，原始 APIGW JWT 用户捕获行为保持不变。
+
+- [ ] **Step 6: 运行代码风格检查**
+
+Run:
+
+```bash
+pre-commit run black --files gcloud/contrib/audit/utils.py gcloud/tests/contrib/audit/test_utils.py
+pre-commit run isort --files gcloud/contrib/audit/utils.py gcloud/tests/contrib/audit/test_utils.py
+pre-commit run flake8 --files gcloud/contrib/audit/utils.py gcloud/tests/contrib/audit/test_utils.py
+```
+
+Expected: 三项检查均通过。
+
+- [ ] **Step 7: 提交修复**
+
+```bash
+git add gcloud/contrib/audit/utils.py \
+  gcloud/tests/contrib/audit/test_utils.py
+git commit -m "fix: 兼容免登录网关委托审计 --story=136920805"
+```

--- a/docs/specs/2026-08-10-delegated-audit-operator-design.md
+++ b/docs/specs/2026-08-10-delegated-audit-operator-design.md
@@ -35,12 +35,13 @@ X-BkSops-Audit-Operator: A
 
 标准运维仅在以下条件全部成立时接受该值：
 
-1. 请求由 API Gateway 注入应用身份和用户身份。
-2. 原始网关 JWT 中的用户 B 已验证。
-3. 调用应用 app code 位于专用配置 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 中。
-4. 请求头中的 A 非空、长度不超过 64，并且只包含允许的账号字符。
+1. 请求由 API Gateway 注入应用身份，且应用身份已经验证。
+2. 调用应用 app code 位于专用配置 `BK_AUDIT_DELEGATED_OPERATOR_APPS` 中。
+3. 请求头中的 A 非空、长度不超过 64，并且只包含允许的账号字符。
 
 接受后，仅审计事件的 `AuditContext.username` 使用 A。业务代码继续使用 `request.user.username`，因此 IAM、任务创建、异步启动、任务/节点操作均保持 B。
+
+PO Facade 使用 `get_client_by_username(B)` 走内部网关免登录认证。当 B 没有可用 access token 时，网关仍会验证 Facade 应用身份，但不会把声明的 B 标记为已验证用户。委托头由已验证且在专用白名单中的 Facade 后端生成，因此 B 的 JWT 用户验证状态不作为接受 A 的条件。
 
 ### 不采用：把网关用户改成 A
 
@@ -57,7 +58,7 @@ X-BkSops-Audit-Operator: A
 | PO 登录与业务权限校验 | A | 判断谁可以在 PO 发起操作 |
 | Facade 本地 `created_by` / `operator` / `task_creator` | A | PO 自身留痕 |
 | Facade 网关客户端 | B | 获取标准运维权限并发起请求 |
-| API Gateway 已验证用户 | B | 生成标准运维请求用户 |
+| API Gateway 免登录调用用户 | B | 生成标准运维请求用户，可能不带已验证用户标记 |
 | 标准运维 `request.user.username` | B | IAM、任务创建和任务/节点操作 |
 | 标准运维审计 `username` | A | 审计中心最终操作人 |
 | 标准运维审计资源快照 | 任务真实数据 | 可继续体现任务 creator/executor 为 B |
@@ -69,7 +70,7 @@ PO 用户 A
   -> PO 鉴权和审批
   -> Facade 读取任务执行人 B
   -> 以 B 调用 API Gateway，并由 Facade 后端添加 A 的审计头
-  -> API Gateway 验证 app code 和 B
+  -> API Gateway 验证 Facade 应用身份并携带 B
   -> 标准运维以 B 完成 IAM 与业务操作
   -> 标准运维仅在可信条件满足时以 A 上报审计
 ```
@@ -105,7 +106,7 @@ PO 用户 A
 在 `gcloud/contrib/audit/utils.py` 增加公共解析函数，输入 Django request，返回最终审计用户名：
 
 - 默认返回 `request.user.username`，即 B。
-- 只有 APIGW JWT 应用已验证、app code 在专用白名单、原始 APIGW JWT 用户已验证且委托头合法时，返回 A。
+- 只有 APIGW JWT 应用已验证、app code 在专用白名单且委托头合法时，返回 A。
 - 接受委托身份时记录 A、B、app code 和 trace ID 的结构化日志。
 - 请求头存在但不可信或非法时记录不包含原始非法值的告警，并回退 B。
 - 函数不得修改 `request.user`。
@@ -121,10 +122,10 @@ PO 用户 A
 ## 安全与失败处理
 
 - app code 必须来自 APIGW 认证后的 `request.app`，且 `request.app.verified is True`，不能读取普通业务请求参数。
-- 必须检查 `_apigw_jwt_user_verified is True`，防止未验证用户名与委托头组合。
+- 不要求 `_apigw_jwt_user_verified is True`。免登录代理调用中的 B 可能只是由已验证应用声明的执行身份；A 的可信来源是已验证且在专用白名单中的 Facade 应用，而不是 B 的用户认证状态。
 - 专用白名单不得复用现有 `APP_WHITELIST`，避免把其他信任应用自动扩展为审计身份代理。
 - 委托头只接受 ASCII 账号字符 `A-Z`、`a-z`、`0-9`、`_`、`-`、`.`、`@`，长度为 1 到 64。
-- 委托头缺失、非法、调用应用未验证或不可信、网关用户未验证时均回退 B，不返回错误响应。
+- 委托头缺失、非法、调用应用未验证或不可信时均回退 B，不返回错误响应。
 - 日志不得记录 token、cookie、请求体或其他敏感信息。
 
 ## API 与审计中心边界
@@ -145,9 +146,8 @@ PO 用户 A
 
 ### 标准运维
 
-- 可信 app、已验证 B、合法 A：解析结果和审计操作人为 A。
+- 可信且已验证 app、合法 A：无论 B 的 JWT 用户验证状态如何，解析结果和审计操作人均为 A。
 - 未验证或非可信 app：忽略 A，审计操作人为 B。
-- B 未验证：忽略 A，审计操作人为 B。
 - A 缺失、空白、超长或包含非法字符：审计操作人为 B。
 - `create_task` 的任务 creator 仍为 B，审计 username 为 A。
 - `operate_task` 的 Celery/`task_action` 用户仍为 B，审计 username 为 A。

--- a/gcloud/contrib/audit/utils.py
+++ b/gcloud/contrib/audit/utils.py
@@ -72,11 +72,7 @@ def get_audit_username(request):
     app_code = getattr(app, settings.APIGW_MANAGER_APP_CODE_KEY, "")
     trusted_apps = getattr(settings, "BK_AUDIT_DELEGATED_OPERATOR_APPS", set())
     trace_id = getattr(request, "trace_id", "")
-    if (
-        app_code not in trusted_apps
-        or getattr(app, "verified", False) is not True
-        or getattr(request, "_apigw_jwt_user_verified", False) is not True
-    ):
+    if app_code not in trusted_apps or getattr(app, "verified", False) is not True:
         logger.warning(
             "bk_audit delegated_operator_ignored app_code=%s proxy_username=%s trace_id=%s",
             app_code,

--- a/gcloud/tests/contrib/audit/test_utils.py
+++ b/gcloud/tests/contrib/audit/test_utils.py
@@ -34,18 +34,21 @@ class DelegatedAuditUsernameTestCase(SimpleTestCase):
         self.assertEqual(utils.get_audit_username(self.request(operator="alice@tai")), "alice@tai")
 
     @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
-    def test_untrusted_or_unverified_request_falls_back_to_proxy(self):
+    def test_untrusted_or_unverified_app_falls_back_to_proxy(self):
         self.assertEqual(
             utils.get_audit_username(self.request(app_code="other-app", operator="alice")),
             "executor",
         )
         self.assertEqual(
-            utils.get_audit_username(self.request(operator="alice", verified=False)),
-            "executor",
-        )
-        self.assertEqual(
             utils.get_audit_username(self.request(operator="alice", app_verified=False)),
             "executor",
+        )
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_trusted_app_uses_delegated_operator_for_unverified_gateway_user(self):
+        self.assertEqual(
+            utils.get_audit_username(self.request(operator="alice", verified=False)),
+            "alice",
         )
 
     @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})


### PR DESCRIPTION
## 背景

PO 环境通过免登录网关调用 api-server 时，网关应用身份已认证，但任务执行人对应的网关用户未认证。原逻辑同时要求应用和用户均已认证，导致可信委托操作人被忽略，审计仍记录任务执行人。

## 变更

- 委托审计信任条件调整为：调用应用已认证且位于专用白名单
- 保持任务权限校验和实际执行人仍使用代理执行人 B，仅审计操作人使用 PO 登录用户 A
- 保留委托用户名格式校验及异常回退
- 补充免登录网关场景测试，并同步设计与实施文档

## 验证

- 相关审计、网关、创建任务、操作任务和操作节点共 63 个测试通过
- Black、isort、Flake8 与 git diff check 通过