### PR TITLE
perf: 优化未执行任务列表查询 --bug=1010131351162150454

### DIFF
--- a/docs/plans/2026-08-11-unstarted-task-list-two-phase-query.md
+++ b/docs/plans/2026-08-11-unstarted-task-list-two-phase-query.md
@@ -14,7 +14,7 @@
 - Do not add or alter database indexes or migrations.
 - Preserve `TaskFlowInstance.id DESC`, `limit`, `offset`, response fields, IAM injection, and template-info injection.
 - Only the explicit `pipeline_instance__is_started=false` and `is_child_taskflow=false` list path with `without_count` and default ordering may opt in.
-- `is_started=true`, absent status, explicit ordering, name search, “我的动态”, `task_instance_status`, count, retrieve, and other endpoints must retain their existing path.
+- `is_started=true`, absent status, explicit ordering, name search, exact task-ID search, “我的动态”, `task_instance_status`, count, retrieve, and other endpoints must retain their existing path.
 - Do not silently retry a failed phase-one SQL query.
 - The current primary worktree is dirty; execution must use an isolated worktree based on the latest `upstream/master` without stashing or modifying user changes.
 - Repository commits must reference TAPD Bug `1010131351162150454`：`任务列表筛选“未执行”时接口耗时过长`。
@@ -155,6 +155,7 @@ Use `SimpleNamespace(query_params=params)` to assert the guard returns `False` f
 {"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "pipeline_instance__name__icontains": "demo"}
 {"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "creator_or_executor": "user"}
 {"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "task_instance_status": "failed"}
+{"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "id": "147883347"}
 {"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "true"}
 ```
 
@@ -180,7 +181,7 @@ def _is_false_query_param(value):
     return value is False or str(value).lower() in {"false", "0"}
 ```
 
-Add `_should_use_two_phase_unstarted_task_list` requiring project ID, false `pipeline_instance__is_started`, false `is_child_taskflow`, and the absence of `order_by`, `pipeline_instance__name__icontains`, `creator_or_executor`, and `task_instance_status`.
+Add `_should_use_two_phase_unstarted_task_list` requiring project ID, false `pipeline_instance__is_started`, false `is_child_taskflow`, and the absence of `order_by`, `pipeline_instance__name__icontains`, `creator_or_executor`, `task_instance_status`, and `id`.
 
 Inside the existing `without_count` branch, order the decisions as:
 

--- a/docs/plans/2026-08-11-unstarted-task-list-two-phase-query.md
+++ b/docs/plans/2026-08-11-unstarted-task-list-two-phase-query.md
@@ -1,0 +1,275 @@
+# Unstarted Task List Two-Phase Query Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Multi-agent execution is not used for this task.
+
+**Goal:** Reduce the explicitly filtered unstarted task-list request from roughly 70 seconds to the verified 3-4 second ID-scan range without changing API results, ordering, pagination, or other status-filter paths.
+
+**Architecture:** Add a narrowly gated list-view branch that asks `TaskFlowInstanceManager` for a page using two phases. Phase one compiles the fully filtered queryset as an ID-only query and injects the existing production composite-index hint; phase two reapplies the same queryset filters to those IDs, loads `pipeline_instance` and `project` in one query, and restores the phase-one order. Non-MySQL databases and schemas without the production index keep the original ORM path.
+
+**Tech Stack:** Python 3.6, Django ORM, Django REST Framework, MySQL 5.7-compatible SQL, `django.test`, `mock`.
+
+## Global Constraints
+
+- Design source: `docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md`.
+- Do not add or alter database indexes or migrations.
+- Preserve `TaskFlowInstance.id DESC`, `limit`, `offset`, response fields, IAM injection, and template-info injection.
+- Only the explicit `pipeline_instance__is_started=false` and `is_child_taskflow=false` list path with `without_count` and default ordering may opt in.
+- `is_started=true`, absent status, explicit ordering, name search, “我的动态”, `task_instance_status`, count, retrieve, and other endpoints must retain their existing path.
+- Do not silently retry a failed phase-one SQL query.
+- The current primary worktree is dirty; execution must use an isolated worktree based on the latest `upstream/master` without stashing or modifying user changes.
+- Repository commits must reference TAPD Bug `1010131351162150454`：`任务列表筛选“未执行”时接口耗时过长`。
+
+---
+
+### Task 1: Add manager-level two-phase page retrieval
+
+**Files:**
+- Modify: `gcloud/taskflow3/models.py:570-610`
+- Test: `gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py`
+
+**Interfaces:**
+- Consumes: a fully filtered, unsliced `QuerySet[TaskFlowInstance]`, integer `limit`, and integer `offset`.
+- Produces: `TaskFlowInstanceManager.fetch_unstarted_task_list_page_two_phase(queryset, limit, offset) -> list[TaskFlowInstance]`.
+- Produces: `TaskFlowInstanceManager.has_unstarted_task_list_covering_index() -> bool`, cached per process and safe for non-MySQL databases.
+
+- [ ] **Step 1: Write failing tests for index-hint injection, ID execution, detail preloading, and order restoration**
+
+Add manager tests that construct an ID-only SQL string, return cursor rows `[(9,), (4,), (2,)]`, and assert:
+
+```python
+result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+    queryset=queryset,
+    limit=15,
+    offset=5,
+)
+
+assert [instance.id for instance in result] == [9, 4, 2]
+cursor.execute.assert_called_once_with(expected_sql_with_force_index, expected_params)
+detail_queryset.select_related.assert_called_once_with("pipeline_instance", "project")
+```
+
+The mock queryset records `values_list("id", flat=True)`, slicing with `slice(5, 20)`, `filter(id__in=[9, 4, 2])`, and the `select_related` call. Add a separate assertion that an empty ID result does not execute phase two.
+
+- [ ] **Step 2: Run the focused manager tests and verify the new API is absent**
+
+Run:
+
+```bash
+pytest -q gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
+```
+
+Expected: the new tests fail because `fetch_unstarted_task_list_page_two_phase` and the covering-index capability method do not exist; the existing ignore-primary tests continue to pass.
+
+- [ ] **Step 3: Implement cached index capability detection**
+
+In `TaskFlowInstanceManager`, add constants:
+
+```python
+TASK_LIST_UNSTARTED_COVERING_INDEX = "idx_proj_del_child_id_pipe"
+FORCE_UNSTARTED_COVERING_INDEX_HINT_SQL = "FORCE INDEX (`idx_proj_del_child_id_pipe`)"
+```
+
+Add a process-cached method that returns `False` for non-MySQL connections, otherwise executes:
+
+```python
+cursor.execute(
+    "SHOW INDEX FROM `taskflow3_taskflowinstance` WHERE Key_name = %s",
+    ["idx_proj_del_child_id_pipe"],
+)
+```
+
+It returns whether `cursor.fetchone()` is present. Catch `django.db.DatabaseError`, log one warning through the module `logger`, and cache `False`. Expose `cache_clear()` through the decorated function so tests can isolate cached state.
+
+- [ ] **Step 4: Implement the ID-only query and filtered detail reload**
+
+Implement the method with this exact flow:
+
+```python
+if not self.has_unstarted_task_list_covering_index():
+    return list(queryset[offset : offset + limit])
+
+id_queryset = queryset.values_list("id", flat=True)[offset : offset + limit]
+sql, params = id_queryset.query.sql_with_params()
+sql = self._inject_unstarted_covering_index_hint(sql)
+
+with connection.cursor() as cursor:
+    cursor.execute(sql, params)
+    task_ids = [row[0] for row in cursor.fetchall()]
+
+if not task_ids:
+    return []
+
+instances = queryset.filter(id__in=task_ids).select_related("pipeline_instance", "project")
+instance_by_id = {instance.id: instance for instance in instances}
+return [instance_by_id[task_id] for task_id in task_ids if task_id in instance_by_id]
+```
+
+Reapplying the original queryset in phase two prevents a task that starts, expires, or is deleted between statements from being returned with stale filter semantics. Missing IDs are omitted without backfilling, matching a concurrent-change race rather than issuing another large scan.
+
+- [ ] **Step 5: Run manager tests**
+
+Run:
+
+```bash
+pytest -q gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
+```
+
+Expected: all existing and new manager tests pass.
+
+### Task 2: Gate the optimization in the task-list endpoint
+
+**Files:**
+- Modify: `gcloud/core/apis/drf/viewsets/taskflow.py:321-352`
+- Test: `gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py`
+
+**Interfaces:**
+- Consumes: `request.query_params` from `TaskFlowInstanceViewSet.list`.
+- Produces: `TaskFlowInstanceViewSet._should_use_two_phase_unstarted_task_list(request) -> bool`.
+- Calls: `TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(queryset, limit, offset)` only when the guard returns `True`.
+
+- [ ] **Step 1: Write a failing positive-path endpoint test**
+
+Add a request with:
+
+```python
+query_params = {
+    "project__id": self.test_project.id,
+    "pipeline_instance__is_started": False,
+    "is_child_taskflow": False,
+    "without_count": True,
+    "limit": 15,
+    "offset": 0,
+}
+```
+
+Patch `fetch_unstarted_task_list_page_two_phase` to return `[]`; assert it is called once with the filtered queryset, `limit=15`, and `offset=0`, while `fetch_task_list_page_ignore_primary_index` is not called.
+
+- [ ] **Step 2: Write guard regression tests for unaffected paths**
+
+Use `SimpleNamespace(query_params=params)` to assert the guard returns `False` for these exact dictionaries:
+
+```python
+{"project__id": "1", "pipeline_instance__is_started": "true", "is_child_taskflow": "false"}
+{"project__id": "1", "is_child_taskflow": "false"}
+{"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "order_by": "-pipeline_instance__create_time"}
+{"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "pipeline_instance__name__icontains": "demo"}
+{"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "creator_or_executor": "user"}
+{"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "false", "task_instance_status": "failed"}
+{"project__id": "1", "pipeline_instance__is_started": "false", "is_child_taskflow": "true"}
+```
+
+Also assert both string forms `"false"` and `"0"`, plus the boolean `False`, are accepted for the two Boolean query parameters.
+
+- [ ] **Step 3: Run the focused view tests and verify they fail**
+
+Run:
+
+```bash
+pytest -q gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py -k "two_phase or task_name_search_without_count"
+```
+
+Expected: new tests fail because the guard and manager call are not wired; the existing name-search optimization test passes.
+
+- [ ] **Step 4: Implement the narrow request guard and list branch**
+
+Add a Boolean parser:
+
+```python
+@staticmethod
+def _is_false_query_param(value):
+    return value is False or str(value).lower() in {"false", "0"}
+```
+
+Add `_should_use_two_phase_unstarted_task_list` requiring project ID, false `pipeline_instance__is_started`, false `is_child_taskflow`, and the absence of `order_by`, `pipeline_instance__name__icontains`, `creator_or_executor`, and `task_instance_status`.
+
+Inside the existing `without_count` branch, order the decisions as:
+
+```python
+if self._should_use_two_phase_unstarted_task_list(request):
+    page = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+        queryset=queryset,
+        limit=self.paginator.limit,
+        offset=self.paginator.offset,
+    )
+elif self._should_ignore_primary_index_for_task_list(request):
+    page = TaskFlowInstance.objects.fetch_task_list_page_ignore_primary_index(
+        queryset=queryset,
+        limit=self.paginator.limit,
+        offset=self.paginator.offset,
+    )
+else:
+    page = list(queryset[self.paginator.offset : self.paginator.offset + self.paginator.limit])
+```
+
+- [ ] **Step 5: Run the focused view tests**
+
+Run:
+
+```bash
+pytest -q gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py -k "two_phase or task_name_search_without_count"
+```
+
+Expected: all selected tests pass.
+
+### Task 3: Verify response semantics and regressions
+
+**Files:**
+- Test: `gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py`
+- Test: `gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py`
+
+**Interfaces:**
+- Consumes: the manager and view interfaces completed in Tasks 1 and 2.
+- Produces: regression evidence that response semantics and unaffected query paths remain stable.
+
+- [ ] **Step 1: Add an integration-style order and serialization test**
+
+Create three unstarted pipeline/task pairs in the test database. Patch only the capability check to return `True` and patch phase-one cursor rows to descending task IDs. Call `/api/v3/taskflow/` with the target parameters and assert:
+
+```python
+assert [item["id"] for item in response.data["data"]["results"]] == expected_ids_desc
+assert all(item["is_started"] is False for item in response.data["data"]["results"])
+assert all(item["project"]["id"] == self.test_project.id for item in response.data["data"]["results"])
+```
+
+Assert the response continues to use `count == -1` for `without_count`.
+
+- [ ] **Step 2: Add empty and fewer-than-limit cases**
+
+Return `[]` and then 13 phase-one IDs; assert the endpoint does not issue a supplemental scan and returns exactly zero or 13 records in the requested order.
+
+- [ ] **Step 3: Run the complete affected test files**
+
+Run:
+
+```bash
+pytest -q \
+  gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py \
+  gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+```
+
+Expected: both files pass with no regressions.
+
+- [ ] **Step 4: Run formatting and static checks on changed Python files**
+
+Run:
+
+```bash
+pre-commit run --files \
+  gcloud/taskflow3/models.py \
+  gcloud/core/apis/drf/viewsets/taskflow.py \
+  gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py \
+  gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+```
+
+Expected: all configured hooks pass. If `pre-commit` is unavailable, run the repository's configured Python formatter and report the missing hook runner explicitly.
+
+- [ ] **Step 5: Review the final diff and commit with the TAPD Bug**
+
+Run:
+
+```bash
+git diff --check
+git status --short
+```
+
+Expected: only the design, plan, two implementation files, and two test files belong to this task. Commit with `perf: 优化未执行任务列表查询 --bug=1010131351162150454`.

--- a/docs/plans/2026-08-11-unstarted-task-list-two-phase-query.md
+++ b/docs/plans/2026-08-11-unstarted-task-list-two-phase-query.md
@@ -2,9 +2,15 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Multi-agent execution is not used for this task.
 
-**Goal:** Reduce the explicitly filtered unstarted task-list request from roughly 70 seconds to the verified 3-4 second ID-scan range without changing API results, ordering, pagination, or other status-filter paths.
+> **Revised after production validation:** two decisions in the steps below are superseded. Phase one now injects
+> `IGNORE INDEX (\`PRIMARY\`)` instead of `FORCE INDEX (\`idx_proj_del_child_id_pipe\`)`, and the request guard is a
+> parameter whitelist instead of a list of excluded parameters. The covering-index capability check was dropped
+> along with the forced hint. See `docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md` for the
+> measurements behind both changes.
 
-**Architecture:** Add a narrowly gated list-view branch that asks `TaskFlowInstanceManager` for a page using two phases. Phase one compiles the fully filtered queryset as an ID-only query and injects the existing production composite-index hint; phase two reapplies the same queryset filters to those IDs, loads `pipeline_instance` and `project` in one query, and restores the phase-one order. Non-MySQL databases and schemas without the production index keep the original ORM path.
+**Goal:** Reduce the explicitly filtered unstarted task-list request from roughly 70 seconds to the verified 3-4 second ID-scan range without changing API results, ordering, pagination, or other status-filter paths, and without regressing projects whose unstarted tasks are dense enough for the optimizer to already return in milliseconds.
+
+**Architecture:** Add a narrowly gated list-view branch that asks `TaskFlowInstanceManager` for a page using two phases. Phase one compiles the fully filtered queryset as an ID-only query and excludes the `PRIMARY` index so the optimizer can pick a plan that fits the project's data distribution; phase two reapplies the same queryset filters to those IDs, loads `pipeline_instance` and `project` in one query, and restores the phase-one order. Non-MySQL databases keep the original ORM path.
 
 **Tech Stack:** Python 3.6, Django ORM, Django REST Framework, MySQL 5.7-compatible SQL, `django.test`, `mock`.
 

--- a/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
+++ b/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
@@ -33,6 +33,7 @@
 
 - 不修改 `pipeline_instance__is_started=true` 查询。
 - 不修改未传 `pipeline_instance__is_started` 的任务列表。
+- 不修改按 `TaskFlowInstance.id` 精确查询的任务列表。
 - 不修改 `task_instance_status`、“我的动态”、任务数量和任务详情接口。
 - 不改变默认排序为 `pipeline.create_time`。
 - 本期不引入 Redis 缓存或任务列表读模型。
@@ -50,6 +51,7 @@
 7. 不包含 `creator_or_executor`。
 8. 不包含 `task_instance_status`。
 9. 不包含 `pipeline_instance__name__icontains`，避免与现有名称搜索优化路径重叠。
+10. 不包含 `id`，保留主键精确查询的 `PRIMARY + const` 执行计划。
 
 不满足任一条件时，继续使用现有 ORM 分页逻辑。
 
@@ -119,7 +121,7 @@ project_id, is_deleted, is_child_taskflow, id, pipeline_instance_id
 ### 单元测试
 
 1. 仅在显式“未执行”参数组合下触发两阶段路径。
-2. `is_started=true`、未传状态、显式排序、名称搜索、“我的动态”和 `task_instance_status` 均不触发。
+2. `is_started=true`、未传状态、显式排序、名称搜索、“我的动态”、`task_instance_status` 和任务 ID 精确查询均不触发。
 3. 第一阶段 SQL 包含 `FORCE INDEX (idx_proj_del_child_id_pipe)` 且参数仍由数据库驱动参数化。
 4. 第二阶段包含 `select_related("pipeline_instance", "project")`。
 5. 第二阶段结果严格恢复第一阶段 ID 顺序。
@@ -142,6 +144,11 @@ project_id, is_deleted, is_child_taskflow, id, pipeline_instance_id
 - 第一阶段 SQL 耗时和扫描行数；
 - DB CPU、IO 和 Buffer Pool 命中率；
 - `is_started=true` 和无状态筛选的延迟不发生回归。
+
+生产 WebConsole 对 3 个真实任务 ID 和 1 个不存在 ID 的复测显示，原路径耗时约
+`5-22ms`，强制使用 `idx_proj_del_child_id_pipe` 的两阶段路径耗时约 `222-238ms`，
+且强制索引计划会从 `PRIMARY + const` 单行查询退化为扫描项目复合索引。因此任务 ID
+精确查询必须留在原 ORM 分页路径。
 
 ## 发布与回退
 

--- a/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
+++ b/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
@@ -18,16 +18,20 @@
 已验证的真实耗时：
 
 - 原接口：约 70 秒以上。
-- 仅查询任务 ID，强制使用现有
-  `idx_proj_del_child_id_pipe`：首次 4.13 秒，预热后 2.99 秒。
+- 仅查询任务 ID：约 3.8 至 4.9 秒。
+
+需要注意的是，慢查询的成因是优化器在“未执行任务极稀疏”的项目上误选了 `PRIMARY` 倒序扫描，
+而不是缺少可用索引。未执行任务较多的项目上，优化器本来就能选到按 `id` 有序的
+`project_id` 索引并提前结束扫描，耗时约 20 毫秒。因此优化手段必须只排除错误计划，
+不能把计划锁死到某个具体索引。
 
 ## 目标
 
 1. 保持接口路径、请求参数、响应结构和权限语义不变。
 2. 保持 `TaskFlowInstance.id DESC` 排序和 `limit/offset` 分页语义不变。
 3. 仅优化明确的“未执行任务”慢查询，不改变其他状态查询的执行路径。
-4. 不新增数据库索引。
-5. 在索引不存在或数据库不是 MySQL 时安全退回原查询。
+4. 不新增数据库索引，也不依赖某个未在迁移中声明的运维侧索引。
+5. 在数据库不是 MySQL 时安全退回原查询。
 
 ## 非目标
 
@@ -40,24 +44,31 @@
 
 ## 触发条件
 
-仅当请求同时满足以下条件时启用两阶段查询：
+采用请求参数白名单，仅当请求参数是以下集合的子集时才可能启用两阶段查询：
+
+```text
+without_count, project__id, pipeline_instance__is_started, is_child_taskflow, limit, offset
+```
+
+并且同时满足：
 
 1. 当前 action 为普通任务列表 `list`。
 2. 请求包含 `without_count`。
 3. 请求包含有效的 `project__id`。
 4. `pipeline_instance__is_started` 明确为 false。
 5. `is_child_taskflow` 明确为 false。
-6. 未传入显式 `order_by`。
-7. 不包含 `creator_or_executor`。
-8. 不包含 `task_instance_status`。
-9. 不包含 `pipeline_instance__name__icontains`，避免与现有名称搜索优化路径重叠。
-10. 不包含 `id`，保留主键精确查询的 `PRIMARY + const` 执行计划。
 
 不满足任一条件时，继续使用现有 ORM 分页逻辑。
 
+之所以用白名单而不是逐个排除已知的坏组合：生产验证显示，只要带上任意附加筛选条件，
+MySQL 往往存在比两阶段查询更优的计划。例如按创建时间区间筛选时，优化器会从
+`pipeline_pipelineinstance.create_time` 索引驱动，只需 0.3 至 0.8 秒；而改写成只取 ID 后
+优化器转向按项目扫描，退化到 3.5 秒。这类组合无法穷举，白名单可以保证以后新增
+FilterSet 字段时不会静默落入优化路径。
+
 ## 查询设计
 
-### 第一阶段：覆盖索引只取 ID
+### 第一阶段：只取 ID 并排除 PRIMARY
 
 在完成现有 FilterSet、过期过滤和 180 天过滤后，基于最终 queryset 生成仅查询
 `TaskFlowInstance.id` 的分页 SQL：
@@ -65,13 +76,21 @@
 ```sql
 SELECT t.id
 FROM taskflow3_taskflowinstance AS t
-    FORCE INDEX (idx_proj_del_child_id_pipe)
+    IGNORE INDEX (`PRIMARY`)
 INNER JOIN pipeline_pipelineinstance AS p
     ON p.id = t.pipeline_instance_id
 WHERE ...
 ORDER BY t.id DESC
 LIMIT %s OFFSET %s
 ```
+
+只取 ID 让分页查询能落在索引上，省掉逐行回表；`IGNORE INDEX (PRIMARY)` 只排除掉造成慢查询的
+全表倒序扫描，把索引选择权留给优化器。索引提示复用现有的
+`TaskFlowInstanceManager._inject_ignore_primary_index_hint`，与任务名称搜索优化保持同一套实现。
+
+这里不使用 `FORCE INDEX`。生产验证显示强制 `idx_proj_del_child_id_pipe` 会让未执行任务较多的项目
+从 20 毫秒退化到 1.1 秒，因为该索引在 ORM 生成的条件下无法提供按 `id` 有序的访问路径，必须
+filesort 扫完整个项目。
 
 SQL 条件继续由 Django queryset 生成和参数化，索引提示通过对已编译 SQL 的固定表名注入完成。
 数据库游标只返回整数 ID，避免把 RawQuerySet 的延迟字段带入第二阶段。
@@ -93,20 +112,11 @@ queryset.filter(id__in=task_ids).select_related(
 
 ## 数据库兼容与回退
 
-现有生产库包含 `idx_proj_del_child_id_pipe`，字段顺序为：
+索引提示是 MySQL 语法，因此只有 `connection.vendor == "mysql"` 时才启用两阶段查询，其余数据库直接使用原 ORM 分页。
 
-```text
-project_id, is_deleted, is_child_taskflow, id, pipeline_instance_id
-```
+`IGNORE INDEX (PRIMARY)` 不依赖任何特定索引存在，因此不需要运行期探测表结构，也不存在探测结果被错误缓存的问题。
 
-但该索引未在当前源码迁移中声明。因此启用前必须同时满足：
-
-- `connection.vendor == "mysql"`；
-- 数据库表中存在 `idx_proj_del_child_id_pipe`。
-
-索引能力检查按进程缓存，避免每次请求执行 `SHOW INDEX`。若数据库不是 MySQL、索引不存在或能力检查失败，则不注入索引提示，直接使用原查询路径。
-
-两阶段查询只读取数据。第一阶段执行异常不进行静默重试，避免同一请求先执行慢 SQL 再重复执行；异常按现有数据库异常处理链上报。索引缺失通过执行前能力检查规避。
+两阶段查询只读取数据。第一阶段执行异常不进行静默重试，避免同一请求先执行慢 SQL 再重复执行；异常按现有数据库异常处理链上报。
 
 ## 分页与响应
 
@@ -121,12 +131,13 @@ project_id, is_deleted, is_child_taskflow, id, pipeline_instance_id
 ### 单元测试
 
 1. 仅在显式“未执行”参数组合下触发两阶段路径。
-2. `is_started=true`、未传状态、显式排序、名称搜索、“我的动态”、`task_instance_status` 和任务 ID 精确查询均不触发。
-3. 第一阶段 SQL 包含 `FORCE INDEX (idx_proj_del_child_id_pipe)` 且参数仍由数据库驱动参数化。
+2. `is_started=true`、未传状态、显式排序、名称搜索、“我的动态”、`task_instance_status`、任务 ID 精确查询，
+   以及模板、创建方式、创建人、创建时间区间等白名单外的任意附加筛选条件均不触发。
+3. 第一阶段 SQL 包含 `IGNORE INDEX (\`PRIMARY\`)` 且参数仍由数据库驱动参数化。
 4. 第二阶段包含 `select_related("pipeline_instance", "project")`。
 5. 第二阶段结果严格恢复第一阶段 ID 顺序。
 6. 结果少于 15 条和空结果正确返回。
-7. 非 MySQL或索引不存在时回退原逻辑。
+7. 非 MySQL 时回退原逻辑且不访问游标。
 8. `offset > 0` 时分页语义保持不变。
 
 ### 回归测试
@@ -150,6 +161,31 @@ project_id, is_deleted, is_child_taskflow, id, pipeline_instance_id
 且强制索引计划会从 `PRIMARY + const` 单行查询退化为扫描项目复合索引。因此任务 ID
 精确查询必须留在原 ORM 分页路径。
 
+生产 WebConsole 在两个数据分布相反的项目上对比了三种方案，结果决定了最终选型
+（`MAX_EXECUTION_TIME` 上限 8 秒）：
+
+| 项目 | 场景 | 原路径 | 两阶段 + FORCE 覆盖索引 | 两阶段 + IGNORE PRIMARY |
+| --- | --- | --- | --- | --- |
+| 5001537，224 万任务、13 条未执行 | 纯未执行 | 超时 | 4348ms | 3802ms |
+| 5001537 | 附加最近 1 天创建时间 | 339ms | 3552ms | 3553ms |
+| 5001537 | 附加 7 至 8 天创建时间区间 | 393ms | 3689ms | 3490ms |
+| 5000122，578 万任务、未执行较多 | 纯未执行 | 23.2ms | 1151ms | 21.6ms |
+| 5000122 | 附加最近 1 天创建时间 | 397.7ms | 1163ms | 350.4ms |
+| 5000122 | 附加 7 至 8 天创建时间区间 | 376.1ms | 超时 | 366.4ms |
+
+由此得到两条结论：`FORCE INDEX` 会在未执行任务较多的项目上造成数量级回退，必须改用
+`IGNORE INDEX (PRIMARY)`；带创建时间区间的组合即使改用 `IGNORE PRIMARY` 仍会回退约 9 至 10 倍，
+必须由参数白名单挡在优化路径之外。
+
+同时记录一个未在本期解决的问题：Django 把 `is_deleted=False` 一类布尔过滤编译成 `NOT col`
+而非 `col = 0`，`NOT col` 无法作为 ref 的 key part，导致
+`idx_proj_del_child_id_pipe` 在 ORM 查询下只用到首列 `project_id`，后续列形同虚设并被迫 filesort。
+手写等值条件的同一查询可以用满前三列且无需 filesort。彻底解决稀疏项目的秒级耗时需要消除跨表
+状态判断（例如把 `is_started` 冗余到任务表并配套索引），应另立需求跟进。
+
 ## 发布与回退
 
 两阶段路径使用独立判断函数封装，便于快速禁用。若灰度期间出现查询计划或兼容性回归，将判断函数关闭并恢复原 ORM 分页，不涉及数据回滚或数据库 DDL。
+
+灰度期需要重点观察未执行任务较多的项目：这类项目原本就是毫秒级返回，一旦出现秒级延迟即说明
+优化器又选回了需要 filesort 的计划，应立即关闭该路径。

--- a/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
+++ b/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
@@ -1,0 +1,148 @@
+# 未执行任务列表两阶段查询优化设计
+
+## 背景
+
+`GET /api/v3/taskflow/` 在同时使用以下参数时出现稳定慢查询：
+
+- `without_count=true`
+- `project__id` 已设置为目标项目 ID
+- `pipeline_instance__is_started=false`
+- `is_child_taskflow=false`
+- 默认按 `TaskFlowInstance.id DESC` 排序
+
+生产执行计划显示，原查询为了避免排序而从
+`taskflow3_taskflowinstance.PRIMARY` 倒序扫描，然后逐条通过
+`pipeline_instance_id` 查询 `pipeline_pipelineinstance`。目标项目在最近一千万条候选任务中实际只有
+13 条满足“180 天内、未启动、未过期”，不足 `LIMIT 15`，因此数据库无法提前结束扫描。
+
+已验证的真实耗时：
+
+- 原接口：约 70 秒以上。
+- 仅查询任务 ID，强制使用现有
+  `idx_proj_del_child_id_pipe`：首次 4.13 秒，预热后 2.99 秒。
+
+## 目标
+
+1. 保持接口路径、请求参数、响应结构和权限语义不变。
+2. 保持 `TaskFlowInstance.id DESC` 排序和 `limit/offset` 分页语义不变。
+3. 仅优化明确的“未执行任务”慢查询，不改变其他状态查询的执行路径。
+4. 不新增数据库索引。
+5. 在索引不存在或数据库不是 MySQL 时安全退回原查询。
+
+## 非目标
+
+- 不修改 `pipeline_instance__is_started=true` 查询。
+- 不修改未传 `pipeline_instance__is_started` 的任务列表。
+- 不修改 `task_instance_status`、“我的动态”、任务数量和任务详情接口。
+- 不改变默认排序为 `pipeline.create_time`。
+- 本期不引入 Redis 缓存或任务列表读模型。
+
+## 触发条件
+
+仅当请求同时满足以下条件时启用两阶段查询：
+
+1. 当前 action 为普通任务列表 `list`。
+2. 请求包含 `without_count`。
+3. 请求包含有效的 `project__id`。
+4. `pipeline_instance__is_started` 明确为 false。
+5. `is_child_taskflow` 明确为 false。
+6. 未传入显式 `order_by`。
+7. 不包含 `creator_or_executor`。
+8. 不包含 `task_instance_status`。
+9. 不包含 `pipeline_instance__name__icontains`，避免与现有名称搜索优化路径重叠。
+
+不满足任一条件时，继续使用现有 ORM 分页逻辑。
+
+## 查询设计
+
+### 第一阶段：覆盖索引只取 ID
+
+在完成现有 FilterSet、过期过滤和 180 天过滤后，基于最终 queryset 生成仅查询
+`TaskFlowInstance.id` 的分页 SQL：
+
+```sql
+SELECT t.id
+FROM taskflow3_taskflowinstance AS t
+    FORCE INDEX (idx_proj_del_child_id_pipe)
+INNER JOIN pipeline_pipelineinstance AS p
+    ON p.id = t.pipeline_instance_id
+WHERE ...
+ORDER BY t.id DESC
+LIMIT %s OFFSET %s
+```
+
+SQL 条件继续由 Django queryset 生成和参数化，索引提示通过对已编译 SQL 的固定表名注入完成。
+数据库游标只返回整数 ID，避免把 RawQuerySet 的延迟字段带入第二阶段。
+
+### 第二阶段：批量加载详情
+
+根据第一阶段返回的最多 `limit` 个 ID 执行一次 ORM 查询：
+
+```python
+queryset.filter(id__in=task_ids).select_related(
+    "pipeline_instance", "project"
+)
+```
+
+`TaskFlowInstanceListSerializer` 会读取 `pipeline_instance` 的名称、创建时间、开始/结束时间和状态，
+并嵌套序列化 `project`，因此必须使用 `select_related` 避免 N+1 查询。
+
+数据库不保证 `IN` 查询返回顺序。第二阶段完成后，按照第一阶段 ID 列表建立位置映射并在内存中恢复顺序。
+
+## 数据库兼容与回退
+
+现有生产库包含 `idx_proj_del_child_id_pipe`，字段顺序为：
+
+```text
+project_id, is_deleted, is_child_taskflow, id, pipeline_instance_id
+```
+
+但该索引未在当前源码迁移中声明。因此启用前必须同时满足：
+
+- `connection.vendor == "mysql"`；
+- 数据库表中存在 `idx_proj_del_child_id_pipe`。
+
+索引能力检查按进程缓存，避免每次请求执行 `SHOW INDEX`。若数据库不是 MySQL、索引不存在或能力检查失败，则不注入索引提示，直接使用原查询路径。
+
+两阶段查询只读取数据。第一阶段执行异常不进行静默重试，避免同一请求先执行慢 SQL 再重复执行；异常按现有数据库异常处理链上报。索引缺失通过执行前能力检查规避。
+
+## 分页与响应
+
+- 沿用现有 paginator 的 `limit`、`offset`、`count=-1` 和 `request`。
+- 第一阶段 ID 查询直接应用相同的 `LIMIT/OFFSET`。
+- 返回不足 `limit` 条时不补查，因为这表示过滤结果已耗尽。
+- 序列化、任务权限注入、模板权限和模板信息注入继续使用现有逻辑。
+- API 响应字段和 HTTP 状态码不变。
+
+## 测试设计
+
+### 单元测试
+
+1. 仅在显式“未执行”参数组合下触发两阶段路径。
+2. `is_started=true`、未传状态、显式排序、名称搜索、“我的动态”和 `task_instance_status` 均不触发。
+3. 第一阶段 SQL 包含 `FORCE INDEX (idx_proj_del_child_id_pipe)` 且参数仍由数据库驱动参数化。
+4. 第二阶段包含 `select_related("pipeline_instance", "project")`。
+5. 第二阶段结果严格恢复第一阶段 ID 顺序。
+6. 结果少于 15 条和空结果正确返回。
+7. 非 MySQL或索引不存在时回退原逻辑。
+8. `offset > 0` 时分页语义保持不变。
+
+### 回归测试
+
+- 任务列表已有测试集全部通过。
+- 对序列化查询数增加断言，避免引入 pipeline/project N+1。
+- 验证权限注入和模板信息注入收到的实例顺序与响应顺序一致。
+
+### 生产验证
+
+灰度观察以下指标：
+
+- 目标 URL 的 P50、P95、P99；
+- API worker timeout 数量；
+- 第一阶段 SQL 耗时和扫描行数；
+- DB CPU、IO 和 Buffer Pool 命中率；
+- `is_started=true` 和无状态筛选的延迟不发生回归。
+
+## 发布与回退
+
+两阶段路径使用独立判断函数封装，便于快速禁用。若灰度期间出现查询计划或兼容性回归，将判断函数关闭并恢复原 ORM 分页，不涉及数据回滚或数据库 DDL。

--- a/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
+++ b/docs/specs/2026-08-11-unstarted-task-list-two-phase-query-design.md
@@ -177,11 +177,31 @@ queryset.filter(id__in=task_ids).select_related(
 `IGNORE INDEX (PRIMARY)`；带创建时间区间的组合即使改用 `IGNORE PRIMARY` 仍会回退约 9 至 10 倍，
 必须由参数白名单挡在优化路径之外。
 
-同时记录一个未在本期解决的问题：Django 把 `is_deleted=False` 一类布尔过滤编译成 `NOT col`
-而非 `col = 0`，`NOT col` 无法作为 ref 的 key part，导致
-`idx_proj_del_child_id_pipe` 在 ORM 查询下只用到首列 `project_id`，后续列形同虚设并被迫 filesort。
-手写等值条件的同一查询可以用满前三列且无需 filesort。彻底解决稀疏项目的秒级耗时需要消除跨表
-状态判断（例如把 `is_started` 冗余到任务表并配套索引），应另立需求跟进。
+合入前对最终实现做了一轮完整验证，四个性能用例加十四种参数组合的路径判定全部通过：
+
+| 场景 | 原路径 | 两阶段 + IGNORE PRIMARY | 返回结果 |
+| --- | --- | --- | --- |
+| 5001537 首页 | 8004ms 被语句超时中断 | 3809ms | 13 条，条件校验通过 |
+| 5001537 第二页 | 8003ms 被语句超时中断 | 3707ms | 空页 |
+| 5000122 首页 | 57.3ms | 43.2ms | 15 条，ID 与原路径逐个相同 |
+| 5000122 第二页 | 30.8ms | 37.4ms | 15 条，ID 与原路径逐个相同 |
+
+关键证据是 5000122 上两条路径选中了同一个索引
+`taskflow3_taskflowin_project_id_3c18b071_fk_core_proj` 且都没有 filesort，说明
+`IGNORE INDEX (PRIMARY)` 只排除了错误计划，没有干扰优化器的正常选择。另外 5001537 的原路径计划
+估算走 `PRIMARY` 只需扫 12181 行，实际要扫完两百多万行，估算偏差近两个数量级，这也说明该问题
+无法靠更新统计信息解决。
+
+同时记录一个未在本期解决的问题：Django 把布尔过滤编译成 `NOT col` 而非 `col = 0`，`NOT col`
+无法作为 ref 的 key part。视图基础 queryset 里的 `is_deleted=Value(0)` 会编译成 `= 0`，因此
+`idx_proj_del_child_id_pipe` 实际用到 `project_id` 和 `is_deleted` 两列；而 `is_child_taskflow`
+由 FilterSet 生成，仍是不可 sarg 的形式，索引到第三列即中断，`id` 接不上排序，只能 filesort。
+即使补上冗余等值条件让索引用满前三列并去掉 filesort，稀疏项目也快不了多少：其耗时主要来自约
+227 万次回流水线实例表的 eq_ref 查找，而不是排序。彻底解决需要消除跨表状态判断（例如把
+`is_started` 冗余到任务表并配套索引），应另立需求跟进。
+
+另有一个固有代价：翻页越过数据末尾时仍需扫完整个项目区间才能确认没有更多结果，稀疏项目上返回
+空页同样耗时约 3.7 秒，本期不做处理。
 
 ## 发布与回退
 

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -275,6 +275,15 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
     iam_resource_helper = ViewSetResourceHelper(resource_func=res_factory.resources_for_task_obj, actions=TASK_ACTIONS)
     filter_class = TaskFlowFilterSet
     permission_classes = [permissions.IsAuthenticated, TaskFlowInstancePermission]
+    # 允许进入未执行任务两阶段查询的全部请求参数，出现任何其他参数都回退到原查询
+    TWO_PHASE_UNSTARTED_TASK_LIST_PARAMS = {
+        "without_count",
+        "project__id",
+        "pipeline_instance__is_started",
+        "is_child_taskflow",
+        "limit",
+        "offset",
+    }
 
     def _get_queryset(self, request):
         queryset = self.filter_queryset(self.get_queryset())
@@ -586,18 +595,19 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
     def _should_use_two_phase_unstarted_task_list(cls, request):
         """
         仅优化按项目查询未执行根任务且保持默认 ID 倒序的任务列表。
+
+        采用参数白名单而非排除法：带上任意附加筛选条件后，MySQL 往往存在比两阶段查询更优的执行计划
+        （例如按创建时间区间筛选时可从流水线实例侧驱动），此时继续走原查询。
         """
         query_params = request.query_params
+        if set(query_params) - cls.TWO_PHASE_UNSTARTED_TASK_LIST_PARAMS:
+            return False
+
         return bool(
             "without_count" in query_params
             and query_params.get("project__id")
             and cls._is_false_query_param(query_params.get("pipeline_instance__is_started"))
             and cls._is_false_query_param(query_params.get("is_child_taskflow"))
-            and not query_params.get("order_by")
-            and not query_params.get("pipeline_instance__name__icontains")
-            and not query_params.get("creator_or_executor")
-            and not query_params.get("task_instance_status")
-            and not query_params.get("id")
         )
 
     @swagger_auto_schema(

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -597,6 +597,7 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
             and not query_params.get("pipeline_instance__name__icontains")
             and not query_params.get("creator_or_executor")
             and not query_params.get("task_instance_status")
+            and not query_params.get("id")
         )
 
     @swagger_auto_schema(

--- a/gcloud/core/apis/drf/viewsets/taskflow.py
+++ b/gcloud/core/apis/drf/viewsets/taskflow.py
@@ -345,7 +345,11 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
             self.paginator.offset = self.paginator.get_offset(request)
             self.paginator.count = -1
             self.paginator.request = request
-            if self._should_ignore_primary_index_for_task_list(request):
+            if self._should_use_two_phase_unstarted_task_list(request):
+                page = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+                    queryset=queryset, limit=self.paginator.limit, offset=self.paginator.offset
+                )
+            elif self._should_ignore_primary_index_for_task_list(request):
                 page = TaskFlowInstance.objects.fetch_task_list_page_ignore_primary_index(
                     queryset=queryset, limit=self.paginator.limit, offset=self.paginator.offset
                 )
@@ -572,6 +576,27 @@ class TaskFlowInstanceViewSet(GcloudReadOnlyViewSet, generics.CreateAPIView, gen
             query_params.get("project__id")
             and query_params.get("pipeline_instance__name__icontains")
             and not query_params.get("order_by")
+        )
+
+    @staticmethod
+    def _is_false_query_param(value):
+        return value is False or str(value).lower() in {"false", "0"}
+
+    @classmethod
+    def _should_use_two_phase_unstarted_task_list(cls, request):
+        """
+        仅优化按项目查询未执行根任务且保持默认 ID 倒序的任务列表。
+        """
+        query_params = request.query_params
+        return bool(
+            "without_count" in query_params
+            and query_params.get("project__id")
+            and cls._is_false_query_param(query_params.get("pipeline_instance__is_started"))
+            and cls._is_false_query_param(query_params.get("is_child_taskflow"))
+            and not query_params.get("order_by")
+            and not query_params.get("pipeline_instance__name__icontains")
+            and not query_params.get("creator_or_executor")
+            and not query_params.get("task_instance_status")
         )
 
     @swagger_auto_schema(

--- a/gcloud/taskflow3/models.py
+++ b/gcloud/taskflow3/models.py
@@ -15,10 +15,9 @@ import datetime
 import logging
 import traceback
 from copy import deepcopy
-from functools import lru_cache
 
 import ujson as json
-from django.db import DatabaseError, connection, models, transaction
+from django.db import connection, models, transaction
 from django.db.models import Count, Q
 from django.utils.translation import ugettext_lazy as _
 from pipeline.component_framework.models import ComponentModel
@@ -572,8 +571,6 @@ class TaskFlowStatisticsMixin(ClassificationCountMixin):
 class TaskFlowInstanceManager(models.Manager, TaskFlowStatisticsMixin):
     TASKFLOW_INSTANCE_TABLE_SQL = "`taskflow3_taskflowinstance`"
     IGNORE_PRIMARY_INDEX_HINT_SQL = "IGNORE INDEX (`PRIMARY`)"
-    TASK_LIST_UNSTARTED_COVERING_INDEX = "idx_proj_del_child_id_pipe"
-    FORCE_UNSTARTED_COVERING_INDEX_HINT_SQL = "FORCE INDEX (`idx_proj_del_child_id_pipe`)"
 
     @classmethod
     def _inject_ignore_primary_index_hint(cls, sql):
@@ -582,31 +579,6 @@ class TaskFlowInstanceManager(models.Manager, TaskFlowStatisticsMixin):
             return sql
 
         return sql.replace("FROM {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL), "FROM {}".format(table_with_hint), 1)
-
-    @classmethod
-    def _inject_unstarted_covering_index_hint(cls, sql):
-        table_with_hint = "{} {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL, cls.FORCE_UNSTARTED_COVERING_INDEX_HINT_SQL)
-        if table_with_hint in sql:
-            return sql
-
-        return sql.replace("FROM {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL), "FROM {}".format(table_with_hint), 1)
-
-    @staticmethod
-    @lru_cache(maxsize=1)
-    def has_unstarted_task_list_covering_index():
-        if connection.vendor != "mysql":
-            return False
-
-        try:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    "SHOW INDEX FROM `taskflow3_taskflowinstance` WHERE Key_name = %s",
-                    [TaskFlowInstanceManager.TASK_LIST_UNSTARTED_COVERING_INDEX],
-                )
-                return cursor.fetchone() is not None
-        except DatabaseError:
-            logger.warning("failed to check unstarted task list covering index", exc_info=True)
-            return False
 
     def fetch_task_list_page_ignore_primary_index(self, queryset, limit, offset):
         sliced_queryset = queryset[offset : offset + limit]
@@ -618,12 +590,15 @@ class TaskFlowInstanceManager(models.Manager, TaskFlowStatisticsMixin):
         return list(self.raw(sql, params))
 
     def fetch_unstarted_task_list_page_two_phase(self, queryset, limit, offset):
-        if not self.has_unstarted_task_list_covering_index():
+        if connection.vendor != "mysql":
             return list(queryset[offset : offset + limit])
 
+        # 第一阶段只取 ID，让分页查询尽量落在二级索引上，避免逐条回表加载详情。
+        # 这里只排除 PRIMARY 而不强制某个索引：生产验证显示强制覆盖索引会让未执行任务较多的项目
+        # 从毫秒级退化到秒级，而排除 PRIMARY 后优化器能按项目数据分布选到合适的索引。
         id_queryset = queryset.values_list("id", flat=True)[offset : offset + limit]
         sql, params = id_queryset.query.sql_with_params()
-        sql = self._inject_unstarted_covering_index_hint(sql)
+        sql = self._inject_ignore_primary_index_hint(sql)
 
         with connection.cursor() as cursor:
             cursor.execute(sql, params)

--- a/gcloud/taskflow3/models.py
+++ b/gcloud/taskflow3/models.py
@@ -15,9 +15,10 @@ import datetime
 import logging
 import traceback
 from copy import deepcopy
+from functools import lru_cache
 
 import ujson as json
-from django.db import connection, models, transaction
+from django.db import DatabaseError, connection, models, transaction
 from django.db.models import Count, Q
 from django.utils.translation import ugettext_lazy as _
 from pipeline.component_framework.models import ComponentModel
@@ -571,6 +572,8 @@ class TaskFlowStatisticsMixin(ClassificationCountMixin):
 class TaskFlowInstanceManager(models.Manager, TaskFlowStatisticsMixin):
     TASKFLOW_INSTANCE_TABLE_SQL = "`taskflow3_taskflowinstance`"
     IGNORE_PRIMARY_INDEX_HINT_SQL = "IGNORE INDEX (`PRIMARY`)"
+    TASK_LIST_UNSTARTED_COVERING_INDEX = "idx_proj_del_child_id_pipe"
+    FORCE_UNSTARTED_COVERING_INDEX_HINT_SQL = "FORCE INDEX (`idx_proj_del_child_id_pipe`)"
 
     @classmethod
     def _inject_ignore_primary_index_hint(cls, sql):
@@ -580,6 +583,31 @@ class TaskFlowInstanceManager(models.Manager, TaskFlowStatisticsMixin):
 
         return sql.replace("FROM {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL), "FROM {}".format(table_with_hint), 1)
 
+    @classmethod
+    def _inject_unstarted_covering_index_hint(cls, sql):
+        table_with_hint = "{} {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL, cls.FORCE_UNSTARTED_COVERING_INDEX_HINT_SQL)
+        if table_with_hint in sql:
+            return sql
+
+        return sql.replace("FROM {}".format(cls.TASKFLOW_INSTANCE_TABLE_SQL), "FROM {}".format(table_with_hint), 1)
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def has_unstarted_task_list_covering_index():
+        if connection.vendor != "mysql":
+            return False
+
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SHOW INDEX FROM `taskflow3_taskflowinstance` WHERE Key_name = %s",
+                    [TaskFlowInstanceManager.TASK_LIST_UNSTARTED_COVERING_INDEX],
+                )
+                return cursor.fetchone() is not None
+        except DatabaseError:
+            logger.warning("failed to check unstarted task list covering index", exc_info=True)
+            return False
+
     def fetch_task_list_page_ignore_primary_index(self, queryset, limit, offset):
         sliced_queryset = queryset[offset : offset + limit]
         if connection.vendor != "mysql":
@@ -588,6 +616,25 @@ class TaskFlowInstanceManager(models.Manager, TaskFlowStatisticsMixin):
         sql, params = sliced_queryset.query.sql_with_params()
         sql = self._inject_ignore_primary_index_hint(sql)
         return list(self.raw(sql, params))
+
+    def fetch_unstarted_task_list_page_two_phase(self, queryset, limit, offset):
+        if not self.has_unstarted_task_list_covering_index():
+            return list(queryset[offset : offset + limit])
+
+        id_queryset = queryset.values_list("id", flat=True)[offset : offset + limit]
+        sql, params = id_queryset.query.sql_with_params()
+        sql = self._inject_unstarted_covering_index_hint(sql)
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, params)
+            task_ids = [row[0] for row in cursor.fetchall()]
+
+        if not task_ids:
+            return []
+
+        instances = queryset.filter(id__in=task_ids).select_related("pipeline_instance", "project")
+        instance_by_id = {instance.id: instance for instance in instances}
+        return [instance_by_id[task_id] for task_id in task_ids if task_id in instance_by_id]
 
     @staticmethod
     def create_pipeline_instance(template, **kwargs):

--- a/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
@@ -243,6 +243,13 @@ class TestTaskInstanceView(
             {
                 "project__id": "1",
                 "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "id": "147883347",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
                 "is_child_taskflow": "true",
                 "without_count": True,
             },
@@ -309,6 +316,28 @@ class TestTaskInstanceView(
         query_params = {
             "project__id": self.test_project.id,
             "pipeline_instance__is_started": True,
+            "is_child_taskflow": False,
+            "without_count": True,
+            "limit": 15,
+            "offset": 0,
+        }
+
+        with patch.object(
+            TaskFlowInstance.objects, "fetch_unstarted_task_list_page_two_phase", return_value=[]
+        ) as mock_two_phase:
+            resp = self.client.get(path=self.task_url, data=query_params)
+
+        self.assertTrue(resp.data["result"])
+        self.assertEqual([item["id"] for item in resp.data["data"]["results"]], [self.taskflow_instance.id])
+        mock_two_phase.assert_not_called()
+
+    def test_task_id_search_without_count_does_not_use_two_phase_query(self):
+        self.pipeline_instance.is_started = False
+        self.pipeline_instance.save()
+        query_params = {
+            "id": self.taskflow_instance.id,
+            "project__id": self.test_project.id,
+            "pipeline_instance__is_started": False,
             "is_child_taskflow": False,
             "without_count": True,
             "limit": 15,

--- a/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
@@ -160,6 +160,170 @@ class TestTaskInstanceView(
         self.assertEqual(mock_fetch.call_args[1]["limit"], 15)
         self.assertEqual(mock_fetch.call_args[1]["offset"], 0)
 
+    def test_unstarted_task_list_without_count_uses_two_phase_query(self):
+        query_params = {
+            "project__id": self.test_project.id,
+            "pipeline_instance__is_started": False,
+            "is_child_taskflow": False,
+            "without_count": True,
+            "limit": 15,
+            "offset": 0,
+        }
+
+        with patch.object(
+            TaskFlowInstance.objects,
+            "fetch_unstarted_task_list_page_two_phase",
+            return_value=[],
+            create=True,
+        ) as mock_two_phase:
+            with patch.object(
+                TaskFlowInstance.objects, "fetch_task_list_page_ignore_primary_index", return_value=[]
+            ) as mock_ignore_primary:
+                resp = self.client.get(path=self.task_url, data=query_params)
+
+        self.assertTrue(resp.data["result"])
+        mock_two_phase.assert_called_once()
+        self.assertEqual(mock_two_phase.call_args[1]["limit"], 15)
+        self.assertEqual(mock_two_phase.call_args[1]["offset"], 0)
+        mock_ignore_primary.assert_not_called()
+
+    def test_two_phase_unstarted_task_list_guard_accepts_explicit_false_values(self):
+        view = TaskFlowInstanceViewSet()
+
+        for false_value in (False, "false", "0"):
+            request = SimpleNamespace(
+                query_params={
+                    "project__id": "1",
+                    "pipeline_instance__is_started": false_value,
+                    "is_child_taskflow": false_value,
+                    "without_count": True,
+                }
+            )
+            with self.subTest(false_value=false_value):
+                self.assertTrue(view._should_use_two_phase_unstarted_task_list(request))
+
+    def test_two_phase_unstarted_task_list_guard_rejects_unaffected_queries(self):
+        view = TaskFlowInstanceViewSet()
+        unaffected_query_params = [
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "true",
+                "is_child_taskflow": "false",
+                "without_count": True,
+            },
+            {"project__id": "1", "is_child_taskflow": "false", "without_count": True},
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "order_by": "-pipeline_instance__create_time",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "pipeline_instance__name__icontains": "demo",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "creator_or_executor": "user",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "task_instance_status": "failed",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "true",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+            },
+        ]
+
+        for query_params in unaffected_query_params:
+            with self.subTest(query_params=query_params):
+                request = SimpleNamespace(query_params=query_params)
+                self.assertFalse(view._should_use_two_phase_unstarted_task_list(request))
+
+    @factory.django.mute_signals(signals.pre_save, signals.post_save)
+    def test_two_phase_unstarted_task_list_preserves_response_order_and_fields(self):
+        unstarted_tasks = []
+        for index in range(3):
+            pipeline_instance = PipelineInstance.objects.create(
+                instance_id="unstarted_root_{}".format(index),
+                creator="creator",
+                snapshot=self.test_snapshot,
+                template=self.pipeline_template,
+                is_finished=False,
+                is_started=False,
+                is_revoked=False,
+            )
+            unstarted_tasks.append(
+                TaskFlowInstance.objects.create(
+                    project=self.test_project,
+                    pipeline_instance=pipeline_instance,
+                    template_id=self.pipeline_template.id,
+                    engine_ver=2,
+                )
+            )
+
+        expected_tasks = list(reversed(unstarted_tasks))
+        query_params = {
+            "project__id": self.test_project.id,
+            "pipeline_instance__is_started": False,
+            "is_child_taskflow": False,
+            "without_count": True,
+            "limit": 15,
+            "offset": 0,
+        }
+
+        with patch.object(
+            TaskFlowInstance.objects,
+            "fetch_unstarted_task_list_page_two_phase",
+            return_value=expected_tasks,
+        ) as mock_two_phase:
+            resp = self.client.get(path=self.task_url, data=query_params)
+
+        self.assertTrue(resp.data["result"])
+        self.assertEqual(resp.data["data"]["count"], -1)
+        results = resp.data["data"]["results"]
+        self.assertEqual([item["id"] for item in results], [task.id for task in expected_tasks])
+        self.assertTrue(all(item["is_started"] is False for item in results))
+        self.assertTrue(all(item["project"]["id"] == self.test_project.id for item in results))
+        mock_two_phase.assert_called_once()
+
+    def test_started_task_list_without_count_does_not_use_two_phase_query(self):
+        query_params = {
+            "project__id": self.test_project.id,
+            "pipeline_instance__is_started": True,
+            "is_child_taskflow": False,
+            "without_count": True,
+            "limit": 15,
+            "offset": 0,
+        }
+
+        with patch.object(
+            TaskFlowInstance.objects, "fetch_unstarted_task_list_page_two_phase", return_value=[]
+        ) as mock_two_phase:
+            resp = self.client.get(path=self.task_url, data=query_params)
+
+        self.assertTrue(resp.data["result"])
+        self.assertEqual([item["id"] for item in resp.data["data"]["results"]], [self.taskflow_instance.id])
+        mock_two_phase.assert_not_called()
+
     def test_task_list_filter_days_disabled(self):
         """测试当项目配置了 task_list_filter_days 为 False 时，跳过日期过滤"""
         # 创建一个超过过滤天数的旧任务

--- a/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
+++ b/gcloud/tests/core/apis/drf/views_set/test_task_instance_view.py
@@ -197,6 +197,8 @@ class TestTaskInstanceView(
                     "pipeline_instance__is_started": false_value,
                     "is_child_taskflow": false_value,
                     "without_count": True,
+                    "limit": 15,
+                    "offset": 0,
                 }
             )
             with self.subTest(false_value=false_value):
@@ -257,6 +259,42 @@ class TestTaskInstanceView(
                 "project__id": "1",
                 "pipeline_instance__is_started": "false",
                 "is_child_taskflow": "false",
+            },
+            # 附加筛选条件下 MySQL 往往有更优计划，白名单之外的参数一律不进入两阶段查询
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "pipeline_instance__create_time__gte": "2026-08-01 00:00:00",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "pipeline_instance__start_time__lte": "2026-08-01 00:00:00",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "template_id": "10058",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "create_method": "app",
+                "without_count": True,
+            },
+            {
+                "project__id": "1",
+                "pipeline_instance__is_started": "false",
+                "is_child_taskflow": "false",
+                "pipeline_instance__creator__contains": "someone",
+                "without_count": True,
             },
         ]
 

--- a/gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
+++ b/gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
@@ -11,8 +11,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+from django.db import DatabaseError
 from django.test import SimpleTestCase
-from mock import patch
+from mock import MagicMock, patch
 
 from gcloud.taskflow3.models import TaskFlowInstance
 
@@ -43,6 +44,35 @@ class MockQuerySet(object):
     def __getitem__(self, used_slice):
         self.used_slice = used_slice
         return self.sliced_queryset
+
+
+class MockDetailQuerySet(object):
+    def __init__(self, rows):
+        self.rows = rows
+        self.select_related_fields = None
+
+    def select_related(self, *fields):
+        self.select_related_fields = fields
+        return self
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class MockTwoPhaseQuerySet(MockQuerySet):
+    def __init__(self, sql, params, detail_rows=None, fallback_rows=None):
+        super(MockTwoPhaseQuerySet, self).__init__(sql, params, fallback_rows)
+        self.values_list_call = None
+        self.filter_call = None
+        self.detail_queryset = MockDetailQuerySet(detail_rows or [])
+
+    def values_list(self, *fields, **kwargs):
+        self.values_list_call = (fields, kwargs)
+        return self
+
+    def filter(self, **kwargs):
+        self.filter_call = kwargs
+        return self.detail_queryset
 
 
 class TaskFlowInstanceManagerTestCase(SimpleTestCase):
@@ -85,3 +115,110 @@ class TaskFlowInstanceManagerTestCase(SimpleTestCase):
         self.assertEqual(result, ["row"])
         self.assertEqual(queryset.used_slice, slice(0, 15, None))
         mock_raw.assert_not_called()
+
+    def test_fetch_unstarted_task_list_page_two_phase_restores_id_order(self):
+        sql = (
+            "SELECT `taskflow3_taskflowinstance`.`id` "
+            "FROM `taskflow3_taskflowinstance` "
+            "INNER JOIN `pipeline_pipelineinstance` "
+            "ON (`taskflow3_taskflowinstance`.`pipeline_instance_id` = `pipeline_pipelineinstance`.`id`) "
+            "ORDER BY `taskflow3_taskflowinstance`.`id` DESC LIMIT 15 OFFSET 5"
+        )
+        params = [False, 5001537]
+        instances = [MagicMock(id=2), MagicMock(id=9), MagicMock(id=4)]
+        queryset = MockTwoPhaseQuerySet(sql, params, detail_rows=instances)
+        cursor = MagicMock()
+        cursor.fetchall.return_value = [(9,), (4,), (2,)]
+        mock_connection = MagicMock()
+        mock_connection.cursor.return_value.__enter__.return_value = cursor
+
+        with patch.object(TaskFlowInstance.objects, "has_unstarted_task_list_covering_index", return_value=True):
+            with patch("gcloud.taskflow3.models.connection", mock_connection):
+                result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+                    queryset=queryset, limit=15, offset=5
+                )
+
+        expected_sql = sql.replace(
+            "FROM `taskflow3_taskflowinstance`",
+            "FROM `taskflow3_taskflowinstance` FORCE INDEX (`idx_proj_del_child_id_pipe`)",
+            1,
+        )
+        self.assertEqual([instance.id for instance in result], [9, 4, 2])
+        self.assertEqual(queryset.values_list_call, (("id",), {"flat": True}))
+        self.assertEqual(queryset.used_slice, slice(5, 20, None))
+        self.assertEqual(queryset.filter_call, {"id__in": [9, 4, 2]})
+        self.assertEqual(queryset.detail_queryset.select_related_fields, ("pipeline_instance", "project"))
+        cursor.execute.assert_called_once_with(expected_sql, params)
+
+    def test_fetch_unstarted_task_list_page_two_phase_skips_detail_query_for_empty_ids(self):
+        queryset = MockTwoPhaseQuerySet(
+            "SELECT `taskflow3_taskflowinstance`.`id` FROM `taskflow3_taskflowinstance`", []
+        )
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        mock_connection = MagicMock()
+        mock_connection.cursor.return_value.__enter__.return_value = cursor
+
+        with patch.object(TaskFlowInstance.objects, "has_unstarted_task_list_covering_index", return_value=True):
+            with patch("gcloud.taskflow3.models.connection", mock_connection):
+                result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+                    queryset=queryset, limit=15, offset=0
+                )
+
+        self.assertEqual(result, [])
+        self.assertIsNone(queryset.filter_call)
+
+    def test_fetch_unstarted_task_list_page_two_phase_falls_back_without_covering_index(self):
+        fallback_rows = [MagicMock(id=1)]
+        queryset = MockTwoPhaseQuerySet(
+            "SELECT `taskflow3_taskflowinstance`.`id` FROM `taskflow3_taskflowinstance`",
+            [],
+            fallback_rows=fallback_rows,
+        )
+
+        with patch.object(TaskFlowInstance.objects, "has_unstarted_task_list_covering_index", return_value=False):
+            result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+                queryset=queryset, limit=15, offset=3
+            )
+
+        self.assertEqual(result, fallback_rows)
+        self.assertEqual(queryset.used_slice, slice(3, 18, None))
+
+    def test_has_unstarted_task_list_covering_index_checks_mysql_schema(self):
+        cursor = MagicMock()
+        cursor.fetchone.return_value = ("taskflow3_taskflowinstance",)
+        mock_connection = MagicMock(vendor="mysql")
+        mock_connection.cursor.return_value.__enter__.return_value = cursor
+
+        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
+        with patch("gcloud.taskflow3.models.connection", mock_connection):
+            result = TaskFlowInstance.objects.has_unstarted_task_list_covering_index()
+
+        self.assertTrue(result)
+        cursor.execute.assert_called_once_with(
+            "SHOW INDEX FROM `taskflow3_taskflowinstance` WHERE Key_name = %s",
+            ["idx_proj_del_child_id_pipe"],
+        )
+        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
+
+    def test_has_unstarted_task_list_covering_index_returns_false_for_non_mysql(self):
+        mock_connection = MagicMock(vendor="sqlite")
+
+        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
+        with patch("gcloud.taskflow3.models.connection", mock_connection):
+            result = TaskFlowInstance.objects.has_unstarted_task_list_covering_index()
+
+        self.assertFalse(result)
+        mock_connection.cursor.assert_not_called()
+        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
+
+    def test_has_unstarted_task_list_covering_index_returns_false_when_schema_check_fails(self):
+        mock_connection = MagicMock(vendor="mysql")
+        mock_connection.cursor.return_value.__enter__.side_effect = DatabaseError("schema check failed")
+
+        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
+        with patch("gcloud.taskflow3.models.connection", mock_connection):
+            result = TaskFlowInstance.objects.has_unstarted_task_list_covering_index()
+
+        self.assertFalse(result)
+        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()

--- a/gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
+++ b/gcloud/tests/taskflow3/models/test_taskflow_instance_manager.py
@@ -11,7 +11,6 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from django.db import DatabaseError
 from django.test import SimpleTestCase
 from mock import MagicMock, patch
 
@@ -129,18 +128,17 @@ class TaskFlowInstanceManagerTestCase(SimpleTestCase):
         queryset = MockTwoPhaseQuerySet(sql, params, detail_rows=instances)
         cursor = MagicMock()
         cursor.fetchall.return_value = [(9,), (4,), (2,)]
-        mock_connection = MagicMock()
+        mock_connection = MagicMock(vendor="mysql")
         mock_connection.cursor.return_value.__enter__.return_value = cursor
 
-        with patch.object(TaskFlowInstance.objects, "has_unstarted_task_list_covering_index", return_value=True):
-            with patch("gcloud.taskflow3.models.connection", mock_connection):
-                result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
-                    queryset=queryset, limit=15, offset=5
-                )
+        with patch("gcloud.taskflow3.models.connection", mock_connection):
+            result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+                queryset=queryset, limit=15, offset=5
+            )
 
         expected_sql = sql.replace(
             "FROM `taskflow3_taskflowinstance`",
-            "FROM `taskflow3_taskflowinstance` FORCE INDEX (`idx_proj_del_child_id_pipe`)",
+            "FROM `taskflow3_taskflowinstance` IGNORE INDEX (`PRIMARY`)",
             1,
         )
         self.assertEqual([instance.id for instance in result], [9, 4, 2])
@@ -156,69 +154,31 @@ class TaskFlowInstanceManagerTestCase(SimpleTestCase):
         )
         cursor = MagicMock()
         cursor.fetchall.return_value = []
-        mock_connection = MagicMock()
+        mock_connection = MagicMock(vendor="mysql")
         mock_connection.cursor.return_value.__enter__.return_value = cursor
 
-        with patch.object(TaskFlowInstance.objects, "has_unstarted_task_list_covering_index", return_value=True):
-            with patch("gcloud.taskflow3.models.connection", mock_connection):
-                result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
-                    queryset=queryset, limit=15, offset=0
-                )
+        with patch("gcloud.taskflow3.models.connection", mock_connection):
+            result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
+                queryset=queryset, limit=15, offset=0
+            )
 
         self.assertEqual(result, [])
         self.assertIsNone(queryset.filter_call)
 
