### PR TITLE
feat: PO 审计上报代理执行人

### DIFF
--- a/docs/plans/2026-08-11-audit-proxy-extend-data.md
+++ b/docs/plans/2026-08-11-audit-proxy-extend-data.md
@@ -1,0 +1,506 @@
+# Audit Proxy Extend Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在可信 PO 委托审计事件中，将任务代理执行人 B 上报为 `extend_data.proxy_username`，同时保持审计操作人 A、IAM 权限主体 B 和任务执行人 B 的现有语义。
+
+**Architecture:** 保留 `get_audit_username(request)` 作为唯一委托信任判断，新建 `get_audit_event_kwargs(request)` 组合标准 `username` 与可选 `extend_data`。审计通用入口显式接收、脱敏并透传 `extend_data`，三个已支持 PO 委托的 APIGW 写入口统一解包该事件参数。
+
+**Tech Stack:** Python 3.6、Django 3.2、bk-audit 1.1.1、unittest/mock、pre-commit。
+
+## Global Constraints
+
+- 设计规格：`docs/specs/2026-08-11-audit-proxy-extend-data-design.md`。
+- 仅可信委托生效、代理执行人非空且 A 与 B 不同时生成 `extend_data.proxy_username`。
+- 普通调用、回退调用及 A 与 B 相同的调用不携带代理字段。
+- 不修改 PO Facade Header 协议、IAM 权限主体、任务执行人、审计动作或资源。
+- `extend_data` 必须经过现有 `sanitize_audit_data` 脱敏。
+- 所有提交关联 TAPD 需求 `136920805`。
+
+---
+
+### Task 1: 生成委托审计事件身份参数
+
+**Files:**
+- Modify: `gcloud/contrib/audit/utils.py:65-100`
+- Test: `gcloud/tests/contrib/audit/test_utils.py:12-59`
+
+**Interfaces:**
+- Consumes: `get_audit_username(request) -> str`，继续负责应用白名单、应用认证和委托用户名格式校验。
+- Produces: `get_audit_event_kwargs(request) -> dict`，固定返回 `username` 和 `extend_data` 两个键。
+
+- [ ] **Step 1: 写入会捕获“可信委托未携带代理字段”的失败测试**
+
+在 `DelegatedAuditUsernameTestCase` 中新增：
+
+```python
+@override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+def test_event_kwargs_include_proxy_for_passwordless_trusted_delegation(self):
+    self.assertEqual(
+        utils.get_audit_event_kwargs(
+            self.request(operator="alice", proxy="executor", verified=False)
+        ),
+        {
+            "username": "alice",
+            "extend_data": {"proxy_username": "executor"},
+        },
+    )
+
+@override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+def test_event_kwargs_omit_proxy_without_effective_delegation(self):
+    cases = (
+        (
+            self.request(operator=None, proxy="executor"),
+            {"username": "executor", "extend_data": {}},
+        ),
+        (
+            self.request(app_code="other-app", operator="alice", proxy="executor"),
+            {"username": "executor", "extend_data": {}},
+        ),
+        (
+            self.request(operator="executor", proxy="executor"),
+            {"username": "executor", "extend_data": {}},
+        ),
+        (
+            self.request(operator="alice", proxy=""),
+            {"username": "alice", "extend_data": {}},
+        ),
+    )
+    for request, expected in cases:
+        with self.subTest(request=request):
+            self.assertEqual(utils.get_audit_event_kwargs(request), expected)
+```
+
+第一个测试防止可信免登录委托丢失 B；第二个测试防止普通或回退操作被误标记成代理操作。预期值中的 `extend_data` 使用手写字面量，不复用生产构造逻辑。
+
+- [ ] **Step 2: 运行测试并确认因接口不存在而失败**
+
+Run:
+
+```bash
+set -a
+source /Users/dengyh/Projects/bk-sops/.env
+set +a
+PYTHONPATH=/Users/dengyh/Projects/bk-sops \
+  /Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  gcloud.tests.contrib.audit.test_utils.DelegatedAuditUsernameTestCase -v 2
+```
+
+Expected: FAIL，错误包含 `AttributeError: module 'gcloud.contrib.audit.utils' has no attribute 'get_audit_event_kwargs'`。
+
+- [ ] **Step 3: 写入最小实现**
+
+在 `get_audit_username` 后新增：
+
+```python
+def get_audit_event_kwargs(request):
+    username = get_audit_username(request)
+    proxy_username = getattr(getattr(request, "user", None), "username", "")
+    extend_data = {}
+    if proxy_username and username != proxy_username:
+        extend_data["proxy_username"] = proxy_username
+    return {"username": username, "extend_data": extend_data}
+```
+
+该实现不重复信任校验，只根据 `get_audit_username` 已接受的最终结果判断 A/B 是否分离。
+
+- [ ] **Step 4: 运行委托身份测试并确认通过**
+
+Run: 使用 Step 2 的相同命令。
+
+Expected: `DelegatedAuditUsernameTestCase` 全部 PASS。
+
+- [ ] **Step 5: 提交身份参数实现**
+
+```bash
+git add gcloud/contrib/audit/utils.py gcloud/tests/contrib/audit/test_utils.py
+git commit -m "feat: 生成委托审计代理执行人参数 --story=136920805"
+```
+
+---
+
+### Task 2: 脱敏并透传审计扩展数据
+
+**Files:**
+- Modify: `gcloud/contrib/audit/utils.py:165-220`
+- Test: `gcloud/tests/contrib/audit/test_utils.py:61-204`
+
+**Interfaces:**
+- Consumes: 可选字典 `extend_data`，内容由调用方提供。
+- Produces: `bk_audit_add_event_on_commit(..., extend_data=None)` 和 `bk_audit_add_event(..., extend_data=None)`；最终 SDK 参数包含脱敏后的 `extend_data`。
+
+- [ ] **Step 1: 写入事务回调和 SDK 边界的失败测试**
+
+在 `AuditUtilsTestCase` 中新增 SDK 边界测试：
+
+```python
+@override_settings(ENABLE_BK_AUDIT=True)
+@mock.patch("gcloud.contrib.audit.utils.bk_audit_client.add_event")
+@mock.patch("gcloud.contrib.audit.utils.build_instance", return_value="audit-instance")
+def test_event_sanitizes_and_forwards_extend_data(self, build_instance, add_event):
+    utils.bk_audit_add_event(
+        "alice",
+        "task_operate",
+        "task",
+        mock.Mock(id=1),
+        extend_data={
+            "proxy_username": "executor",
+            "access_token": "sensitive-value",
+        },
+    )
+
+    self.assertEqual(
+        add_event.call_args[1]["extend_data"],
+        {
+            "proxy_username": "executor",
+            "access_token": "******",
+        },
+    )
+```
+
+在 `AuditTransactionTestCase` 中新增事务透传测试：
+
+```python
+@override_settings(ENABLE_BK_AUDIT=True)
+@mock.patch("gcloud.contrib.audit.utils.bk_audit_add_event")
+def test_commit_forwards_extend_data(self, add_event):
+    with self.captureOnCommitCallbacks(execute=True):
+        utils.bk_audit_add_event_on_commit(
+            username="alice",
+            action_id="task_operate",
+            resource_id="task",
+            instance=mock.Mock(id=1),
+            extend_data={"proxy_username": "executor"},
+        )
+
+    self.assertEqual(
+        add_event.call_args[1]["extend_data"],
+        {"proxy_username": "executor"},
+    )
+```
+
+这两个测试分别捕获 SDK 参数遗漏和 `transaction.on_commit` 延迟回调丢字段。
+
+- [ ] **Step 2: 运行新增测试并确认按预期失败**
+
+Run:
+
+```bash
+set -a
+source /Users/dengyh/Projects/bk-sops/.env
+set +a
+PYTHONPATH=/Users/dengyh/Projects/bk-sops \
+  /Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  gcloud.tests.contrib.audit.test_utils.AuditUtilsTestCase.test_event_sanitizes_and_forwards_extend_data \
+  gcloud.tests.contrib.audit.test_utils.AuditTransactionTestCase.test_commit_forwards_extend_data -v 2
+```
+
+Expected: 两个测试 FAIL；SDK 测试缺少 `extend_data` 调用参数，事务测试的延迟调用也缺少该参数。
+
+- [ ] **Step 3: 显式接收并透传扩展数据**
+
+将两个入口签名调整为：
+
+```python
+def bk_audit_add_event_on_commit(
+    username,
+    action_id,
+    resource_id=None,
+    instance=None,
+    origin_data=None,
+    *args,
+    data=None,
+    extend_data=None,
+    **kwargs
+):
+```
+
+```python
+def bk_audit_add_event(
+    username,
+    action_id,
+    resource_id=None,
+    instance=None,
+    origin_data=None,
+    *args,
+    data=None,
+    extend_data=None,
+    **kwargs
+):
+```
+
+在 `transaction.on_commit(partial(...))` 中加入：
+
+```python
+extend_data=extend_data,
+```
+
+在 `bk_audit_add_event` 中与资源快照一起脱敏：
+
+```python
+safe_extend_data = sanitize_audit_data(extend_data)
+```
+
+并在 SDK 调用中加入：
+
+```python
+extend_data=safe_extend_data,
+```
+
+- [ ] **Step 4: 运行审计工具测试并确认通过**
+
+Run:
+
+```bash
+set -a
+source /Users/dengyh/Projects/bk-sops/.env
+set +a
+PYTHONPATH=/Users/dengyh/Projects/bk-sops \
+  /Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  gcloud.tests.contrib.audit.test_utils -v 2
+```
+
+Expected: 全部 PASS，既有禁用、异常隔离、回滚和资源脱敏测试不回归。
+
+- [ ] **Step 5: 提交扩展字段上报实现**
+
+```bash
+git add gcloud/contrib/audit/utils.py gcloud/tests/contrib/audit/test_utils.py
+git commit -m "feat: 透传审计代理执行人扩展字段 --story=136920805"
+```
+
+---
+
+### Task 3: 三个 PO 写入口统一上报代理执行人
+
+**Files:**
+- Modify: `gcloud/apigw/views/create_task.py:38,246-253`
+- Modify: `gcloud/apigw/views/operate_task.py:25,83-104`
+- Modify: `gcloud/apigw/views/operate_node.py:23,80-86`
+- Test: `gcloud/tests/apigw/views/test_create_task.py:54-87`
+- Test: `gcloud/tests/apigw/views/test_operate_task.py:46-77`
+- Test: `gcloud/tests/apigw/views/test_operate_node.py:50-87`
+
+**Interfaces:**
+- Consumes: Task 1 产生的 `get_audit_event_kwargs(request) -> {"username": str, "extend_data": dict}`。
+- Produces: 创建任务、操作任务和操作节点成功事件均把该字典解包给 `bk_audit_add_event_on_commit`。
+
+- [ ] **Step 1: 将三个现有身份隔离测试改为要求扩展字段**
+
+`test_create_task_uses_proxy_for_business_and_delegated_operator_for_audit` 把 `get_audit_username` mock 替换为：
+
+```python
+with mock.patch(
+    "gcloud.apigw.views.create_task.get_audit_event_kwargs",
+    return_value={
+        "username": "alice",
+        "extend_data": {"proxy_username": "executor"},
+    },
+    create=True,
+) as get_audit_event_kwargs:
+```
+
+`test_start_uses_proxy_for_business_and_delegated_operator_for_audit` 把 `get_audit_username` mock 替换为：
+
+```python
+with mock.patch(
+    "gcloud.apigw.views.operate_task.get_audit_event_kwargs",
+    return_value={
+        "username": "alice",
+        "extend_data": {"proxy_username": "executor"},
+    },
+    create=True,
+) as get_audit_event_kwargs:
+```
+
+`test_operate_node_uses_proxy_for_business_and_delegated_operator_for_audit` 把 `get_audit_username` mock 替换为：
+
+```python
+with patch(
+    "gcloud.apigw.views.operate_node.get_audit_event_kwargs",
+    return_value={
+        "username": "alice",
+        "extend_data": {"proxy_username": "executor"},
+    },
+    create=True,
+) as get_audit_event_kwargs:
+```
+
+三个测试保留对业务执行人 `executor` 的现有断言，并统一增加：
+
+```python
+get_audit_event_kwargs.assert_called_once()
+self.assertEqual(add_event.call_args[1]["username"], "alice")
+self.assertEqual(
+    add_event.call_args[1]["extend_data"],
+    {"proxy_username": "executor"},
+)
+```
+
+这些测试会在错误地继续调用旧 helper、遗漏某个入口或误把 B 改成业务操作人时失败。
+
+- [ ] **Step 2: 运行三个 APIGW 测试并确认旧代码失败**
+
+Run:
+
+```bash
+set -a
+source /Users/dengyh/Projects/bk-sops/.env
+set +a
+PYTHONPATH=/Users/dengyh/Projects/bk-sops \
+  /Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  gcloud.tests.apigw.views.test_create_task.CreateTaskAPITest.test_create_task_uses_proxy_for_business_and_delegated_operator_for_audit \
+  gcloud.tests.apigw.views.test_operate_task.OperateTaskAPITest.test_start_uses_proxy_for_business_and_delegated_operator_for_audit \
+  gcloud.tests.apigw.views.test_operate_node.OperateNodeAPITest.test_operate_node_uses_proxy_for_business_and_delegated_operator_for_audit -v 2
+```
+
+Expected: 三个测试 FAIL；`get_audit_event_kwargs` 未被调用，且旧上报参数不含 `extend_data`。
+
+- [ ] **Step 3: 替换三个入口的统一事件参数**
+
+三个文件的导入均改为：
+
+```python
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_event_kwargs
+```
+
+每个成功事件调用统一改成以下形态，`**` 必须放在参数列表最后以兼容 Python 3.6：
+
+```python
+bk_audit_add_event_on_commit(
+    action_id=action_id,
+    resource_id=IAMMeta.TASK_RESOURCE,
+    instance=task,
+    **get_audit_event_kwargs(request)
+)
+```
+
+`operate_task` 和 `operate_node` 的 `action_id` 继续使用 `IAMMeta.TASK_OPERATE_ACTION`。不要修改传给 `prepare_and_start_task`、`task.task_action` 或 `task.nodes_action` 的 `username`，这些业务调用必须继续使用 B。
+
+- [ ] **Step 4: 运行三个入口的完整测试文件**
+
+Run:
+
+```bash
+set -a
+source /Users/dengyh/Projects/bk-sops/.env
+set +a
+PYTHONPATH=/Users/dengyh/Projects/bk-sops \
+  /Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  gcloud.tests.apigw.views.test_create_task \
+  gcloud.tests.apigw.views.test_operate_task \
+  gcloud.tests.apigw.views.test_operate_node -v 2
+```
+
+Expected: 三个测试文件全部 PASS。
+
+- [ ] **Step 5: 提交三个入口的接入修改**
+
+```bash
+git add \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+git commit -m "feat: PO 审计上报代理执行人 --story=136920805"
+```
+
+---
+
+### Task 4: 完整回归和提交前检查
+
+**Files:**
+- Verify: `gcloud/contrib/audit/utils.py`
+- Verify: `gcloud/apigw/views/create_task.py`
+- Verify: `gcloud/apigw/views/operate_task.py`
+- Verify: `gcloud/apigw/views/operate_node.py`
+- Verify: 上述对应测试文件及设计、计划文档
+
+**Interfaces:**
+- Consumes: Task 1-3 的所有实现和测试。
+- Produces: 可提交评审的验证结果，不产生新的运行时接口。
+
+- [ ] **Step 1: 运行相关完整回归测试**
+
+Run:
+
+```bash
+set -o pipefail
+set -a
+source /Users/dengyh/Projects/bk-sops/.env
+set +a
+PYTHONPATH=/Users/dengyh/Projects/bk-sops \
+  /Users/dengyh/.pyenv/versions/3.6.15/bin/python manage.py test \
+  gcloud.tests.contrib.audit.test_utils \
+  gcloud.tests.apigw.views.test_plugin_gateway \
+  gcloud.tests.apigw.views.test_create_task \
+  gcloud.tests.apigw.views.test_operate_task \
+  gcloud.tests.apigw.views.test_operate_node -v 2
+```
+
+Expected: 全部测试 PASS，测试数至少为基线 63 加本计划新增用例。
+
+- [ ] **Step 2: 运行格式和静态检查**
+
+Run:
+
+```bash
+/Users/dengyh/.local/bin/pre-commit run black --files \
+  gcloud/contrib/audit/utils.py \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/contrib/audit/test_utils.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+/Users/dengyh/.local/bin/pre-commit run isort --files \
+  gcloud/contrib/audit/utils.py \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/contrib/audit/test_utils.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+/Users/dengyh/.local/bin/pre-commit run flake8 --files \
+  gcloud/contrib/audit/utils.py \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py \
+  gcloud/tests/contrib/audit/test_utils.py \
+  gcloud/tests/apigw/views/test_create_task.py \
+  gcloud/tests/apigw/views/test_operate_task.py \
+  gcloud/tests/apigw/views/test_operate_node.py
+git diff --check upstream/master...HEAD
+```
+
+Expected: Black、isort、Flake8 和 `git diff --check` 全部退出码为 0。
+
+- [ ] **Step 3: 核对最终差异和身份边界**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --stat upstream/master...HEAD
+git diff upstream/master...HEAD -- \
+  gcloud/contrib/audit/utils.py \
+  gcloud/apigw/views/create_task.py \
+  gcloud/apigw/views/operate_task.py \
+  gcloud/apigw/views/operate_node.py
+```
+
+Expected:
+
+- 工作区无未提交代码；
+- `username` 仍为 A；
+- `extend_data.proxy_username` 为 B；
+- 业务调用继续使用原 `request.user.username`；
+- 没有审计动作、资源、Header 协议或依赖版本变化。
+
+- [ ] **Step 4: 按 `superpowers:finishing-a-development-branch` 提供集成选项**
+
+基线分支固定为 `upstream/master`。不要直接推送或创建 PR；先向用户提供本地合并、推送创建 PR、保留分支三个选项，并按用户选择执行。

--- a/docs/specs/2026-08-11-audit-proxy-extend-data-design.md
+++ b/docs/specs/2026-08-11-audit-proxy-extend-data-design.md
@@ -1,0 +1,114 @@
+# 委托审计代理执行人扩展字段设计
+
+## 背景
+
+PO 通过免登录网关调用 api-server 时，标准运维已经能够保持两类身份相互独立：
+
+- PO 登录用户 A 作为审计事件的最终操作人 `username`。
+- PO 业务配置中的任务执行人 B 继续用于 IAM 权限校验和任务执行。
+
+当前 api-server 只在本地 `delegated_operator_resolved` 日志中记录 B，审计 SDK 上报的事件不包含该信息。审计中心因此可以检索 A，但无法从事件本身追溯代理执行人 B。
+
+## 目标
+
+可信委托生效时，在不改变现有身份语义的前提下，将代理执行人写入审计事件：
+
+```json
+{
+  "username": "operator_a",
+  "extend_data": {
+    "proxy_username": "executor_b"
+  }
+}
+```
+
+本期不新增审计动作或资源，不调整 IAM 权限主体、任务执行人及现有审计操作人。
+
+## 方案对比
+
+### 方案一：使用 `extend_data`（采用）
+
+BK Audit SDK 1.1.1 的 `add_event` 原生支持 `extend_data`，并将其序列化到 `AuditEvent.extend_data`。该字段适合承载不改变标准操作人语义的辅助上下文。
+
+优点：不污染标准身份字段和资源快照，兼容现有审计事件结构；普通调用可以保持原样。
+
+### 方案二：复用 `user_identify_src_username`（不采用）
+
+该字段描述最终操作人的账号来源信息，不是代理执行人。复用会导致审计中心对操作主体的解释产生歧义。
+
+### 方案三：写入 `instance_data`（不采用）
+
+任务实例数据用于资源快照。代理执行人属于事件上下文而不是任务资源属性，写入会污染前后快照和差异展示。
+
+## 设计
+
+### 委托身份解析
+
+保留现有 `get_audit_username(request)` 的信任校验和回退逻辑，新增 `get_audit_event_kwargs(request)` 统一生成事件身份参数：
+
+```python
+{
+    "username": audit_username,
+    "extend_data": {"proxy_username": proxy_username},
+}
+```
+
+只有同时满足以下条件时才包含 `proxy_username`：
+
+1. 现有可信应用和委托用户名校验已经接受 A；
+2. 请求中存在非空代理执行人 B；
+3. A 与 B 不相同。
+
+普通登录调用、未携带委托操作人、应用不可信、委托用户名无效以及 A 与 B 相同的场景，`extend_data` 均为空，不把普通操作误标记为代理操作。
+
+### 审计事件上报
+
+`bk_audit_add_event_on_commit` 和 `bk_audit_add_event` 增加可选参数 `extend_data=None`：
+
+1. 事务提交回调继续透传该字段；
+2. 上报前复用 `sanitize_audit_data` 清理敏感字段；
+3. 调用 `bk_audit_client.add_event(..., extend_data=safe_extend_data)`。
+
+未传 `extend_data` 的全部存量调用行为保持不变。
+
+### 接入范围
+
+本期只调整已支持 PO 委托审计的三个 APIGW 写操作入口：
+
+- 创建任务 `create_task`；
+- 操作任务 `operate_task`；
+- 操作节点 `operate_node`。
+
+三个入口从只传 `username=get_audit_username(request)` 调整为解包 `get_audit_event_kwargs(request)`，避免各接口重复实现 A/B 判断。
+
+## 异常与安全边界
+
+- `proxy_username` 仅来自 api-server 已认证请求对象的 `request.user.username`，不直接信任新增外部 Header。
+- 委托 Header 不可信或格式非法时沿用现有回退策略，审计操作人和执行人均为 B，且不生成代理扩展字段。
+- `extend_data` 继续遵守审计数据脱敏规则；审计 SDK 异常仍只记录错误日志，不阻断业务请求。
+- 审计中心是否将 `extend_data.proxy_username` 展示为独立检索字段，由审计中心字段映射配置决定；本设计保证事件原始数据包含该字段。
+
+## 测试与验收
+
+单元测试覆盖：
+
+1. 可信委托 A/B 不同时生成 `extend_data.proxy_username=B`；
+2. 免登录网关用户未验证但应用可信时仍生成代理字段；
+3. 普通调用、回退调用及 A/B 相同时不生成代理字段；
+4. `bk_audit_add_event_on_commit` 将扩展字段传递到实际上报函数；
+5. `bk_audit_add_event` 清理扩展数据后传给 BK Audit SDK；
+6. 三个 APIGW 写入口均使用统一事件参数。
+
+Stage 验收以同一 trace 中的以下结果为准：
+
+- IAM 权限主体仍为 B；
+- 审计事件 `username` 为 A；
+- 审计事件原始数据包含 `extend_data.proxy_username=B`；
+- api-server 记录 `bk_audit add_event: success`。
+
+## 非目标
+
+- 不修改 PO Facade Header 协议；
+- 不把 B 改为最终审计操作人；
+- 不调整审计动作、资源或审计中心展示配置；
+- 不为普通非委托操作补充 `proxy_username`。

--- a/gcloud/apigw/views/create_task.py
+++ b/gcloud/apigw/views/create_task.py
@@ -35,7 +35,7 @@ from gcloud.common_template.models import CommonTemplate
 from gcloud.conf import settings
 from gcloud.constants import NON_COMMON_TEMPLATE_TYPES, PROJECT, TaskCreateMethod
 from gcloud.contrib.audit.mappings import get_task_create_action
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_username
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_event_kwargs
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.models import EngineConfig
@@ -246,10 +246,7 @@ def create_task(request, template_id, project_id):
     action_id = get_task_create_action(template_source, create_method)
     if action_id:
         bk_audit_add_event_on_commit(
-            username=get_audit_username(request),
-            action_id=action_id,
-            resource_id=IAMMeta.TASK_RESOURCE,
-            instance=task,
+            action_id=action_id, resource_id=IAMMeta.TASK_RESOURCE, instance=task, **get_audit_event_kwargs(request)
         )
     result_data = {"task_id": task.id, "task_url": task.url, "pipeline_tree": task.pipeline_tree}
     if task.flow_type == "common_func":

--- a/gcloud/apigw/views/operate_node.py
+++ b/gcloud/apigw/views/operate_node.py
@@ -20,7 +20,7 @@ from django.views.decorators.http import require_POST
 
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_username
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_event_kwargs
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
@@ -79,10 +79,10 @@ def operate_node(request, project_id, task_id):
     result = task.nodes_action(action, node_id, username, **kwargs)
     if result.get("result") is True:
         bk_audit_add_event_on_commit(
-            username=get_audit_username(request),
             action_id=IAMMeta.TASK_OPERATE_ACTION,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=task,
+            **get_audit_event_kwargs(request)
         )
     result["code"] = err_code.SUCCESS.code if result["result"] else err_code.UNKNOWN_ERROR.code
     return result

--- a/gcloud/apigw/views/operate_task.py
+++ b/gcloud/apigw/views/operate_task.py
@@ -22,7 +22,7 @@ from django.views.decorators.http import require_POST
 import env
 from gcloud import err_code
 from gcloud.apigw.decorators import mark_request_whether_is_trust, project_inject, return_json_response
-from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_username
+from gcloud.contrib.audit.utils import bk_audit_add_event_on_commit, get_audit_event_kwargs
 from gcloud.contrib.operate_record.constants import OperateSource, OperateType, RecordType
 from gcloud.contrib.operate_record.decorators import record_operation
 from gcloud.core.trace import CallFrom, trace_view
@@ -81,10 +81,10 @@ def operate_task(request, task_id, project_id):
             kwargs=dict(task_id=task_id, project_id=project.id, username=username), queue=queue, routing_key=routing_key
         )
         bk_audit_add_event_on_commit(
-            username=get_audit_username(request),
             action_id=IAMMeta.TASK_OPERATE_ACTION,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=task,
+            **get_audit_event_kwargs(request)
         )
 
         return {
@@ -97,9 +97,9 @@ def operate_task(request, task_id, project_id):
     ctx = task.task_action(action, username)
     if ctx.get("result") is True:
         bk_audit_add_event_on_commit(
-            username=get_audit_username(request),
             action_id=IAMMeta.TASK_OPERATE_ACTION,
             resource_id=IAMMeta.TASK_RESOURCE,
             instance=task,
+            **get_audit_event_kwargs(request)
         )
     return ctx

--- a/gcloud/contrib/audit/utils.py
+++ b/gcloud/contrib/audit/utils.py
@@ -172,7 +172,7 @@ def get_periodic_task_audit_snapshot(instance):
 
 
 def bk_audit_add_event_on_commit(
-    username, action_id, resource_id=None, instance=None, origin_data=None, *args, data=None, **kwargs
+    username, action_id, resource_id=None, instance=None, origin_data=None, *args, data=None, extend_data=None, **kwargs
 ):
     """Register a success event only after the surrounding transaction commits."""
     if not settings.ENABLE_BK_AUDIT:
@@ -186,12 +186,13 @@ def bk_audit_add_event_on_commit(
             instance=instance,
             origin_data=origin_data,
             data=data,
+            extend_data=extend_data,
         )
     )
 
 
 def bk_audit_add_event(
-    username, action_id, resource_id=None, instance=None, origin_data=None, *args, data=None, **kwargs
+    username, action_id, resource_id=None, instance=None, origin_data=None, *args, data=None, extend_data=None, **kwargs
 ):
     if not settings.ENABLE_BK_AUDIT:
         return
@@ -211,6 +212,7 @@ def bk_audit_add_event(
             data = build_instance_data(resource_id, instance)
         safe_origin_data = sanitize_audit_data(origin_data)
         safe_data = sanitize_audit_data(data)
+        safe_extend_data = sanitize_audit_data(extend_data)
         instance = build_instance(resource_id, instance, safe_origin_data, safe_data)
         context = AuditContext(username=username)
         bk_audit_client.add_event(
@@ -218,6 +220,7 @@ def bk_audit_add_event(
             resource_type=ResourceType(resource_id) if resource_id else None,
             audit_context=context,
             instance=instance,
+            extend_data=safe_extend_data,
         )
         logger.info("bk_audit add_event: success")
     except Exception:

--- a/gcloud/contrib/audit/utils.py
+++ b/gcloud/contrib/audit/utils.py
@@ -100,6 +100,15 @@ def get_audit_username(request):
     return operator
 
 
+def get_audit_event_kwargs(request):
+    username = get_audit_username(request)
+    proxy_username = getattr(getattr(request, "user", None), "username", "")
+    extend_data = {}
+    if proxy_username and username != proxy_username:
+        extend_data["proxy_username"] = proxy_username
+    return {"username": username, "extend_data": extend_data}
+
+
 def sanitize_audit_data(data):
     """Remove large payloads and redact secret-like values from audit snapshots."""
     if isinstance(data, dict):

--- a/gcloud/tests/apigw/views/test_create_task.py
+++ b/gcloud/tests/apigw/views/test_create_task.py
@@ -66,10 +66,13 @@ class CreateTaskAPITest(APITest):
                 MagicMock(return_value=MockQuerySet(get_result=tmpl)),
             ):
                 with mock.patch(
-                    "gcloud.apigw.views.create_task.get_audit_username",
-                    return_value="alice",
+                    "gcloud.apigw.views.create_task.get_audit_event_kwargs",
+                    return_value={
+                        "username": "alice",
+                        "extend_data": {"proxy_username": "executor"},
+                    },
                     create=True,
-                ) as get_audit_username:
+                ) as get_audit_event_kwargs:
                     with mock.patch("gcloud.apigw.views.create_task.bk_audit_add_event_on_commit") as add_event:
                         response = self.client.post(
                             path=self.url().format(template_id=TEST_TEMPLATE_ID, project_id=TEST_PROJECT_ID),
@@ -83,8 +86,12 @@ class CreateTaskAPITest(APITest):
         self.assertTrue(data["result"], msg=data)
         pipeline_kwargs = TaskFlowInstance.objects.create_pipeline_instance_exclude_task_nodes.call_args[0][1]
         self.assertEqual(pipeline_kwargs["creator"], "executor")
-        get_audit_username.assert_called_once()
+        get_audit_event_kwargs.assert_called_once()
         self.assertEqual(add_event.call_args[1]["username"], "alice")
+        self.assertEqual(
+            add_event.call_args[1]["extend_data"],
+            {"proxy_username": "executor"},
+        )
 
         TaskFlowInstance.objects.create_pipeline_instance_exclude_task_nodes.reset_mock()
         TaskFlowInstance.objects.create.reset_mock()

--- a/gcloud/tests/apigw/views/test_operate_node.py
+++ b/gcloud/tests/apigw/views/test_operate_node.py
@@ -53,10 +53,13 @@ class OperateNodeAPITest(APITest):
 
         with patch(TASKINSTANCE_GET, MagicMock(return_value=task_instance)):
             with patch(
-                "gcloud.apigw.views.operate_node.get_audit_username",
-                return_value="alice",
+                "gcloud.apigw.views.operate_node.get_audit_event_kwargs",
+                return_value={
+                    "username": "alice",
+                    "extend_data": {"proxy_username": "executor"},
+                },
                 create=True,
-            ) as get_audit_username:
+            ) as get_audit_event_kwargs:
                 with patch("gcloud.apigw.views.operate_node.bk_audit_add_event_on_commit") as add_event:
                     response = self.client.post(
                         path=self.url().format(project_id=TEST_PROJECT_ID, task_id=TEST_TASKFLOW_ID),
@@ -83,8 +86,12 @@ class OperateNodeAPITest(APITest):
             inputs=TEST_INPUTS,
             flow_id=TEST_FLOW_ID,
         )
-        get_audit_username.assert_called_once()
+        get_audit_event_kwargs.assert_called_once()
         self.assertEqual(add_event.call_args[1]["username"], "alice")
+        self.assertEqual(
+            add_event.call_args[1]["extend_data"],
+            {"proxy_username": "executor"},
+        )
 
     @patch(
         PROJECT_GET,

--- a/gcloud/tests/apigw/views/test_operate_task.py
+++ b/gcloud/tests/apigw/views/test_operate_task.py
@@ -55,10 +55,13 @@ class OperateTaskAPITest(APITest):
         with mock.patch(APIGW_OPERATE_TASK_TASKFLOW_INSTANCE, taskflow_instance):
             with mock.patch(APIGW_OPERATE_TASK_PREPARE_AND_START_TASK, prepare_and_start_task):
                 with mock.patch(
-                    "gcloud.apigw.views.operate_task.get_audit_username",
-                    return_value="alice",
+                    "gcloud.apigw.views.operate_task.get_audit_event_kwargs",
+                    return_value={
+                        "username": "alice",
+                        "extend_data": {"proxy_username": "executor"},
+                    },
                     create=True,
-                ) as get_audit_username:
+                ) as get_audit_event_kwargs:
                     with mock.patch("gcloud.apigw.views.operate_task.bk_audit_add_event_on_commit") as add_event:
                         response = self.client.post(
                             path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
@@ -73,8 +76,12 @@ class OperateTaskAPITest(APITest):
             prepare_and_start_task.apply_async.call_args[1]["kwargs"]["username"],
             "executor",
         )
-        get_audit_username.assert_called_once()
+        get_audit_event_kwargs.assert_called_once()
         self.assertEqual(add_event.call_args[1]["username"], "alice")
+        self.assertEqual(
+            add_event.call_args[1]["extend_data"],
+            {"proxy_username": "executor"},
+        )
 
     @mock.patch(
         PROJECT_GET,
@@ -179,6 +186,7 @@ class OperateTaskAPITest(APITest):
         prepare_and_start_task.apply_async.assert_called_once()
         add_event.assert_called_once_with(
             username="",
+            extend_data={},
             action_id="task_operate",
             resource_id="task",
             instance=task,

--- a/gcloud/tests/apigw/views/test_operate_task.py
+++ b/gcloud/tests/apigw/views/test_operate_task.py
@@ -94,23 +94,39 @@ class OperateTaskAPITest(APITest):
             )
         ),
     )
-    def test_operate_task(self):
+    def test_operate_task_uses_proxy_for_business_and_delegated_operator_for_audit(self):
         assert_return = {"result": True}
         assert_action = "any_action"
         task = MockTaskFlowInstance(task_action_return=assert_return)
 
         with mock.patch(TASKINSTANCE_GET, MagicMock(return_value=task)):
-            response = self.client.post(
-                path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
-                data=json.dumps({"action": assert_action}),
-                content_type="application/json",
-            )
+            with mock.patch(
+                "gcloud.apigw.views.operate_task.get_audit_event_kwargs",
+                return_value={
+                    "username": "alice",
+                    "extend_data": {"proxy_username": "executor"},
+                },
+                create=True,
+            ) as get_audit_event_kwargs:
+                with mock.patch("gcloud.apigw.views.operate_task.bk_audit_add_event_on_commit") as add_event:
+                    response = self.client.post(
+                        path=self.url().format(task_id=TEST_TASKFLOW_ID, project_id=TEST_PROJECT_ID),
+                        data=json.dumps({"action": assert_action}),
+                        content_type="application/json",
+                        HTTP_BK_USERNAME="executor",
+                    )
 
-            task.task_action.assert_called_once_with(assert_action, "")
+        task.task_action.assert_called_once_with(assert_action, "executor")
+        get_audit_event_kwargs.assert_called_once()
+        self.assertEqual(add_event.call_args[1]["username"], "alice")
+        self.assertEqual(
+            add_event.call_args[1]["extend_data"],
+            {"proxy_username": "executor"},
+        )
 
-            data = json.loads(response.content)
+        data = json.loads(response.content)
 
-            self.assertEqual(data, assert_return)
+        self.assertEqual(data, assert_return)
 
     @mock.patch(
         PROJECT_GET,

--- a/gcloud/tests/contrib/audit/test_utils.py
+++ b/gcloud/tests/contrib/audit/test_utils.py
@@ -201,6 +201,29 @@ class AuditUtilsTestCase(SimpleTestCase):
         add_event.assert_called_once()
 
     @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.bk_audit_client.add_event")
+    @mock.patch("gcloud.contrib.audit.utils.build_instance", return_value="audit-instance")
+    def test_event_sanitizes_and_forwards_extend_data(self, build_instance, add_event):
+        utils.bk_audit_add_event(
+            "alice",
+            "task_operate",
+            "task",
+            mock.Mock(id=1),
+            extend_data={
+                "proxy_username": "executor",
+                "access_token": "sensitive-value",
+            },
+        )
+
+        self.assertEqual(
+            add_event.call_args[1]["extend_data"],
+            {
+                "proxy_username": "executor",
+                "access_token": "******",
+            },
+        )
+
+    @override_settings(ENABLE_BK_AUDIT=True)
     def test_snapshot_accepts_lazy_data_builder(self):
         snapshot = utils.get_audit_snapshot(
             "periodic_task",
@@ -221,6 +244,23 @@ class AuditTransactionTestCase(TestCase):
             )
 
         add_event.assert_called_once()
+
+    @override_settings(ENABLE_BK_AUDIT=True)
+    @mock.patch("gcloud.contrib.audit.utils.bk_audit_add_event")
+    def test_commit_forwards_extend_data(self, add_event):
+        with self.captureOnCommitCallbacks(execute=True):
+            utils.bk_audit_add_event_on_commit(
+                username="alice",
+                action_id="task_operate",
+                resource_id="task",
+                instance=mock.Mock(id=1),
+                extend_data={"proxy_username": "executor"},
+            )
+
+        self.assertEqual(
+            add_event.call_args[1]["extend_data"],
+            {"proxy_username": "executor"},
+        )
 
     @override_settings(ENABLE_BK_AUDIT=True)
     @mock.patch("gcloud.contrib.audit.utils.bk_audit_add_event")

--- a/gcloud/tests/contrib/audit/test_utils.py
+++ b/gcloud/tests/contrib/audit/test_utils.py
@@ -52,6 +52,40 @@ class DelegatedAuditUsernameTestCase(SimpleTestCase):
         )
 
     @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_event_kwargs_include_proxy_for_passwordless_trusted_delegation(self):
+        self.assertEqual(
+            utils.get_audit_event_kwargs(self.request(operator="alice", proxy="executor", verified=False)),
+            {
+                "username": "alice",
+                "extend_data": {"proxy_username": "executor"},
+            },
+        )
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
+    def test_event_kwargs_omit_proxy_without_effective_delegation(self):
+        cases = (
+            (
+                self.request(operator=None, proxy="executor"),
+                {"username": "executor", "extend_data": {}},
+            ),
+            (
+                self.request(app_code="other-app", operator="alice", proxy="executor"),
+                {"username": "executor", "extend_data": {}},
+            ),
+            (
+                self.request(operator="executor", proxy="executor"),
+                {"username": "executor", "extend_data": {}},
+            ),
+            (
+                self.request(operator="alice", proxy=""),
+                {"username": "alice", "extend_data": {}},
+            ),
+        )
+        for request, expected in cases:
+            with self.subTest(request=request):
+                self.assertEqual(utils.get_audit_event_kwargs(request), expected)
+
+    @override_settings(BK_AUDIT_DELEGATED_OPERATOR_APPS={"bk-sops-facade"})
     def test_missing_or_invalid_operator_falls_back_to_proxy(self):
         for operator in (None, "", "has space", "bad/value", "x" * 65):
             with self.subTest(operator=operator):


### PR DESCRIPTION
## 背景

PO 通过免登录网关委托调用 api-server 时，现有链路能够将 PO 登录账号 A 识别为最终审计操作人，同时继续使用配置的任务执行人 B 完成业务执行和 IAM 校验；但 B 尚未进入 BK Audit 事件，审计中心无法从原始事件中还原完整代理执行关系。

## 变更内容

- 新增统一审计事件参数生成逻辑，继续复用既有受信任应用、委托账号和用户名合法性校验。
- 当受信任委托调用满足 A 与 B 不同时，将 B 写入 `extend_data.proxy_username`，审计 `username` 仍为 A。
- 审计通用入口和事务提交回调支持显式透传、递归清洗 `extend_data`。
- 接入创建任务、任务操作（start 与非 start）和节点操作三个 APIGW 写入口。
- 补充普通调用、不可信应用、A=B、B 为空、失败分支及 A/B 身份隔离测试。

## 兼容性与影响

- 业务执行和既有 IAM 校验继续使用 B，不改变任务实际执行人。
- 普通调用、委托校验失败、A=B 或 B 为空时不增加 `proxy_username`。
- 不新增审计动作、资源、Header 协议、依赖或数据库迁移。
- TAPD Story：136920805。

## 验证

- 相关 Django 测试：67 项通过。
- Black、isort、Flake8：通过。
- `git diff --check`、敏感信息检查、迁移检查：通过。
- 整分支最终 Review：Critical / Important / Minor 均为 0。