### PR TITLE
fix: 优化节点回调重试日志与告警分级

### DIFF
--- a/gcloud/taskflow3/apis/django/v4/node_callback.py
+++ b/gcloud/taskflow3/apis/django/v4/node_callback.py
@@ -27,7 +27,12 @@ import env
 from gcloud.core.trace import CallFrom, start_trace
 from gcloud.plugin_gateway.models import PluginGatewayRun
 from gcloud.plugin_gateway.tasks import callback_plugin_gateway_run
-from gcloud.taskflow3.celery.tasks import async_node_callback_retry, is_schedule_not_found_error, is_sleep_process_error
+from gcloud.taskflow3.celery.tasks import (
+    async_node_callback_retry,
+    get_callback_error_reason,
+    is_schedule_not_found_error,
+    is_sleep_process_error,
+)
 from gcloud.taskflow3.domains.dispatchers import NodeCommandDispatcher
 from gcloud.taskflow3.models import TaskFlowInstance
 
@@ -38,8 +43,6 @@ logger = logging.getLogger("root")
 @csrf_exempt
 @require_POST
 def node_callback(request, token):
-    logger.info("[node_callback]callback body for token({}): {}".format(token, request.body))
-
     try:
         f = Fernet(settings.CALLBACK_KEY)
         back_load = f.decrypt(bytes(token, encoding="utf8")).decode().split(":")
@@ -59,7 +62,7 @@ def node_callback(request, token):
         else:
             logger.error("invalid backload: %s" % back_load)
     except Exception:
-        logger.warning("invalid token %s" % token)
+        logger.warning("[node_callback] outcome=invalid_token")
         return JsonResponse({"result": False, "message": "invalid token"}, status=400)
 
     try:
@@ -89,6 +92,12 @@ def node_callback(request, token):
             taskflow_id = qs[0]["id"]
             project_id = qs[0]["project_id"]
 
+    payload_keys = sorted(callback_data.keys()) if isinstance(callback_data, dict) else []
+    logger.info(
+        "[node_callback] outcome=received engine_ver={} taskflow_id={} node_id={} node_version={} "
+        "payload_keys={}".format(engine_ver, taskflow_id, node_id, node_version, payload_keys)
+    )
+
     dispatchers = NodeCommandDispatcher(engine_ver=engine_ver, node_id=node_id, taskflow_id=taskflow_id)
 
     # 由于回调方不一定会进行多次回调，这里为了在业务层防止出现不可抗力（网络，DB 问题等）导致失败