-    def test_fetch_unstarted_task_list_page_two_phase_falls_back_without_covering_index(self):
+    def test_fetch_unstarted_task_list_page_two_phase_falls_back_for_non_mysql(self):
         fallback_rows = [MagicMock(id=1)]
         queryset = MockTwoPhaseQuerySet(
             "SELECT `taskflow3_taskflowinstance`.`id` FROM `taskflow3_taskflowinstance`",
             [],
             fallback_rows=fallback_rows,
         )
+        mock_connection = MagicMock(vendor="sqlite")
 
-        with patch.object(TaskFlowInstance.objects, "has_unstarted_task_list_covering_index", return_value=False):
+        with patch("gcloud.taskflow3.models.connection", mock_connection):
             result = TaskFlowInstance.objects.fetch_unstarted_task_list_page_two_phase(
                 queryset=queryset, limit=15, offset=3
             )
 
         self.assertEqual(result, fallback_rows)
         self.assertEqual(queryset.used_slice, slice(3, 18, None))
-
-    def test_has_unstarted_task_list_covering_index_checks_mysql_schema(self):
-        cursor = MagicMock()
-        cursor.fetchone.return_value = ("taskflow3_taskflowinstance",)
-        mock_connection = MagicMock(vendor="mysql")
-        mock_connection.cursor.return_value.__enter__.return_value = cursor
-
-        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
-        with patch("gcloud.taskflow3.models.connection", mock_connection):
-            result = TaskFlowInstance.objects.has_unstarted_task_list_covering_index()
-
-        self.assertTrue(result)
-        cursor.execute.assert_called_once_with(
-            "SHOW INDEX FROM `taskflow3_taskflowinstance` WHERE Key_name = %s",
-            ["idx_proj_del_child_id_pipe"],
-        )
-        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
-
-    def test_has_unstarted_task_list_covering_index_returns_false_for_non_mysql(self):
-        mock_connection = MagicMock(vendor="sqlite")
-
-        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
-        with patch("gcloud.taskflow3.models.connection", mock_connection):
-            result = TaskFlowInstance.objects.has_unstarted_task_list_covering_index()
-
-        self.assertFalse(result)
         mock_connection.cursor.assert_not_called()
