### PR TITLE
fix: 补齐插件运行壳业务ID兼容上下文

### DIFF
--- a/gcloud/plugin_gateway/services/runner.py
+++ b/gcloud/plugin_gateway/services/runner.py
@@ -114,6 +114,7 @@ class PluginGatewayRunner:
             "executor": operator,
             "project_id": run_context.get("project_id"),
             "bk_biz_id": run_context.get("bk_biz_id"),
+            "biz_cc_id": run_context.get("bk_biz_id"),
             "task_id": run_context.get("task_id"),
             "task_name": run_context.get("task_name"),
             "task_start_time": None,

--- a/gcloud/tests/plugin_gateway/test_runner.py
+++ b/gcloud/tests/plugin_gateway/test_runner.py
@@ -70,6 +70,24 @@ class _RuntimeAwareComponent:
     bound_service = _RuntimeAwareService
 
 
+class _LegacyBizContextService(_RuntimeService):
+    interval = None
+
+    def execute(self, data, parent_data):
+        biz_cc_id = data.get_one_of_inputs("biz_cc_id", parent_data.inputs.biz_cc_id)
+        data.set_outputs("biz_cc_id", biz_cc_id)
+        return True
+
+    def need_schedule(self):
+        return False
+
+
+class _LegacyBizContextComponent:
+    code = "legacy_biz_context"
+    version = "legacy"
+    bound_service = _LegacyBizContextService
+
+
 class _ThirdPartyShellService(_RuntimeService):
     interval = None
 
@@ -164,6 +182,21 @@ class PluginGatewayRunnerExecuteTestCase(TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["outputs"]["runtime_id"], "a" * 32)
         self.assertEqual(result["outputs"]["runtime_root_pipeline_id"], "a" * 32)
+
+    @patch("gcloud.plugin_gateway.services.runner.ComponentLibrary")
+    def test_execute_injects_legacy_biz_cc_id_context(self, mock_lib):
+        mock_lib.get_component_class.return_value = _LegacyBizContextComponent
+
+        result = PluginGatewayRunner.run_execute(
+            self._run(
+                plugin_id="builtin__legacy_biz_context",
+                trigger_payload={"inputs": {"biz_cc_id": 100605}},
+            ),
+            {"operator": "zhangsan", "project_id": 10, "bk_biz_id": 100605},
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["outputs"]["biz_cc_id"], 100605)
 
     @patch("gcloud.plugin_gateway.services.runner.ComponentLibrary")
     def test_execute_exception_maps_failed(self, mock_lib):


### PR DESCRIPTION
## 问题

BKFlow 通过 uniform_api v4 调用标准运维内置插件时，部分组件仍会从原生父上下文读取兼容字段 `biz_cc_id`。插件网关运行壳只注入了 `bk_biz_id`，导致快速执行脚本等组件在执行前抛出 `AttributeError: 'biz_cc_id'`。

## 修复

- 在 `PluginGatewayRunner` 构造的父上下文中补齐 `biz_cc_id`，值与已解析的 `bk_biz_id` 保持一致
- 增加回归测试，覆盖真实组件常用的 `data.get_one_of_inputs("biz_cc_id", parent_data.inputs.biz_cc_id)` 访问方式
- 不修改组件实现、V4 协议和项目解析逻辑

## 验证

- `python manage.py test gcloud.tests.plugin_gateway -v 2`：131 tests passed
- Black：passed
- isort：passed
- Flake8：passed
- `git diff --check`：passed

## 本地钩子说明

仓库当前缺少 `scripts/check_migrate/check_migrate.py` 和 `scripts/check_sensitive_info.sh`，对应 pre-commit hook 无法执行；commitlint 受本地 Node 18/CommonJS 与 ESM 工具链冲突阻断。提交时仅跳过了这三个不可执行 hook，其余钩子均通过。