@@ -99,8 +108,16 @@ def node_callback(request, token):
                 command="callback", operator="", version=node_version, data=callback_data
             )
             logger.info(
-                "result of callback call(token: {} engine_ver: {} node_id: {}, node_version: {}): {}".format(
-                    token, engine_ver, node_id, node_version, callback_result
+                "[node_callback] outcome=attempt_result engine_ver={} taskflow_id={} node_id={} node_version={} "
+                "local_retry_times={} success={} error_reason={} error_code={}".format(
+                    engine_ver,
+                    taskflow_id,
+                    node_id,
+                    node_version,
+                    i,
+                    callback_result.get("result"),
+                    get_callback_error_reason(callback_result),
+                    callback_result.get("code"),
                 )
             )
             if callback_result["result"]:
@@ -115,34 +132,40 @@ def node_callback(request, token):
     if should_async_retry:
         error_type = "sleep process" if is_sleep_process_error(callback_result) else "schedule not found"
         logger.warning(
-            "[node_callback] Local retry failed with {} error, triggering async retry. "
-            "token: {}, engine_ver: {}, node_id: {}, node_version: {}, message: {}".format(
-                error_type, token, engine_ver, node_id, node_version, callback_result.get("message", "")
+            "[node_callback] outcome=async_retry_requested engine_ver={} taskflow_id={} node_id={} "
+            "node_version={} error_type={} error_reason={} error_code={}".format(
+                engine_ver,
+                taskflow_id,
+                node_id,
+                node_version,
+                error_type,
+                get_callback_error_reason(callback_result),
+                callback_result.get("code"),
             )
         )
         try:
             async_node_callback_retry.apply_async(
-                kwargs=dict(
-                    engine_ver=engine_ver,
-                    node_id=node_id,
-                    node_version=node_version,
-                    callback_data=callback_data,
-                    taskflow_id=taskflow_id,
-                    project_id=project_id,
-                    retry_times=0,
-                ),
+                kwargs={
+                    "engine_ver": engine_ver,
+                    "node_id": node_id,
+                    "node_version": node_version,
+                    "callback_data": callback_data,
+                    "taskflow_id": taskflow_id,
+                    "project_id": project_id,
+                    "retry_times": 0,
+                },
                 queue="task_callback",
                 routing_key="task_callback",
                 countdown=env.ASYNC_NODE_CALLBACK_RETRY_INTERVAL,
             )
             logger.info(
-                "[node_callback] Async retry task scheduled successfully. "
-                "token: {}, engine_ver: {}, node_id: {}".format(token, engine_ver, node_id)
+                "[node_callback] outcome=async_retry_scheduled engine_ver={} taskflow_id={} node_id={} "
+                "node_version={}".format(engine_ver, taskflow_id, node_id, node_version)
             )
         except Exception as e:
             logger.exception(
-                "[node_callback] Failed to schedule async retry task. "
-                "token: {}, engine_ver: {}, node_id: {}, error: {}".format(token, engine_ver, node_id, e)
+                "[node_callback] outcome=async_retry_schedule_failed engine_ver={} taskflow_id={} node_id={} "
+                "node_version={} error_type={}".format(engine_ver, taskflow_id, node_id, node_version, type(e).__name__)
             )
 
     return JsonResponse(callback_result)

--- a/gcloud/taskflow3/celery/tasks.py
+++ b/gcloud/taskflow3/celery/tasks.py
@@ -9,6 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+
 import json
 import logging
 import re
@@ -16,6 +17,7 @@ import socket
 import time
 
 import requests
+from bamboo_engine import states as bamboo_engine_states
 from celery import task
 from django.conf import settings
 from django.utils import timezone
@@ -248,6 +250,57 @@ def is_schedule_not_found_error(callback_result):
     )
 
 
+def get_callback_error_reason(callback_result):
+    message = callback_result.get("message", "").lower()
+    if is_sleep_process_error(callback_result):
+        return "sleep_process_missing"
+    if is_schedule_not_found_error(callback_result):
+        return "schedule_not_found"
+    if "schedule is already expired" in message:
+        return "schedule_expired"
+    if "node version" in message and "not exist" in message:
+        return "node_version_not_exist"
+    return "unknown"
+
+
+def get_callback_failure_state_context(engine_ver, node_id, node_version):
+    context = {
+        "outcome": "actionable_callback_failure",
+        "reason": "state_unavailable",
+        "current_node_version": None,
+        "current_node_state": None,
+        "current_node_skip": None,
+    }
+    if engine_ver != EngineConfig.ENGINE_VER_V2:
+        return context
+
+    try:
+        current_state = BambooDjangoRuntime().get_state_or_none(node_id)
+    except Exception:
+        context["reason"] = "state_lookup_failed"
+        return context
+
+    if current_state is None:
+        context["reason"] = "state_not_found"
+        return context
+
+    context.update(
+        {
+            "current_node_version": current_state.version,
+            "current_node_state": current_state.name,
+            "current_node_skip": current_state.skip,
+        }
+    )
+    if current_state.version != node_version:
+        context.update({"outcome": "stale_callback_ignored", "reason": "node_version_mismatch"})
+    elif current_state.name in {bamboo_engine_states.FINISHED, bamboo_engine_states.REVOKED}:
+        context.update({"outcome": "stale_callback_ignored", "reason": "node_already_terminal"})
+    else:
+        context["reason"] = "active_node_retry_exhausted"
+
+    return context
+
+
 @task
 def async_node_callback_retry(
     engine_ver, node_id, node_version, callback_data, taskflow_id=None, project_id=None, retry_times=0
@@ -277,19 +330,27 @@ def async_node_callback_retry(
     ):
         callback_result = dispatcher.dispatch(command="callback", operator="", version=node_version, data=callback_data)
 
+        error_reason = get_callback_error_reason(callback_result)
         logger.info(
-            "[async_node_callback_retry] result of callback call(engine_ver: {} node_id: {}, "
-            "taskflow_id: {}, node_version: {}, retry_times: {}): {}".format(
-                engine_ver, node_id, taskflow_id, node_version, retry_times, callback_result
+            "[async_node_callback_retry] outcome=attempt_result engine_ver={} taskflow_id={} node_id={} "
+            "callback_node_version={} retry_times={} success={} error_reason={} error_code={}".format(
+                engine_ver,
+                taskflow_id,
+                node_id,
+                node_version,
+                retry_times,
+                callback_result.get("result"),
+                error_reason,
+                callback_result.get("code"),
             )
         )
 
         # 如果成功，直接返回
         if callback_result.get("result"):
             logger.info(
-                "[async_node_callback_retry] callback success after async retry, "
-                "engine_ver: {}, node_id: {}, taskflow_id: {}, retry_times: {}".format(
-                    engine_ver, node_id, taskflow_id, retry_times
+                "[async_node_callback_retry] outcome=success engine_ver={} taskflow_id={} node_id={} "
+                "callback_node_version={} retry_times={}".format(
+                    engine_ver, taskflow_id, node_id, node_version, retry_times
                 )
             )
             return callback_result
@@ -297,35 +358,50 @@ def async_node_callback_retry(
         # 如果失败且错误信息中包含 sleep process 相关错误，且未达到最大重试次数，继续异步重试
         if is_sleep_process_error(callback_result) and retry_times < MAX_ASYNC_RETRY_TIMES:
             logger.warning(
-                "[async_node_callback_retry] Sleep process error detected, scheduling next async retry. "
-                "engine_ver: {}, node_id: {}, taskflow_id: {}, node_version: {}, retry_times: {}, message: {}. ".format(
+                "[async_node_callback_retry] outcome=retry_scheduled engine_ver={} taskflow_id={} node_id={} "
+                "callback_node_version={} retry_times={} error_reason={} error_code={}".format(
                     engine_ver,
-                    node_id,
                     taskflow_id,
+                    node_id,
                     node_version,
                     retry_times,
-                    callback_result.get("message", ""),
+                    error_reason,
+                    callback_result.get("code"),
                 )
             )
             async_node_callback_retry.apply_async(
-                kwargs=dict(
-                    engine_ver=engine_ver,
-                    node_id=node_id,
-                    node_version=node_version,
-                    callback_data=callback_data,
-                    taskflow_id=taskflow_id,
-                    project_id=project_id,
-                    retry_times=retry_times + 1,
-                ),
+                kwargs={
+                    "engine_ver": engine_ver,
+                    "node_id": node_id,
+                    "node_version": node_version,
+                    "callback_data": callback_data,
+                    "taskflow_id": taskflow_id,
+                    "project_id": project_id,
+                    "retry_times": retry_times + 1,
+                },
                 queue="task_callback",
                 routing_key="task_callback",
                 countdown=env.ASYNC_NODE_CALLBACK_RETRY_INTERVAL,
             )
         else:
-            logger.error(
-                "[async_node_callback_retry] callback failed after async retry, "
-                "engine_ver: {}, node_id: {}, taskflow_id: {},retry_times: {}, result: {}".format(
-                    engine_ver, node_id, taskflow_id, retry_times, callback_result
+            state_context = get_callback_failure_state_context(engine_ver, node_id, node_version)
+            log = logger.warning if state_context["outcome"] == "stale_callback_ignored" else logger.error
+            log(
+                "[async_node_callback_retry] outcome={} reason={} engine_ver={} taskflow_id={} node_id={} "
+                "callback_node_version={} current_node_version={} current_node_state={} current_node_skip={} "
+                "retry_times={} error_reason={} error_code={}".format(
+                    state_context["outcome"],
+                    state_context["reason"],
+                    engine_ver,
+                    taskflow_id,
+                    node_id,
+                    node_version,
+                    state_context["current_node_version"],
+                    state_context["current_node_state"],
+                    state_context["current_node_skip"],
+                    retry_times,
+                    error_reason,
+                    callback_result.get("code"),
                 )
             )
 
@@ -534,7 +610,6 @@ def truncate_error_analysis_content(content, max_bytes=4000) -> str:
 
 
 def get_ai_analysis_notify_group_config(ai_analysis_notify_group: dict, msg_type: str) -> tuple:
-
     """
     AI分析报告群聊通知配置
     """

--- a/gcloud/tests/taskflow3/tasks/test_async_node_callback_retry.py
+++ b/gcloud/tests/taskflow3/tasks/test_async_node_callback_retry.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+from mock import MagicMock, patch
+
+from gcloud.taskflow3.celery.tasks import async_node_callback_retry
+
+
+class AsyncNodeCallbackRetryTestCase(SimpleTestCase):
+    engine_ver = 2
+    node_id = "node_id"
+    node_version = "callback_version"
+    taskflow_id = 1
+    project_id = 2
+
+    def _run_retry(self, current_state, retry_times=3):
+        callback_result = {
+            "result": False,
+            "message": (
+                "fail: Traceback (most recent call last):\n"
+                "InvalidOperationError: can not find sleep process with current node id: node_id"
+            ),
+            "code": 3599999,
+        }
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = callback_result
+        runtime = MagicMock()
+        runtime.get_state_or_none.return_value = current_state
+        trace_context = MagicMock()
+
+        with patch("gcloud.taskflow3.celery.tasks.NodeCommandDispatcher", return_value=dispatcher):
+            with patch("gcloud.taskflow3.celery.tasks.BambooDjangoRuntime", return_value=runtime):
+                with patch("gcloud.taskflow3.celery.tasks.start_trace", return_value=trace_context):
+                    with self.assertLogs("celery", level="WARNING") as captured:
+                        result = async_node_callback_retry(
+                            engine_ver=self.engine_ver,
+                            node_id=self.node_id,
+                            node_version=self.node_version,
+                            callback_data={"status": 3},
+                            taskflow_id=self.taskflow_id,
+                            project_id=self.project_id,
+                            retry_times=retry_times,
+                        )
+
+        return result, "\n".join(captured.output)
+
+    def test_stale_callback_is_not_logged_as_actionable_failure(self):
+        current_state = SimpleNamespace(version="current_version", name="FINISHED", skip=False)
+
+        result, logs = self._run_retry(current_state)
+
+        self.assertFalse(result["result"])
+        self.assertIn("outcome=stale_callback_ignored", logs)
+        self.assertIn("reason=node_version_mismatch", logs)
+        self.assertIn("callback_node_version=callback_version", logs)
+        self.assertIn("current_node_version=current_version", logs)
+        self.assertNotIn("outcome=actionable_callback_failure", logs)
+
+    def test_finished_current_version_is_logged_as_stale_callback(self):
+        current_state = SimpleNamespace(version=self.node_version, name="FINISHED", skip=True)
+
+        _, logs = self._run_retry(current_state)
+
+        self.assertIn("outcome=stale_callback_ignored", logs)
+        self.assertIn("reason=node_already_terminal", logs)
+        self.assertIn("current_node_skip=True", logs)
+
+    def test_active_current_version_keeps_actionable_error_log(self):
+        current_state = SimpleNamespace(version=self.node_version, name="RUNNING", skip=False)
+
+        _, logs = self._run_retry(current_state)
+
+        self.assertIn("outcome=actionable_callback_failure", logs)
+        self.assertIn("reason=active_node_retry_exhausted", logs)
+        self.assertIn("error_reason=sleep_process_missing", logs)
+        self.assertNotIn("callback failed after async retry", logs)
+
+    def test_retry_scheduled_log_does_not_repeat_traceback(self):
+        current_state = SimpleNamespace(version=self.node_version, name="RUNNING", skip=False)
+
+        _, logs = self._run_retry(current_state, retry_times=0)
+
+        self.assertIn("outcome=retry_scheduled", logs)
+        self.assertIn("error_reason=sleep_process_missing", logs)
+        self.assertNotIn("Traceback", logs)

--- a/gcloud/tests/taskflow3/test_node_callback_v4.py
+++ b/gcloud/tests/taskflow3/test_node_callback_v4.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+import json
+
+from cryptography.fernet import Fernet
+from django.test import RequestFactory, SimpleTestCase
+from mock import MagicMock, patch
+
+from gcloud.taskflow3.apis.django.v4.node_callback import node_callback
+
+
+class NodeCallbackV4LogTestCase(SimpleTestCase):
+    def test_callback_log_does_not_expose_token_or_payload_values(self):
+        callback_key = Fernet.generate_key()
+        token = Fernet(callback_key).encrypt(b"2:node_id:node_version").decode()
+        secret_value = "do-not-write-this-value-to-log"
+        request = RequestFactory().post(
+            "/taskflow/api/v4/nodes/callback/{}/".format(token),
+            data=json.dumps({"job_instance_id": 1, "status": 3, "secret": secret_value}),
+            content_type="application/json",
+        )
+        dispatcher = MagicMock()
+        dispatcher.dispatch.return_value = {"result": True, "message": "success", "code": 0}
+        trace_context = MagicMock()
+
+        with self.settings(CALLBACK_KEY=callback_key):
+            with patch("gcloud.taskflow3.apis.django.v4.node_callback.NodeCommandDispatcher", return_value=dispatcher):
+                with patch("gcloud.taskflow3.apis.django.v4.node_callback.start_trace", return_value=trace_context):
+                    with self.assertLogs("root", level="INFO") as captured:
+                        response = node_callback(request, token)
+
+        logs = "\n".join(captured.output)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("outcome=received", logs)
+        self.assertIn("node_id=node_id", logs)
+        self.assertIn("node_version=node_version", logs)
+        self.assertIn("payload_keys=['job_instance_id', 'secret', 'status']", logs)
+        self.assertNotIn(token, logs)
+        self.assertNotIn(secret_value, logs)


### PR DESCRIPTION
## 变更说明

- 将 async_node_callback_retry 的模糊失败日志改为结构化 outcome/reason 字段，并区分重试中、成功、过期回调和需要处理的真实失败。
- 异步重试耗尽后读取 engine v2 当前节点状态：版本不一致或节点已 FINISHED/REVOKED 时记录 stale_callback_ignored；节点仍活跃、状态缺失或查询失败时记录 actionable_callback_failure。
- 节点回调入口不再记录 token、原始请求体和完整 callback_result，仅保留 payload key、任务/节点标识、错误分类和错误码。
- 告警规则应从旧关键字 callback failed after async retry 切换为 outcome=actionable_callback_failure。

## 验证

- 回调相关测试：22 passed。
- Black、isort、Flake8、git diff --check 通过。
- 完整后端套件：998 tests，996 通过；2 个 Nodeman 组件导入错误已在纯净 upstream/master 上分别复现，属于基线问题，与本变更无关。

## 关联

- TAPD: https://tapd.woa.com/10131351/prong/stories/view/1010131351128811166