-        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
-
-    def test_has_unstarted_task_list_covering_index_returns_false_when_schema_check_fails(self):
-        mock_connection = MagicMock(vendor="mysql")
-        mock_connection.cursor.return_value.__enter__.side_effect = DatabaseError("schema check failed")
-
-        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()
-        with patch("gcloud.taskflow3.models.connection", mock_connection):
-            result = TaskFlowInstance.objects.has_unstarted_task_list_covering_index()
-
-        self.assertFalse(result)
-        TaskFlowInstance.objects.has_unstarted_task_list_covering_index.cache_clear()


### PR DESCRIPTION
## 背景

任务列表在筛选“未执行”时，原查询会按主键倒序扫描大量任务记录，再逐条关联流水线实例判断状态，生产环境请求耗时约 70 秒以上。

根因是优化器在“未执行任务极稀疏”的项目上误选了 `PRIMARY` 倒序扫描：目标项目最近一千万条候选任务里只有 13 条满足条件，凑不满 `LIMIT 15`，扫描无法提前结束。未执行任务较多的项目上，优化器本来就能选到按 `id` 有序的项目索引并提前结束，耗时只有 20 毫秒左右。因此优化手段必须只排除错误计划，不能把计划锁死到某个具体索引。

TAPD：[1010131351162150454 任务列表筛选“未执行”时接口耗时过长](https://tapd.woa.com/10131351/bugtrace/bugs/view/1010131351162150454)

## 改动

- 仅对 `without_count + project__id + is_started=false + is_child_taskflow=false` 启用两阶段查询，并且请求参数必须是 `without_count / project__id / pipeline_instance__is_started / is_child_taskflow / limit / offset` 这个白名单的子集，出现任何其他参数一律回退原查询。
- 第一阶段复用完整过滤条件只查询任务 ID，并注入 `IGNORE INDEX (PRIMARY)`，只排除造成慢查询的全表倒序扫描，把索引选择权留给优化器；复用已有的 `_inject_ignore_primary_index_hint`，与任务名称搜索优化共用同一套实现。
- 第二阶段按 ID 批量加载任务、流水线实例和项目详情，并恢复第一阶段的 ID 倒序。
- 非 MySQL 时自动回退到原 ORM 查询。不依赖任何未在迁移中声明的运维侧索引，因此不需要运行期探测表结构。
- 不新增索引或迁移，不改变接口响应、权限注入、分页和默认排序语义。

相比初版的两处修订，依据见下方实测：初版强制使用 `idx_proj_del_child_id_pipe` 改为只排除 `PRIMARY`；初版逐个排除已知坏参数改为参数白名单，同时移除了随强制索引一起引入的 `SHOW INDEX` 能力探测和它的进程级缓存。

## 影响范围

只影响明确筛选“未执行”且不带任何附加筛选条件的参数组合。已开始、未传状态、显式排序、名称搜索、精确任务 ID 搜索、“我的动态”、`task_instance_status`，以及模板、创建方式、创建人、创建时间区间等任意附加筛选，都继续走原逻辑。

## 验证

生产 WebConsole 在两个数据分布相反的项目上对比三种方案，`MAX_EXECUTION_TIME` 上限 8 秒：

| 项目 | 场景 | 原路径 | 两阶段 + FORCE 覆盖索引 | 两阶段 + IGNORE PRIMARY |
| --- | --- | --- | --- | --- |
| 5001537，224 万任务、13 条未执行 | 纯未执行 | 超时 | 4348ms | 3802ms |
| 5001537 | 附加最近 1 天创建时间 | 339ms | 3552ms | 3553ms |
| 5001537 | 附加 7 至 8 天创建时间区间 | 393ms | 3689ms | 3490ms |
| 5000122，578 万任务、未执行较多 | 纯未执行 | 23.2ms | 1151ms | 21.6ms |
| 5000122 | 附加最近 1 天创建时间 | 397.7ms | 1163ms | 350.4ms |
| 5000122 | 附加 7 至 8 天创建时间区间 | 376.1ms | 超时 | 366.4ms |

由此得到两条结论：`FORCE INDEX` 会在未执行任务较多的项目上造成数量级回退（21.6ms 到 1151ms），必须改用 `IGNORE INDEX (PRIMARY)`；带创建时间区间的组合即使改用 `IGNORE PRIMARY` 仍会回退约 9 至 10 倍，必须由参数白名单挡在优化路径之外。

### 合入前最终验证

对最终实现（IGNORE PRIMARY + 白名单）做了一轮完整验证，4 个性能用例加 14 种参数组合的路径判定共 18 项全部通过：

| 场景 | 原路径 | 两阶段 + IGNORE PRIMARY | 返回结果 |
| --- | --- | --- | --- |
| 5001537 首页 | 8004ms 被语句超时中断 | 3809ms | 13 条，逐条校验项目归属、未删除、非子流程、未启动、未过期均通过 |
| 5001537 第二页 | 8003ms 被语句超时中断 | 3707ms | 空页 |
| 5000122 首页 | 57.3ms | 43.2ms | 15 条，ID 与原路径逐个相同 |
| 5000122 第二页 | 30.8ms | 37.4ms | 15 条，ID 与原路径逐个相同 |

关键证据是 5000122 上两条路径选中了同一个索引 `taskflow3_taskflowin_project_id_3c18b071_fk_core_proj` 且都没有 filesort，说明 `IGNORE INDEX (PRIMARY)` 只排除了错误计划，没有干扰优化器的正常选择——这正是 `FORCE INDEX` 在该项目上退化到 1151ms 的地方。另外 5001537 原路径的计划估算走 `PRIMARY` 只需扫 12181 行，实际要扫完两百多万行，估算偏差近两个数量级，说明该问题无法靠更新统计信息解决。

路径判定矩阵覆盖：未执行叠加创建时间区间（稀疏与密集各一）、模板、创建人、创建方式、显式排序、名称搜索、精确任务 ID、已执行、子流程、不传状态、状态筛选、我的动态、不带 `without_count` 的带计数分页，实际路径与合入前完全一致。

其余验证：

- 精确任务 ID 保护：WebConsole 验证 3 个真实 ID 和 1 个不存在 ID，原主键路径约 4-22ms，两阶段路径约 222-238ms，4 组结果一致，因此保留原路径，白名单已覆盖该场景。
- 单元测试：`test_taskflow_instance_manager.py` 与 `test_task_instance_view.py` 共 18 passed；另有 1 个上游 SQLite 基线失败 `test_filter_failed_task_list`，已确认在本 PR 改动前同样失败，场景为 `is_started=true + task_instance_status=failed`，无法进入本次新增路径。
- merge-conflict、black、isort、Flake8、check-migrate、敏感信息检查和 commitlint 均通过。

## 遗留问题

Django 把布尔过滤编译成 `NOT col` 而非 `col = 0`，`NOT col` 无法作为 ref 的 key part。视图基础 queryset 里的 `is_deleted=Value(0)` 会编译成 `= 0`，因此 `idx_proj_del_child_id_pipe` 实际用到 `project_id` 和 `is_deleted` 两列；而 `is_child_taskflow` 由 FilterSet 生成，仍是不可 sarg 的形式，索引到第三列即中断，`id` 接不上排序只能 filesort。

即使补上冗余等值条件让索引用满前三列并去掉 filesort，稀疏项目也快不了多少：其耗时主要来自约 227 万次回流水线实例表的 eq_ref 查找，而不是排序。彻底解决需要消除跨表状态判断（例如把 `is_started` 冗余到任务表并配套索引），不在本 PR 范围内，另立需求跟进。

另有一个固有代价：翻页越过数据末尾时仍需扫完整个项目区间才能确认没有更多结果，稀疏项目上返回空页同样耗时约 3.7 秒，本期不做处理。

## 灰度关注点

未执行任务较多的项目原本是毫秒级返回，一旦出现秒级延迟即说明优化器又选回了需要 filesort 的计划，应立即关闭该路径。两阶段路径由独立判断函数封装，回退不涉及数据回滚或 DDL。

