### PR TITLE
fix: 锁定 terser 版本修复流程页空白 --bug=162894271

### DIFF
--- a/frontend/desktop/builds/verify-build-artifacts.js
+++ b/frontend/desktop/builds/verify-build-artifacts.js
@@ -19,6 +19,9 @@
  * 这类组件 render 返回 undefined，Vue 会静默替换成空注释节点——页面整块空白、无 JS 报错、不发任何请求，
  * 只能靠人工点页面才能发现，因此必须在构建阶段卡住。
  *
+ * 已知触发条件：terser 5.51.1 会让 TemplateList/index.vue 出现该问题，5.47.1 正常。
+ * terser 由 terser-webpack-plugin 以范围依赖引入，因此 package.json 把它锁成精确版本。
+ *
  * 用法：
  *   node builds/verify-build-artifacts.js [产物目录]
  * 目录默认为 builds/../static，也可指向解包后的发布包目录，用于校验已产出的 tar 包。
@@ -145,8 +148,11 @@ function main () {
             console.error(`      ${item}`)
         }
     }
-    console.error(`\n  共 ${total} 处。处置建议：清理 node_modules 与构建缓存，用 npm ci 按 lockfile 重装依赖后重新构建；`)
-    console.error('  若重建后仍复现，请对比构建工具链（webpack / terser-webpack-plugin / vue-loader）的实际安装版本。\n')
+    console.error(`\n  共 ${total} 处。首先确认 terser 的实际安装版本：`)
+    console.error('      node -p "require(\'terser/package.json\').version"   # 期望与 package.json 中锁定的版本一致')
+    console.error('  若不一致，说明依赖解析没有按 package.json 生效（例如构建机 npm 版本过低、读不懂 lockfileVersion 3），')
+    console.error('  需清理 node_modules 与 npm 缓存后重装；能用 npm ci 的环境优先用 npm ci。')
+    console.error('  若版本一致仍复现，再对比 webpack / terser-webpack-plugin / vue-loader 的实际安装版本。\n')
     process.exit(1)
 }
 

--- a/frontend/desktop/package-lock.json
+++ b/frontend/desktop/package-lock.json
@@ -111,6 +111,7 @@
         "sass-loader": "^14.1.1",
         "script-loader": "^0.7.2",
         "style-loader": "^3.3.4",
+        "terser": "5.47.1",
         "terser-webpack-plugin": "5.6.0",
         "url-loader": "^4.1.1",
         "vue-content-loader": "^0.2.3",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -113,6 +113,7 @@
     "sass-loader": "^14.1.1",
     "script-loader": "^0.7.2",
     "style-loader": "^3.3.4",
+    "terser": "5.47.1",
     "terser-webpack-plugin": "5.6.0",
     "url-loader": "^4.1.1",
     "vue-content-loader": "^0.2.3",
@@ -128,6 +129,7 @@
   "overrides": {
     "node-forge": "^1.4.0",
     "flatted": "^3.4.2",
-    "picomatch": "^4.0.4"
+    "picomatch": "^4.0.4",
+    "terser": "5.47.1"
   }
 }


### PR DESCRIPTION
## 背景

3.35.5 上线后「流程」列表页整块空白：页面能打开、静态资源全部加载成功、控制台无任何报错、也不发起列表接口请求。#8498 加的产物校验已经把问题定位到 `TemplateList/index.vue` 的 render 在产物里变成了空函数，但没有解决触发原因——校验在最近一次流水线构建中如期失败：

```
[verify-build-artifacts] 校验失败：以下组件的 render 在构建产物中为空函数，运行时会渲染为空白且不报错
  js/268.346c19e6e7.js  (10 处)
      ./src/pages/template/TemplateList/index.vue
```

## 根因

`terser` 的压缩回归。`vue-loader` 通过 `componentNormalizer(scriptExports, render, staticRenderFns, ...)` 注册组件，terser 5.51.1 会把这里的 `render` 实参替换成 `function(){}`，模板编译出的真实 render 留在模块作用域里成了死代码。组件 render 返回 `undefined`，Vue 静默替换为空注释节点，所以表现为页面空白且零报错。

本地定向验证（同一份代码、同一 webpack 5.106.2）：

| terser | 校验结果 |
| --- | --- |
| 5.47.1 | 通过 |
| 5.51.1 | 失败，chunk 268 出现 10 处空 render |

`terser` 不是直接依赖，而是 `terser-webpack-plugin` 以 `^5.31.1` 引入的。构建机是 node 14.19.1 / npm 6.14.16，日志里明确提示读不懂 lockfile：

```
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1,
but package-lock.json was generated for lockfileVersion@3. I'll try to do my best with it!
```

npm 6 因此绕过 lockfile，按范围解析到 registry 上的最新版 5.51.1。这也解释了为什么 #8498 里改的 `generate_frontend_files.sh`（`npm install` → `npm ci`）没有生效：流水线用的是自己的内联脚本 `npm install --legacy-peer-deps`，并不调用该脚本。

## 改动

把 `terser` 提为精确版本的直接 devDependency，并同步加进 `overrides`：

- 直接依赖：npm 6 也一定会按精确版本装在根目录，`terser-webpack-plugin` 的 `^5.31.1` 被 5.47.1 满足从而去重，不产生嵌套副本；
- `overrides`：给支持它的新版 npm 多一层保险（npm 6 会忽略该字段，无副作用）。

同时把校验脚本的处置建议改为先核对 terser 实际版本，原来的「用 npm ci 重装」在 npm 6 的构建机上做不到。

## 验证

- 用与构建机同版本的 npm 6.14.16 实测解析结果：全树仅一份 `node_modules/terser`，版本 5.47.1，`terser-webpack-plugin` 解析到的正是这一份，无嵌套副本。
- 精确锁定在该流水线确实生效：registry 上 webpack 最新为 5.109.2，而 CI 实际使用的是 #8498 锁定的 5.106.2。
- 本地构建 + 校验通过：`扫描 110 个 js 产物，识别到 311 处组件注册调用 / 校验通过：没有 render 为空的组件`。

## 后续建议（不在本 PR 范围）

构建机的 node 14 / npm 6 是这类依赖漂移的根源。建议流水线侧升级构建镜像的 node/npm，使 lockfileVersion 3 可被正确识别，再把内联脚本的 `npm install --legacy-peer-deps` 换成 `npm ci`，从机制上消除漂移；在那之前依赖本 PR 的精确锁定 + #8498 的产物校验兜底。

Made with [Cursor](https://cursor.com)