### PR TITLE
fix: 前端构建增加产物校验并按 lockfile 安装依赖 --bug=162894271

### DIFF
--- a/frontend/desktop/builds/verify-build-artifacts.js
+++ b/frontend/desktop/builds/verify-build-artifacts.js
@@ -1,0 +1,153 @@
+/**
+* Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+* Edition) available.
+* Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+* Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://opensource.org/licenses/MIT
+* Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+* an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations under the License.
+*/
+
+/**
+ * 构建产物校验：拦截 render 函数丢失的组件。
+ *
+ * vue-loader 通过 componentNormalizer(scriptExports, render, staticRenderFns, functionalTemplate, ...)
+ * 注册每个 .vue 组件。构建链路（webpack 模块合并 + terser）曾出现过把 render 实参替换成空函数的情况：
+ * 模板正确编译出的 render 留在模块作用域里成为死代码，注册时传入的却是 function(){}。
+ * 这类组件 render 返回 undefined，Vue 会静默替换成空注释节点——页面整块空白、无 JS 报错、不发任何请求，
+ * 只能靠人工点页面才能发现，因此必须在构建阶段卡住。
+ *
+ * 用法：
+ *   node builds/verify-build-artifacts.js [产物目录]
+ * 目录默认为 builds/../static，也可指向解包后的发布包目录，用于校验已产出的 tar 包。
+ */
+const fs = require('fs')
+const path = require('path')
+
+// render 实参为空函数的组件注册调用。第三个实参 [] 与第四个布尔实参共同构成
+// componentNormalizer 的签名特征，用于避免误伤普通函数调用。
+const EMPTY_RENDER_CALL = /(?:\(\s*0\s*,\s*[\w$]+(?:\.[\w$]+)+\s*\)|[\w$]+(?:\.[\w$]+)*)\(\s*[\w$]+\s*,\s*(?:function\s*\(\s*\)\s*\{\s*\}|\(\s*\)\s*=>\s*\{\s*\})\s*,\s*\[\s*\]\s*,\s*(?:!1|!0|false|true)\s*,/g
+
+// 组件注册调用的尾部特征：staticRenderFns、functionalTemplate、injectStyles、scopeId、moduleIdentifier。
+// 不依赖 render 实参内容，因此可用来判断本脚本的匹配规则是否仍然适用于当前构建产物。
+const NORMALIZER_CALL_TAIL = /,\s*(?:\[\s*\]|[\w$]+)\s*,\s*(?:!1|!0|false|true)\s*,\s*(?:null|[\w$]+)\s*,\s*(?:"[0-9a-f]{6,}"|null)\s*,\s*(?:null|"[^"]*")\s*\)/g
+
+// webpack moduleIds: 'named' 会把模块路径保留在产物里，用于把问题定位到具体组件。
+const MODULE_HEADER = /"(\.\/(?:src|node_modules)\/[^"]+)"\s*\(/g
+
+function collectJsFiles (dir) {
+    const files = []
+    const walk = (current) => {
+        for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+            const full = path.join(current, entry.name)
+            if (entry.isDirectory()) {
+                walk(full)
+            } else if (entry.name.endsWith('.js')) {
+                files.push(full)
+            }
+        }
+    }
+    walk(dir)
+    return files
+}
+
+function findEnclosingModule (moduleOffsets, offset) {
+    let low = 0
+    let high = moduleOffsets.length - 1
+    let found = null
+    while (low <= high) {
+        const mid = (low + high) >> 1
+        if (moduleOffsets[mid].offset <= offset) {
+            found = moduleOffsets[mid].name
+            low = mid + 1
+        } else {
+            high = mid - 1
+        }
+    }
+    return found
+}
+
+function inspectFile (file) {
+    const source = fs.readFileSync(file, 'utf8')
+
+    NORMALIZER_CALL_TAIL.lastIndex = 0
+    let normalizerCalls = 0
+    while (NORMALIZER_CALL_TAIL.exec(source) !== null) {
+        normalizerCalls += 1
+    }
+
+    const moduleOffsets = []
+    MODULE_HEADER.lastIndex = 0
+    let moduleMatch
+    while ((moduleMatch = MODULE_HEADER.exec(source)) !== null) {
+        moduleOffsets.push({ offset: moduleMatch.index, name: moduleMatch[1] })
+    }
+
+    const offenders = []
+    EMPTY_RENDER_CALL.lastIndex = 0
+    let emptyMatch
+    while ((emptyMatch = EMPTY_RENDER_CALL.exec(source)) !== null) {
+        offenders.push({
+            module: findEnclosingModule(moduleOffsets, emptyMatch.index) || '(未能定位所属模块)',
+            offset: emptyMatch.index
+        })
+    }
+
+    return { normalizerCalls, offenders }
+}
+
+function main () {
+    const target = path.resolve(process.argv[2] || path.join(__dirname, '..', 'static'))
+
+    if (!fs.existsSync(target)) {
+        console.error(`[verify-build-artifacts] 产物目录不存在: ${target}`)
+        process.exit(1)
+    }
+
+    const files = collectJsFiles(target)
+    if (files.length === 0) {
+        console.error(`[verify-build-artifacts] 目录下没有 .js 产物，请确认已执行构建: ${target}`)
+        process.exit(1)
+    }
+
+    let normalizerCalls = 0
+    const offendersByFile = new Map()
+
+    for (const file of files) {
+        const result = inspectFile(file)
+        normalizerCalls += result.normalizerCalls
+        if (result.offenders.length > 0) {
+            offendersByFile.set(file, result.offenders)
+        }
+    }
+
+    console.log(`[verify-build-artifacts] 扫描 ${files.length} 个 js 产物，识别到 ${normalizerCalls} 处组件注册调用`)
+
+    if (normalizerCalls === 0) {
+        console.error('[verify-build-artifacts] 未识别到任何组件注册调用。')
+        console.error('  构建链路的产物形态可能已变化，本脚本的匹配规则需要同步更新，否则将失去防护作用。')
+        process.exit(1)
+    }
+
+    if (offendersByFile.size === 0) {
+        console.log('[verify-build-artifacts] 校验通过：没有 render 为空的组件')
+        return
+    }
+
+    let total = 0
+    console.error('\n[verify-build-artifacts] 校验失败：以下组件的 render 在构建产物中为空函数，运行时会渲染为空白且不报错\n')
+    for (const [file, offenders] of offendersByFile) {
+        total += offenders.length
+        console.error(`  ${path.relative(target, file)}  (${offenders.length} 处)`)
+        for (const item of new Set(offenders.map(o => o.module))) {
+            console.error(`      ${item}`)
+        }
+    }
+    console.error(`\n  共 ${total} 处。处置建议：清理 node_modules 与构建缓存，用 npm ci 按 lockfile 重装依赖后重新构建；`)
+    console.error('  若重建后仍复现，请对比构建工具链（webpack / terser-webpack-plugin / vue-loader）的实际安装版本。\n')
+    process.exit(1)
+}
+
+main()

