### PR TITLE
feat: 插件网关增加总开关，默认关闭且不投递队列消息，版本号更新至 3.35.5

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -6,7 +6,7 @@ is_use_celery: True
 author: 蓝鲸智云
 introduction: 标准运维是通过一套成熟稳定的任务调度引擎，把在多系统间的工作整合到一个流程，助力运维实现跨系统调度自动化的SaaS应用。
 introduction_en: SOPS is a SaaS application that utilizes a set of mature and stable task scheduling engines to help realize cross-system scheduling automation, and integrates the work among multiple systems into a single process.
-version: "3.35.4"
+version: "3.35.5"
 category: 运维工具
 language_support: 中文
 desktop:

--- a/app_desc.yaml
+++ b/app_desc.yaml
@@ -1,5 +1,5 @@
 spec_version: 2
-app_version: "3.35.4"
+app_version: "3.35.5"
 app:
   region: default
   bk_app_code: bk_sops

--- a/config/default.py
+++ b/config/default.py
@@ -243,7 +243,7 @@ LOGGING = get_logging_config_dict(locals())
 # mako模板中：<script src="/a.js?v=${ STATIC_VERSION }"></script>
 # 如果静态资源修改了以后，上线前改这个版本号即可
 
-STATIC_VERSION = "3.35.4"
+STATIC_VERSION = "3.35.5"
 DEPLOY_DATETIME = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
 APIGW_DOCS_VERSION = STATIC_VERSION + "+" + str(DEPLOY_DATETIME)
 

--- a/config/default.py
+++ b/config/default.py
@@ -525,6 +525,9 @@ ScalableQueues.add(name=API_TASK_QUEUE_NAME)
 PERIODIC_TASK_QUEUE_NAME = "periodic_task_queue"
 ScalableQueues.add(name=PERIODIC_TASK_QUEUE_NAME)
 
+# 插件网关总开关，关闭时不向 open_plugin_* 队列投递消息
+PLUGIN_GATEWAY_ENABLE = env.PLUGIN_GATEWAY_ENABLE
+
 # 插件网关独立队列
 OPEN_PLUGIN_DISPATCH_QUEUE_NAME = "open_plugin_dispatch"
 OPEN_PLUGIN_POLLING_QUEUE_NAME = "open_plugin_polling"
@@ -557,15 +560,18 @@ CELERY_QUEUES.extend(
 )
 
 CELERYBEAT_SCHEDULE = locals().get("CELERYBEAT_SCHEDULE", {})
