### PR TITLE
fix: 修复 JOB 插件回调客户端重建 --story=133649781

### DIFF
--- a/gcloud/tests/plugin_gateway/test_runner.py
+++ b/gcloud/tests/plugin_gateway/test_runner.py
@@ -11,12 +11,13 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
 from gcloud.plugin_gateway.models import PluginGatewayRun
 from gcloud.plugin_gateway.services.runner import PluginGatewayRunner
+from pipeline_plugins.components.collections.sites.open.job.base import JobService, Jobv3Service
 
 
 class _RuntimeService:
@@ -137,6 +138,26 @@ class _PollComponent:
     bound_service = _PollService
 
 
+class _JobCallbackService(JobService):
+    need_get_sops_var = False
+
+
+class _JobCallbackComponent:
+    code = "job_callback"
+    version = "legacy"
+    bound_service = _JobCallbackService
+
+
+class _Jobv3CallbackService(Jobv3Service):
+    need_get_sops_var = False
+
+
+class _Jobv3CallbackComponent:
+    code = "jobv3_callback"
+    version = "legacy"
+    bound_service = _Jobv3CallbackService
+
+
 class PluginGatewayRunnerExecuteTestCase(TestCase):
     def _run(self, **overrides):
         defaults = {
@@ -237,6 +258,21 @@ class PluginGatewayRunnerExecuteTestCase(TestCase):
 
 
 class PluginGatewayRunnerScheduleTestCase(TestCase):
+    def _job_callback_run(self, plugin_id):
+        return PluginGatewayRun.objects.create(
+            source_key="bkflow",
+            plugin_id=plugin_id,
+            plugin_version="legacy",
+            client_request_id=plugin_id,
+            open_plugin_run_id="c" * 31 + ("2" if "jobv3" in plugin_id else "1"),
+            callback_url="https://bkflow.example.com/callback",
+            callback_token="token",
+            run_status=PluginGatewayRun.Status.RUNNING,
+            caller_app_code="bkflow-app",
+            trigger_payload={"inputs": {"biz_cc_id": 100605}},
+            runtime_outputs={"client": "<serialized-esb-client>", "job_inst_url": "https://job.example.com/1"},
+        )
+
     @patch("gcloud.plugin_gateway.services.runner.ComponentLibrary")
     def test_schedule_finishes_with_runtime_outputs(self, mock_lib):
         mock_lib.get_component_class.return_value = _PollComponent
@@ -265,3 +301,31 @@ class PluginGatewayRunnerScheduleTestCase(TestCase):
         self.assertEqual(result["mode"], "poll")
         self.assertTrue(result["outputs"]["polled"])
         self.assertEqual(result["outputs"]["trace_id_from_runtime"], "trace-001")
+
+    @patch("pipeline_plugins.components.collections.sites.open.job.base.get_client_by_user")
+    @patch("gcloud.plugin_gateway.services.runner.ComponentLibrary")
+    def test_job_callback_rebuilds_serialized_client(self, mock_lib, mock_get_client):
+        client = MagicMock()
+        client.jobv3.get_job_instance_global_var_value.return_value = {
+            "result": True,
+            "data": {"step_instance_var_list": []},
+        }
+        mock_get_client.return_value = client
+
+        for plugin_id, component in (
+            ("builtin__job_callback", _JobCallbackComponent),
+            ("builtin__jobv3_callback", _Jobv3CallbackComponent),
+        ):
+            with self.subTest(plugin_id=plugin_id):
+                mock_lib.get_component_class.return_value = component
+                result = PluginGatewayRunner.run_schedule(
+                    self._job_callback_run(plugin_id),
+                    {"operator": "test-operator", "project_id": 10, "bk_biz_id": 100605},
+                    callback_data={"job_instance_id": 10000, "status": 3},
+                )
+
+                self.assertTrue(result["ok"], result["error_message"])
+                self.assertTrue(result["finished"])
+
+        self.assertEqual(mock_get_client.call_count, 2)
+        mock_get_client.assert_called_with("test-operator")

--- a/pipeline_plugins/components/collections/sites/open/job/base.py
+++ b/pipeline_plugins/components/collections/sites/open/job/base.py
@@ -62,6 +62,14 @@ get_client_by_user = settings.ESB_GET_CLIENT_BY_USER
 job_handle_api_error = partial(handle_api_error, __group_name__)
 
 
+def _get_job_client(data, parent_data):
+    client = data.get_one_of_outputs("client")
+    if not hasattr(client, "jobv3"):
+        client = get_client_by_user(parent_data.get_one_of_inputs("executor"))
+        data.outputs.client = client
+    return client
+
+
 def get_sops_var_dict_from_log_text(log_text, service_logger):
     """
     在日志文本中提取全局变量
@@ -489,7 +497,7 @@ class JobService(BasePluginService):
 
             if self.reload_outputs:
 
-                client = data.outputs.client
+                client = _get_job_client(data, parent_data)
 
                 # 判断是否对IP进行Tag分组, 兼容之前的配置，默认从inputs拿
                 is_tagged_ip = data.get_one_of_inputs("is_tagged_ip", False)
@@ -538,7 +546,7 @@ class JobService(BasePluginService):
                 self.finish_schedule()
                 return True if job_success else False
             get_job_sops_var_dict_return = get_job_sops_var_dict(
-                data.outputs.client,
+                _get_job_client(data, parent_data),
                 self.logger,
                 job_instance_id,
                 data.get_one_of_inputs("biz_cc_id", parent_data.inputs.biz_cc_id),
@@ -736,7 +744,7 @@ class Jobv3Service(BasePluginService):
                 )
 
             if self.reload_outputs:
-                client = data.outputs.client
+                client = _get_job_client(data, parent_data)
 
                 # 判断是否对IP进行Tag分组
                 is_tagged_ip = data.get_one_of_inputs("is_tagged_ip", False)
@@ -785,7 +793,7 @@ class Jobv3Service(BasePluginService):
                 return True if job_success else False
 
             get_jobv3_sops_var_dict_return = get_job_sops_var_dict(
-                data.outputs.client,
+                _get_job_client(data, parent_data),
                 self.logger,
                 job_instance_id,
                 data.get_one_of_inputs("biz_cc_id", parent_data.inputs.biz_cc_id),


### PR DESCRIPTION
## 问题

Open Plugin 运行壳会把组件 `outputs` 持久化到 JSONField。JOB 回调型插件在 execute 阶段写入的 ESB client 跨进程序列化后变为字符串，回调任务重建组件时继续调用 `client.jobv3`，导致任务以 `'str' object has no attribute 'jobv3'` 失败。

## 修改

- 为 JOB 公共回调基类增加 client 有效性检查；已有 `jobv3` 能力时保持存量行为，失效时按 `parent_data.executor` 重建真实 ESB client
- 同时覆盖 `JobService` 与 `Jobv3Service`，不改 uniform_api V4 协议和通用运行壳
- 增加跨进程 `runtime_outputs` 回归测试，覆盖两条 JOB 回调基类

## 验证

- `python manage.py test gcloud.tests.plugin_gateway -v 1`：132 passed
- `python manage.py test pipeline_plugins.tests.components.collections.sites.open.job_test -v 1`：22 passed
- Black、isort、flake8、`git diff --check` 通过