--- a/frontend/desktop/package-lock.json
+++ b/frontend/desktop/package-lock.json
@@ -58,7 +58,7 @@
         "xss": "^1.0.15"
       },
       "devDependencies": {
-        "@babel/core": "^7.4.5",
+        "@babel/core": "7.29.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-decorators": "^7.0.0",
         "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
@@ -79,7 +79,7 @@
         "acorn": "^6.1.1",
         "babel-core": "^7.0.0-bridge.0",
         "babel-eslint": "^8.2.6",
-        "babel-loader": "^8.0.0",
+        "babel-loader": "8.4.1",
         "babel-plugin-component": "^1.1.1",
         "babel-plugin-dynamic-import-node": "^2.3.0",
         "babel-plugin-transform-vue-jsx": "^3.7.0",
@@ -111,15 +111,15 @@
         "sass-loader": "^14.1.1",
         "script-loader": "^0.7.2",
         "style-loader": "^3.3.4",
-        "terser-webpack-plugin": "^5.3.10",
+        "terser-webpack-plugin": "5.6.0",
         "url-loader": "^4.1.1",
         "vue-content-loader": "^0.2.3",
         "vue-json-pretty": "1.8.3",
-        "vue-loader": "^15.10.1",
-        "webpack": "^5.91.0",
-        "webpack-cli": "^5.1.4",
+        "vue-loader": "15.11.1",
+        "webpack": "5.106.2",
+        "webpack-cli": "5.1.4",
         "webpack-dev-server": "^5.0.4",
-        "webpack-merge": "^5.10.0",
+        "webpack-merge": "5.10.0",
         "worker-loader": "^3.0.8",
         "write-file-webpack-plugin": "^4.3.2"
       }

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "dev": "cross-env NODE_ENV=development webpack-dev-server --config ./builds/webpack.dev.config.js",
-    "build": "cross-env NODE_ENV=production webpack --config ./builds/webpack.prod.config.js"
+    "build": "cross-env NODE_ENV=production webpack --config ./builds/webpack.prod.config.js && npm run verify:artifacts",
+    "verify:artifacts": "node ./builds/verify-build-artifacts.js"
   },
   "author": "",
   "license": "ISC",