-CELERYBEAT_SCHEDULE.update(
-    {
-        "sweep_expired_plugin_gateway_runs": {
-            "task": "gcloud.plugin_gateway.tasks.sweep_expired_plugin_gateway_runs",
-            "schedule": 60.0,
-            "options": {"queue": OPEN_PLUGIN_POLLING_QUEUE_NAME},
+# 插件网关关闭时不注册超时清扫周期任务：open_plugin_* 队列在未部署 worker 的环境无人消费，
+# 每分钟一条的投递会在 broker 上无限堆积。
+if PLUGIN_GATEWAY_ENABLE:
+    CELERYBEAT_SCHEDULE.update(
+        {
+            "sweep_expired_plugin_gateway_runs": {
+                "task": "gcloud.plugin_gateway.tasks.sweep_expired_plugin_gateway_runs",
+                "schedule": 60.0,
+                "options": {"queue": OPEN_PLUGIN_POLLING_QUEUE_NAME},
+            }
         }
-    }
-)
+    )
 
 CELERY_ROUTES.update({"gcloud.clocked_task.tasks.clocked_task_start": PIPELINE_ADDITIONAL_PRIORITY_ROUTING})
 

--- a/docs/en/deploy/plugin_gateway_deploy.md
+++ b/docs/en/deploy/plugin_gateway_deploy.md
@@ -33,7 +33,21 @@ Current runtime boundary:
 
 Deploy the version that contains `gcloud.plugin_gateway` and `gcloud.apigw.views.plugin_gateway`.
 
-### 2.2 Install Dependencies
+### 2.2 Turn On the Feature Switch
+
+The gateway is controlled by `BKAPP_PLUGIN_GATEWAY_ENABLE` and is **disabled by default**. It is enabled when the value is one of `1/true/yes/on`.
+
+While disabled:
+
+- `sweep_expired_plugin_gateway_runs` is not registered, so beat never publishes to `open_plugin_polling`
+- the run creation endpoint returns `error_type=gateway_disabled` without persisting a run or publishing to `open_plugin_dispatch`
+- the internal callback endpoint and the plugin gateway branch of `node_callback` never publish to `open_plugin_callback`
+
+Deployments without `open_plugin_*` workers therefore accumulate no messages. Make sure the three queues in 2.5 have consumers before turning the switch on.
+
+Beat runs on the `django_celery_beat` `DatabaseScheduler`, which persists schedule entries into `PeriodicTask` and does not prune them when they disappear from settings. Migration `plugin_gateway.0005` deletes a leftover `sweep_expired_plugin_gateway_runs` row; beat re-registers it on startup once the switch is on, so no manual cleanup is needed.
+
+### 2.3 Install Dependencies
 
 If your deployment rebuilds the Python environment, install dependencies as usual:
 
@@ -41,7 +55,7 @@ If your deployment rebuilds the Python environment, install dependencies as usua
 pip install -r requirements.txt
 ```
 
-### 2.3 Run Migrations
+### 2.4 Run Migrations
 
 The gateway adds two models:
 
@@ -60,7 +74,7 @@ Or only for this app:
 python manage.py migrate plugin_gateway
 ```
 
-### 2.4 Restart Services
+### 2.5 Restart Services
 
 Restart at least:
 
@@ -76,7 +90,7 @@ python manage.py celery worker -l info -Q open_plugin_polling
 python manage.py celery worker -l info -Q open_plugin_callback
 ```
 
-`sweep_expired_plugin_gateway_runs` is triggered by beat every 60 seconds. Confirm the beat schedule is deployed with the code.
+When the switch is on, `sweep_expired_plugin_gateway_runs` is triggered by beat every 60 seconds. Confirm the beat schedule is deployed with the code. The periodic task is not registered while the switch is off.
 
 ## 3. Initialize Source Configuration
 

--- a/docs/zh_hans/deploy/plugin_gateway_deploy.md
+++ b/docs/zh_hans/deploy/plugin_gateway_deploy.md
@@ -33,7 +33,21 @@
 
 将包含 `gcloud.plugin_gateway` 和 `gcloud.apigw.views.plugin_gateway` 变更的版本发布到部署环境。
 
-### 2.2 安装依赖
+### 2.2 开启功能开关
+
+插件网关由 `BKAPP_PLUGIN_GATEWAY_ENABLE` 控制，**默认关闭**，取值为 `1/true/yes/on` 时开启。
+
+关闭时的行为：
+
+- 不注册 `sweep_expired_plugin_gateway_runs` 周期任务，beat 不会向 `open_plugin_polling` 投递消息
+- 创建执行接口返回 `error_type=gateway_disabled`，不会写入 run 记录，也不会向 `open_plugin_dispatch` 投递消息
+- 网关内部回调接口与 `node_callback` 的插件网关分支不会向 `open_plugin_callback` 投递消息
+
+因此未部署 `open_plugin_*` worker 的环境不会出现队列堆积。开启开关前，请先确认 2.5 中的三条队列已经有 worker 消费。
+
+beat 使用 `django_celery_beat` 的 `DatabaseScheduler`，周期任务配置会落到 `PeriodicTask` 表且不会随配置移除自动清理。迁移 `plugin_gateway.0005` 会删除残留的 `sweep_expired_plugin_gateway_runs` 记录，开关开启时 beat 启动会重新登记，无需手工处理。
+
+### 2.3 安装依赖
 
 如部署流程会重建 Python 运行环境，请按常规方式安装依赖：
 
@@ -41,7 +55,7 @@
 pip install -r requirements.txt
 ```
 
-### 2.3 执行数据库迁移
+### 2.4 执行数据库迁移
 
 插件网关新增了以下模型：
 
@@ -54,13 +68,13 @@ pip install -r requirements.txt
 python manage.py migrate
 ```
 
-如需只迁移该 app，可执行：
+如需只迁移该 app，可执行（迁移与开关无关，关闭状态下也可以先建表）：
 
 ```bash
 python manage.py migrate plugin_gateway
 ```
 
-### 2.4 重启服务
+### 2.5 重启服务
 
 部署后应至少重启：
 
@@ -76,7 +90,7 @@ python manage.py celery worker -l info -Q open_plugin_polling
 python manage.py celery worker -l info -Q open_plugin_callback
 ```
 
-`sweep_expired_plugin_gateway_runs` 由 beat 每 60 秒触发，建议确认 beat 配置已随代码发布生效。
+`sweep_expired_plugin_gateway_runs` 在开关开启时由 beat 每 60 秒触发，建议确认 beat 配置已随代码发布生效。开关关闭时该周期任务不会注册。
 
 ## 3. 初始化来源配置
 

--- a/env.py
+++ b/env.py
@@ -61,6 +61,11 @@ BK_PLUGIN_DEVELOP_URL = os.getenv("BK_PLUGIN_DEVELOP_URL", "")
 # 蓝鲸插件授权过滤 APP
 PLUGIN_DISTRIBUTOR_NAME = os.getenv("PLUGIN_DISTRIBUTOR_NAME", os.getenv("BKAPP_PLUGIN_DISTRIBUTOR_NAME"))
 
+# 插件网关总开关，默认关闭。
+# 关闭时不会向 open_plugin_dispatch / open_plugin_polling / open_plugin_callback 投递任何消息，
+# 因此未部署对应 worker 的环境不会出现队列堆积；创建执行的网关接口会直接返回不可用。
+PLUGIN_GATEWAY_ENABLE = os.getenv("BKAPP_PLUGIN_GATEWAY_ENABLE", "").strip().lower() in {"1", "true", "yes", "on"}
+
 # IAM APIGW 地址
 BK_IAM_APIGW_HOST = os.getenv("BK_IAM_APIGW_HOST")
 

--- a/gcloud/apigw/views/plugin_gateway.py
+++ b/gcloud/apigw/views/plugin_gateway.py
@@ -24,6 +24,7 @@ from gcloud.conf import settings
 from gcloud.plugin_gateway.exceptions import (
     PluginGatewayConflictError,
     PluginGatewayContextResolveError,
+    PluginGatewayDisabledError,
     PluginGatewayPluginNotEnabledError,
     PluginGatewayPluginNotFoundError,
     PluginGatewaySourceUnavailableError,
@@ -41,10 +42,15 @@ ERROR_TYPE_PLUGIN_NOT_ENABLED = "plugin_not_enabled"
 ERROR_TYPE_PLUGIN_VERSION_UNAVAILABLE = "plugin_version_unavailable"
 ERROR_TYPE_PLUGIN_REMOVED = "plugin_removed"
 ERROR_TYPE_SOURCE_UNREACHABLE = "source_unreachable"
+ERROR_TYPE_GATEWAY_DISABLED = "gateway_disabled"
 
 
 def _error_response(message, code, error_type=""):
     return {"result": False, "message": message, "code": code, "error_type": error_type}
+
+
+def _disabled_response():
+    return _error_response("plugin gateway is disabled", err_code.INVALID_OPERATION.code, ERROR_TYPE_GATEWAY_DISABLED)
 
 
 def _load_request_body(request):
@@ -195,6 +201,8 @@ def create_plugin_gateway_run(request):
         return _error_response(str(e), err_code.REQUEST_PARAM_INVALID.code, ERROR_TYPE_PLUGIN_VERSION_UNAVAILABLE)
     except PluginGatewayPluginNotEnabledError as e:
         return _error_response(str(e), err_code.REQUEST_PARAM_INVALID.code, ERROR_TYPE_PLUGIN_NOT_ENABLED)
+    except PluginGatewayDisabledError:
+        return _disabled_response()
     except PluginGatewayContextResolveError as e:
         return _error_response(str(e), err_code.REQUEST_PARAM_INVALID.code)
     except PluginGatewaySourceUnavailableError as e:
@@ -282,6 +290,9 @@ def get_plugin_gateway_run_detail(request, run_id):
 @return_json_response
 @mark_request_whether_is_trust
 def plugin_gateway_run_internal_callback(request, run_id):
+    if not settings.PLUGIN_GATEWAY_ENABLE:
+        return _disabled_response()
+
     try:
         raw_payload = _load_request_body(request)
     except ValueError as e:

--- a/gcloud/plugin_gateway/exceptions.py
+++ b/gcloud/plugin_gateway/exceptions.py
@@ -12,6 +12,10 @@ specific language governing permissions and limitations under the License.
 """
 
 
+class PluginGatewayDisabledError(ValueError):
+    """Raised when plugin gateway execution is requested while the feature switch is off."""
+
+
 class PluginGatewayConflictError(ValueError):
     """Raised when the same idempotency key is reused with different business payload."""
 

--- a/gcloud/plugin_gateway/migrations/0005_drop_stale_sweep_periodic_task.py
+++ b/gcloud/plugin_gateway/migrations/0005_drop_stale_sweep_periodic_task.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from django.apps import apps as global_apps
+from django.db import migrations
+
+SWEEP_TASK_PATH = "gcloud.plugin_gateway.tasks.sweep_expired_plugin_gateway_runs"
+
+
+def drop_stale_sweep_periodic_task(apps, schema_editor):
+    """删除 DatabaseScheduler 已落库的超时清扫周期任务。
+
+    beat 使用 django_celery_beat 的 DatabaseScheduler，CELERYBEAT_SCHEDULE 的条目会被同步成
+    PeriodicTask 记录，并且从配置里移除后不会自动清理。插件网关开关关闭后需要主动删除残留记录，
+    否则 beat 仍会按库里的记录向无消费者的 open_plugin_polling 队列投递消息。
+    开关开启时 beat 启动会按配置重新登记，因此这里可以无条件删除。
+    """
+
+    # django_celery_beat 属于第三方 app，这里不通过 migration 依赖引用，避免未启用 celery 时构图失败
+    try:
+        periodic_task_model = global_apps.get_model("django_celery_beat", "PeriodicTask")
+    except LookupError:
+        return
+
+    connection = schema_editor.connection
+    if periodic_task_model._meta.db_table not in connection.introspection.table_names():
+        return
+
+    periodic_task_model.objects.filter(task=SWEEP_TASK_PATH).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("plugin_gateway", "0004_remove_plugin_allow_list"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_stale_sweep_periodic_task, migrations.RunPython.noop),
+    ]

--- a/gcloud/plugin_gateway/services/execution.py
+++ b/gcloud/plugin_gateway/services/execution.py
@@ -15,11 +15,13 @@ import logging
 from datetime import timedelta
 from uuid import uuid4
 
+from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from gcloud.plugin_gateway.exceptions import (
     PluginGatewayConflictError,
+    PluginGatewayDisabledError,
     PluginGatewayPluginNotEnabledError,
     PluginGatewayPluginNotFoundError,
     PluginGatewayVersionNotFoundError,
@@ -41,6 +43,10 @@ class PluginGatewayExecutionService:
 
     @classmethod
     def create_run(cls, caller_app_code, payload):
+        # 开关关闭时直接拒绝：继续走下去会落一条永远不会被调度的 run 记录
+        if not settings.PLUGIN_GATEWAY_ENABLE:
+            raise PluginGatewayDisabledError("plugin gateway is disabled")
+
         source_config = cls._get_source_config(payload["source_key"])
         cls._validate_do_not_open_plugin(source_config, payload["plugin_id"])
         plugin_reference = cls._get_plugin_reference(payload["plugin_id"], payload["plugin_version"])

--- a/gcloud/plugin_gateway/tasks.py
+++ b/gcloud/plugin_gateway/tasks.py
@@ -14,6 +14,7 @@ specific language governing permissions and limitations under the License.
 import logging
 
 from celery import current_app
+from django.conf import settings
 from django.utils import timezone
 
 from gcloud.plugin_gateway.constants import MAX_SCHEDULE_TIMES, poll_countdown
@@ -29,8 +30,23 @@ CALLBACK_READY_RETRY_INTERVAL_SECONDS = 1
 CALLBACK_READY_MAX_RETRY_TIMES = 30
 
 
+def _skip_when_disabled(task_name, open_plugin_run_id=""):
+    """开关关闭时放弃执行，避免任务内部继续向 open_plugin_* 队列投递后续消息。
+
+    正常情况下开关关闭时队列里不会有消息，这里兜住的是运行中途关闭开关的场景。
+    """
+    if settings.PLUGIN_GATEWAY_ENABLE:
+        return False
+
+    logger.info("[plugin_gateway] %s skipped because plugin gateway is disabled, run=%s", task_name, open_plugin_run_id)
+    return True
+
+
 @current_app.task(queue="open_plugin_polling")
 def sweep_expired_plugin_gateway_runs():
+    if _skip_when_disabled("sweep_expired_plugin_gateway_runs"):
+        return
+
     expired_runs = PluginGatewayRun.objects.filter(execution_expire_at__lt=timezone.now()).exclude(
         run_status__in=list(PluginGatewayRun.Status.TERMINAL)
     )
@@ -44,6 +60,9 @@ def sweep_expired_plugin_gateway_runs():
 
 @current_app.task(queue="open_plugin_dispatch")
 def dispatch_plugin_gateway_run(open_plugin_run_id):
+    if _skip_when_disabled("dispatch_plugin_gateway_run", open_plugin_run_id):
+        return
+
     try:
         run = PluginGatewayRun.objects.get(open_plugin_run_id=open_plugin_run_id)
     except PluginGatewayRun.DoesNotExist:
@@ -125,6 +144,9 @@ def dispatch_plugin_gateway_run(open_plugin_run_id):
 
 @current_app.task(queue="open_plugin_polling")
 def poll_plugin_gateway_run(open_plugin_run_id):
+    if _skip_when_disabled("poll_plugin_gateway_run", open_plugin_run_id):
+        return
+
     try:
         run = PluginGatewayRun.objects.get(open_plugin_run_id=open_plugin_run_id)
     except PluginGatewayRun.DoesNotExist:
@@ -214,6 +236,9 @@ def poll_plugin_gateway_run(open_plugin_run_id):
 
 @current_app.task(queue="open_plugin_callback")
 def callback_plugin_gateway_run(open_plugin_run_id, callback_data=None, ready_retry_times=0):
+    if _skip_when_disabled("callback_plugin_gateway_run", open_plugin_run_id):
+        return
+
     try:
         run = PluginGatewayRun.objects.get(open_plugin_run_id=open_plugin_run_id)
     except PluginGatewayRun.DoesNotExist:

--- a/gcloud/taskflow3/apis/django/v4/node_callback.py
+++ b/gcloud/taskflow3/apis/django/v4/node_callback.py
@@ -71,7 +71,8 @@ def node_callback(request, token):
         return JsonResponse({"result": False, "message": message}, status=400)
 
     if (
-        root_pipeline_id
+        settings.PLUGIN_GATEWAY_ENABLE
+        and root_pipeline_id
         and root_pipeline_id == node_id
         and PluginGatewayRun.objects.filter(open_plugin_run_id=root_pipeline_id).exists()
     ):

--- a/gcloud/tests/apigw/views/test_plugin_gateway.py
+++ b/gcloud/tests/apigw/views/test_plugin_gateway.py
@@ -7,12 +7,13 @@ import ujson as json
 import yaml
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.test import modify_settings
+from django.test import modify_settings, override_settings
 
 from gcloud import err_code
 from gcloud.tests.apigw.views.utils import TEST_APP_CODE, TEST_USERNAME, APITest
 
 
+@override_settings(PLUGIN_GATEWAY_ENABLE=True)
 @modify_settings(
     MIDDLEWARE={
         "append": "gcloud.tests.apigw.views.utils.MockApiGatewayJWTPayloadMiddleware",

--- a/gcloud/tests/plugin_gateway/test_callback_routing.py
+++ b/gcloud/tests/plugin_gateway/test_callback_routing.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 from cryptography.fernet import Fernet
 from django.conf import settings
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, override_settings
 
 from gcloud.plugin_gateway.models import PluginGatewayRun
 from gcloud.taskflow3.apis.django.v4.node_callback import node_callback
@@ -24,6 +24,7 @@ from gcloud.utils import crypto
 from pipeline_plugins.components.utils.sites.open.utils import get_node_callback_url
 
 
+@override_settings(PLUGIN_GATEWAY_ENABLE=True)
 class PluginGatewayCallbackRoutingTestCase(TestCase):
     def setUp(self):
         self.run = PluginGatewayRun.objects.create(

--- a/gcloud/tests/plugin_gateway/test_dispatch.py
+++ b/gcloud/tests/plugin_gateway/test_dispatch.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.translation import gettext_lazy
 
@@ -32,6 +32,7 @@ class _LazyOutputScheduleComponent:
     bound_service = _LazyOutputScheduleService
 
 
+@override_settings(PLUGIN_GATEWAY_ENABLE=True)
 class PluginGatewayDispatchTaskTestCase(TestCase):
     def setUp(self):
         PluginGatewaySourceConfig.objects.create(

--- a/gcloud/tests/plugin_gateway/test_execution.py
+++ b/gcloud/tests/plugin_gateway/test_execution.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from django.db import IntegrityError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from gcloud.plugin_gateway.exceptions import PluginGatewayConflictError, PluginGatewayPluginNotEnabledError
@@ -12,6 +12,7 @@ from gcloud.plugin_gateway.tasks import sweep_expired_plugin_gateway_runs
 from gcloud.utils import crypto
 
 
+@override_settings(PLUGIN_GATEWAY_ENABLE=True)
 class PluginGatewayExecutionServiceTestCase(TestCase):
     def setUp(self):
         self.source_config = PluginGatewaySourceConfig.objects.create(

--- a/gcloud/tests/plugin_gateway/test_feature_switch.py
+++ b/gcloud/tests/plugin_gateway/test_feature_switch.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import RequestFactory, TestCase, override_settings
+from django.utils import timezone
+
+from gcloud.plugin_gateway.exceptions import PluginGatewayDisabledError
+from gcloud.plugin_gateway.models import PluginGatewayRun, PluginGatewaySourceConfig
+from gcloud.plugin_gateway.services.execution import PluginGatewayExecutionService
+from gcloud.plugin_gateway.tasks import (
+    callback_plugin_gateway_run,
+    dispatch_plugin_gateway_run,
+    poll_plugin_gateway_run,
+    sweep_expired_plugin_gateway_runs,
+)
+from gcloud.taskflow3.apis.django.v4.node_callback import node_callback
+from gcloud.utils import crypto
+from pipeline_plugins.components.utils.sites.open.utils import get_node_callback_url
+
+
+@override_settings(PLUGIN_GATEWAY_ENABLE=False)
+class PluginGatewayDisabledTestCase(TestCase):
+    """开关关闭时不允许向 open_plugin_* 队列投递任何消息。"""
+
+    def setUp(self):
+        PluginGatewaySourceConfig.objects.create(
+            source_key="bkflow",
+            display_name="BKFlow",
+            default_project_id=2001,
+            callback_domain_allow_list=["bkflow.example.com"],
+            is_enabled=True,
+        )
+        self.payload = {
+            "source_key": "bkflow",
+            "plugin_id": "plugin_job_execute",
+            "plugin_version": "1.2.0",
+            "client_request_id": "task_1_node_1_attempt_1",
+            "callback_url": "https://bkflow.example.com/callback",
+            "callback_token": "token-001",
+            "inputs": {"biz_id": 2},
+        }
+
+    def _create_run(self, **overrides):
+        defaults = {
+            "source_key": "bkflow",
+            "plugin_id": "plugin_job_execute",
+            "plugin_version": "1.2.0",
+            "client_request_id": "task_1_node_1_attempt_1",
+            "open_plugin_run_id": "4f3c2b1a0d9e8f7766554433221100aa",
+            "callback_url": "https://bkflow.example.com/callback",
+            "callback_token": crypto.encrypt("token-001"),
+            "run_status": PluginGatewayRun.Status.RUNNING,
+            "caller_app_code": "bkflow-app",
+            "trigger_payload": {"project_id": 2001},
+        }
+        defaults.update(overrides)
+        return PluginGatewayRun.objects.create(**defaults)
+
+    @patch("gcloud.plugin_gateway.services.execution.dispatch_plugin_gateway_run.apply_async")
+    def test_create_run_rejected_without_enqueue(self, mock_dispatch_apply_async):
+        with self.assertRaises(PluginGatewayDisabledError):
+            PluginGatewayExecutionService.create_run("bkflow-app", self.payload)
+
+        mock_dispatch_apply_async.assert_not_called()
+        self.assertFalse(PluginGatewayRun.objects.exists())
+
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayCallbackService.callback_run")
+    def test_sweep_task_does_nothing(self, mock_callback_run):
+        self._create_run(execution_expire_at=timezone.now() - timedelta(seconds=1))
+
+        sweep_expired_plugin_gateway_runs()
+
+        mock_callback_run.assert_not_called()
+
+    @patch("gcloud.plugin_gateway.tasks.poll_plugin_gateway_run.apply_async")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayRunner.run_execute")
+    def test_dispatch_task_does_not_enqueue_polling(self, mock_run_execute, mock_poll_apply_async):
+        run = self._create_run(run_status=PluginGatewayRun.Status.CREATED)
+
+        dispatch_plugin_gateway_run(open_plugin_run_id=run.open_plugin_run_id)
+
+        mock_run_execute.assert_not_called()
+        mock_poll_apply_async.assert_not_called()
+        run.refresh_from_db()
+        self.assertEqual(run.run_status, PluginGatewayRun.Status.CREATED)
+
+    @patch("gcloud.plugin_gateway.tasks.poll_plugin_gateway_run.apply_async")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayRunner.run_schedule")
+    def test_polling_task_does_not_enqueue_next_round(self, mock_run_schedule, mock_poll_apply_async):
+        run = self._create_run()
+
+        poll_plugin_gateway_run(open_plugin_run_id=run.open_plugin_run_id)
+
+        mock_run_schedule.assert_not_called()
+        mock_poll_apply_async.assert_not_called()
+
+    @patch("gcloud.plugin_gateway.tasks.callback_plugin_gateway_run.apply_async")
+    @patch("gcloud.plugin_gateway.tasks.PluginGatewayRunner.run_schedule")
+    def test_callback_task_does_not_enqueue_retry(self, mock_run_schedule, mock_callback_apply_async):
+        run = self._create_run()
+
+        callback_plugin_gateway_run(open_plugin_run_id=run.open_plugin_run_id, callback_data={"result": "ok"})
+
+        mock_run_schedule.assert_not_called()
+        mock_callback_apply_async.assert_not_called()
+
+    @patch("gcloud.taskflow3.apis.django.v4.node_callback.NodeCommandDispatcher")
+    @patch("gcloud.plugin_gateway.tasks.callback_plugin_gateway_run.apply_async")
+    def test_node_callback_does_not_route_to_gateway_queue(
+        self, mock_callback_apply_async, mock_node_command_dispatcher
+    ):
+        run = self._create_run(run_status=PluginGatewayRun.Status.WAITING_CALLBACK)
+        mock_node_command_dispatcher.return_value.dispatch.return_value = {"result": True, "message": "success"}
+        callback_url = get_node_callback_url(
+            root_pipeline_id=run.open_plugin_run_id,
+            node_id=run.open_plugin_run_id,
+            node_version=run.plugin_version,
+        )
+        request = RequestFactory().post("/", data=json.dumps({"state": "SUCCESS"}), content_type="application/json")
+
+        response = node_callback(request, callback_url.rstrip("/").rsplit("/", 1)[-1])
+
+        self.assertEqual(response.status_code, 200)
+        mock_callback_apply_async.assert_not_called()
+
+
+class PluginGatewayBeatScheduleTestCase(TestCase):
+    def test_sweep_beat_schedule_registration_follows_switch(self):
+        """关闭时不注册周期任务，避免 beat 持续向无消费者的队列投递消息。"""
+
+        registered = "sweep_expired_plugin_gateway_runs" in settings.CELERYBEAT_SCHEDULE
+
+        self.assertEqual(registered, settings.PLUGIN_GATEWAY_ENABLE)

--- a/version_logs_md/V3.35.5_2026-08-26.md
+++ b/version_logs_md/V3.35.5_2026-08-26.md
@@ -1,0 +1,9 @@
+# V3.35.5 版本更新说明
+
+### 新增
+
+- [ 新增 ] 插件网关新增总开关 `BKAPP_PLUGIN_GATEWAY_ENABLE`，默认关闭；关闭时不再向 `open_plugin_dispatch` / `open_plugin_polling` / `open_plugin_callback` 投递消息，未部署对应 worker 的环境不会出现队列堆积
+
+### 修复
+
+- [ 修复 ] 清理 `DatabaseScheduler` 中残留的插件网关超时清扫周期任务记录，避免开关关闭后 beat 仍按库内记录投递消息


### PR DESCRIPTION
## 背景

3.35.4 引入的插件网关使用了三条独立队列 `open_plugin_dispatch` / `open_plugin_polling` / `open_plugin_callback`，但 `app_desc.yaml` 里没有对应的 worker 进程定义。

其中 `sweep_expired_plugin_gateway_runs` 由 beat 每 60 秒投递一次，在未部署 worker 的环境里这些消息无人消费，会在 broker 上无限堆积；插件网关自身的调度与回调也会静默失败。

## 改动

新增 `BKAPP_PLUGIN_GATEWAY_ENABLE` 开关（`1/true/yes/on` 开启），**默认关闭**。关闭时不向 `open_plugin_*` 投递任何消息：

| 投递点 | 关闭时行为 |
| --- | --- |
| `CELERYBEAT_SCHEDULE` 的 `sweep_expired_plugin_gateway_runs` | 不注册周期任务 |
| `PluginGatewayExecutionService.create_run` | 抛 `PluginGatewayDisabledError`，不落 run 记录、不投递调度消息 |
| `create_plugin_gateway_run` 网关接口 | 返回 `error_type=gateway_disabled` |
| `plugin_gateway_run_internal_callback` 网关接口 | 返回 `error_type=gateway_disabled` |
| `node_callback` 的插件网关分支 | 不路由到 `open_plugin_callback`（同时省掉每次回调的一次 DB 查询） |
| `dispatch` / `poll` / `callback` 三个 celery 任务 | 入口提前返回，覆盖运行中途关闭开关的场景 |

beat 使用 `django_celery_beat` 的 `DatabaseScheduler`，`CELERYBEAT_SCHEDULE` 的条目会落到 `PeriodicTask` 表且不会随配置移除自动清理。因此补充数据迁移 `plugin_gateway.0005` 删除残留的 `sweep_expired_plugin_gateway_runs` 记录；开关开启时 beat 启动会按配置重新登记，迁移可无条件执行。迁移对 `django_celery_beat` 未安装或表不存在的情况做了保护，不通过 migration 依赖引用第三方 app。

同步更新中英文《插件网关部署指南》，补充开关说明与队列 worker 前置条件。

## 版本号

3.35.4 已经出包但尚未发布，本次修复需要重新出包，因此版本号更新至 **3.35.5**：

- `app.yml` / `app_desc.yaml` / `config/default.py` 的 `STATIC_VERSION`
- 新增 `version_logs_md/V3.35.5_2026-08-26.md`

3.35.3 -> 3.35.4 的完整版本日志见 #8496，本 PR 的版本日志只记录插件网关开关这一项。

## 测试

- 新增 `gcloud/tests/plugin_gateway/test_feature_switch.py`：覆盖关闭状态下创建执行被拒绝且不投递、三个 celery 任务不产生后续投递、超时清扫空转、`node_callback` 不路由到网关队列，以及周期任务注册与开关一致
- 已有插件网关用例补充 `override_settings(PLUGIN_GATEWAY_ENABLE=True)`，保持原有行为覆盖

## 发布注意

- 默认关闭，存量环境发布后行为与 3.35.3 一致
- 需要使用插件网关的环境，先补齐 `open_plugin_*` 三条队列的 worker，再打开 `BKAPP_PLUGIN_GATEWAY_ENABLE`