@@ -59,7 +60,7 @@
     "xss": "^1.0.15"
   },
   "devDependencies": {
-    "@babel/core": "^7.4.5",
+    "@babel/core": "7.29.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
     "@babel/plugin-proposal-decorators": "^7.0.0",
     "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
@@ -80,7 +81,7 @@
     "acorn": "^6.1.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^8.2.6",
-    "babel-loader": "^8.0.0",
+    "babel-loader": "8.4.1",
     "babel-plugin-component": "^1.1.1",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "babel-plugin-transform-vue-jsx": "^3.7.0",
@@ -112,15 +113,15 @@
     "sass-loader": "^14.1.1",
     "script-loader": "^0.7.2",
     "style-loader": "^3.3.4",
-    "terser-webpack-plugin": "^5.3.10",
+    "terser-webpack-plugin": "5.6.0",
     "url-loader": "^4.1.1",
     "vue-content-loader": "^0.2.3",
     "vue-json-pretty": "1.8.3",
-    "vue-loader": "^15.10.1",
-    "webpack": "^5.91.0",
-    "webpack-cli": "^5.1.4",
+    "vue-loader": "15.11.1",
+    "webpack": "5.106.2",
+    "webpack-cli": "5.1.4",
     "webpack-dev-server": "^5.0.4",
-    "webpack-merge": "^5.10.0",
+    "webpack-merge": "5.10.0",
     "worker-loader": "^3.0.8",
     "write-file-webpack-plugin": "^4.3.2"
   },

--- a/scripts/generate_frontend_files.sh
+++ b/scripts/generate_frontend_files.sh
@@ -12,7 +12,9 @@ echo $STATIC_DIR
 # build frontend files
 if [ -n "$1" ]; then
   cd frontend/desktop
-  npm install
+  # 必须按 lockfile 安装：npm install 会在 package.json 的版本范围内重新解析依赖，
+  # 曾导致同一份源码在不同时间构建出行为不同的产物。
+  npm ci
   npm run build -- --STATIC_ENV=dev
   cd ../..
   if [ -d "$STATIC_DIR/bk_sops" ]; then


### PR DESCRIPTION
## 背景

3.35.5 升级后「流程」页内容区完全空白：浏览器控制台无报错，F12 网络面板看不到流程列表接口请求，3.35.4 正常，其他页面（任务记录等）不受影响。

排查结论：**这是前端构建产物缺陷，与业务代码逻辑无关。**

3.35.5 包的 chunk `268.d522fb346d.js` 中，webpack 模块 `./src/pages/template/TemplateList/index.vue`（模块合并后内联了整棵流程列表页组件树，共 10 个组件）在调用 vue-loader 的 `componentNormalizer()` 注册组件时，**render 实参全部被传成空函数 `function(){}`、staticRenderFns 全部为 `[]`**。模板正确编译出的 render 保留在模块作用域内但从未被引用，成为死代码：

```js
var r = function(){ ... return t("div",{staticClass:"tpl-list-page"}, ...) }, i = [];   // 真实 render，未被使用
...
var Hle = (0, me.A)(zle, function(){}, [], !1, null, "56800dcf", null);                 // 注册时传入空函数
```

render 返回 undefined 后 Vue 会静默替换为空注释节点，因此表现为整块空白、无异常抛出、组件不挂载也就不发起接口请求。

## 定位证据

1. **线上实测**：`TplListPage` 实例已挂载（`_isMounted=true`）但 `$el` 为注释节点；手动调用 `_render()` 返回空注释且不抛异常；其 Ctor render 源码为 `function(){}`，而正常组件（`Navigation`）为完整编译产物。
2. **排除其他因素**：`window.DEFAULT_PROJECT_ID=50`、路由匹配 `processHome`、`isRouterViewShow=true`、`authActions` 含 `project_view`/`flow_create`、`api/v3/project/50/` 返回 200、全部静态资源 200，路由/权限/项目上下文均正常。
3. **包级对比**：扫描两个包全部 205 个 js 产物，「render 为空的组件注册」在 3.35.4 中为 **0 处**，在 3.35.5 中为 **10 处**且全部集中在 chunk 268。
4. **输入源码一致性**：chunk 268 的 source map 显示两个版本均为 60 个模块、**内容零差异、无增删**，流程列表页 10 个组件源码完全一致。即同样的输入源码产出了不同的产物。
5. **构建不确定性来源**：`scripts/generate_frontend_files.sh` 使用 `npm install` 而非 `npm ci`；`package.json` 中 47 个 dependencies 有 37 个、64 个 devDependencies 有 61 个使用 caret 范围。source map 对比可见 `axios` 在两次构建之间确实发生了版本漂移（新增 `methodList.js`、`normalizeURLForProtocolCheck.js`，另有 14 个模块内容不同），而 git 中的 lockfile 在两次构建期间未变更（最后一次改动为 8/21 的 #8486，两次构建分别在 8/25 与 8/26）。

## 改动内容

1. 新增 `frontend/desktop/builds/verify-build-artifacts.js`：扫描构建产物中 render 为空的组件注册，命中即构建失败，并定位到具体的 `.vue` 模块。脚本自带**规则失效自检**——若识别不到任何组件注册调用（例如工具链升级改变了产物形态），同样失败退出，避免防护静默失效。
2. 将校验挂到 `npm run build` 之后，使其覆盖所有构建路径（包含内部发布流水线，而不仅是 GitHub Actions）；同时提供 `npm run verify:artifacts`，可直接校验已产出的发布包。
3. `scripts/generate_frontend_files.sh` 改用 `npm ci`，严格按 lockfile 安装。
4. 锁定决定产物形态的构建工具链版本：`webpack`、`terser-webpack-plugin`、`vue-loader`、`babel-loader`、`@babel/core`、`webpack-cli`、`webpack-merge`。锁定值取自 lockfile 中已解析的版本，因此 lockfile 仅同步根节点的声明范围（7 行），不改变实际安装的版本。

## 验证

用两个真实发布包验证校验脚本，行为符合预期：

```
$ node builds/verify-build-artifacts.js <3.35.4 产物目录>
[verify-build-artifacts] 扫描 107 个 js 产物，识别到 311 处组件注册调用
[verify-build-artifacts] 校验通过：没有 render 为空的组件
EXIT=0

$ node builds/verify-build-artifacts.js <3.35.5 产物目录>
[verify-build-artifacts] 扫描 107 个 js 产物，识别到 311 处组件注册调用
[verify-build-artifacts] 校验失败：以下组件的 render 在构建产物中为空函数，运行时会渲染为空白且不报错
  268.d522fb346d.js  (10 处)
      ./src/pages/template/TemplateList/index.vue
EXIT=1
```

两个包都识别出相同的 311 处组件注册调用（自检通过），差异仅在空 render 数量。

其他边界情况已验证：产物目录不存在、目录下无 js 产物、产物中识别不到组件注册调用，三种情况均以非 0 退出并给出明确提示。

## 发布注意

- **3.35.5 包不可直接发布**，需按本 PR 的流程重新构建并通过产物校验后再发。
- 工具链锁定值取自当前 lockfile，尚未确认其中是否已包含引发本问题的版本。若重建后校验仍然失败，则说明 lockfile 中的工具链版本本身有问题，需要定向升降级——此时校验会明确失败而非静默产出坏包，这正是本 PR 的目的。

## 遗留项（本 PR 未处理）

- `vue` 固定为 `2.7.14`，而 lockfile 中 `vue-template-compiler` 为 `2.7.16`，模板编译器与运行时版本不一致。修正需要重新生成 lockfile，风险与本 PR 不同，建议单独处理。
- `.github/workflows/eslint.yml` 仍使用 `npm install` 且 node 版本为 12（npm 6 对 lockfileVersion 3 支持不佳），该 workflow 只做 lint、不产出产物，未一并调整。

Made with [Cursor](https://cursor.com)