### PR TITLE
fix: 保持系统上下文持久化兼容并支持隔离渲染

### DIFF
--- a/.ai/review/knowledge.md
+++ b/.ai/review/knowledge.md
@@ -3,7 +3,7 @@
 ## 分支基线
 
 - 核验日期：2026-09-09；目标 `master`；base SHA `8c62c86cca084a7938d5449a428eaafbbb71a81f`。仓库默认分支当前是 `release_humming_bird`；这里的 master 名称不代表 GitHub 工作流执行入口。
-- `runtime.txt` 为 `python-3.6.12`；`requirements.txt` 锁定 `Django==3.2.25`、`bamboo-pipeline==3.24.18`、`celery==4.4.0`、`blueapps[opentelemetry,bkcrypto]==4.14.0`。不能按 humming_bird 的 Python 3.11/Django 4 或旧 LTS 的更早引擎版本审查。
+- `runtime.txt` 为 `python-3.6.12`；`requirements.txt` 锁定 `Django==3.2.25`、`bamboo-pipeline==3.24.19`、`celery==4.4.0`、`blueapps[opentelemetry,bkcrypto]==4.14.0`。不能按 humming_bird 的 Python 3.11/Django 4 或旧 LTS 的更早引擎版本审查。
 - 本分支仍无 Project.tenant_id 和多租户 IAM client/resource 构造；新增隔离需求应按实际需求检查，不能把 dev_multi_tenant 的字段/能力当成本分支已存在。
 
 ## 当前 API、MCP 与插件网关

--- a/.ai/review/rules.md
+++ b/.ai/review/rules.md
@@ -4,7 +4,7 @@
 
 ## master 专属约束
 
-本分支 Python 3.6.12、Django 3.2.25、Celery 4.4 和 bamboo-pipeline 3.24.18 仍是兼容基线；同时已有 plugin_gateway/MCP 能力。不能以存在新模块就升级应用语法/依赖假设，也不能以旧运行时就认定新模块缺失。
+本分支 Python 3.6.12、Django 3.2.25、Celery 4.4 和 bamboo-pipeline 3.24.19 仍是兼容基线；同时已有 plugin_gateway/MCP 能力。不能以存在新模块就升级应用语法/依赖假设，也不能以旧运行时就认定新模块缺失。
 
 - APIGW 创建追踪 `gcloud/apigw/views/create_task.py`、`task_node_selector.py`、schema/validator、IAM、TaskFlowInstance、审计 on_commit 及返回。核对显式树/模板路径、方案互斥/节点范围、变量配置与转换值、代理执行身份和审计来源；现有多选默认值转换须看当前测试，不复述旧缺陷。
 - MCP 由 `gcloud/apigw/decorators.py` 和 view 装饰器实现；单独核对 API/MCP create_method、exclude/trim/include、普通响应与缓存共享对象。真实资源是 `gcloud/apigw/management/commands/data/api-resources.yml`，不存在根 apigw/MCP additions/supplement 文件。

--- a/docs/en/deploy/mako_render.md
+++ b/docs/en/deploy/mako_render.md
@@ -2,6 +2,8 @@
 
 Use `bamboo-pipeline==3.24.18`, which pins `bamboo-engine==2.6.7`. Do not override the engine dependency separately.
 
+These are the currently released dependency versions. The explicit infrastructure-failure behavior described below requires a future engine release containing `RenderInfrastructureError`, a pipeline release pinning that engine, and deployment alongside this bk-sops `SystemObject` source fix. The versions above do not yet include that behavior. This change updates neither dependency versions nor default settings; packaging and publication are separate steps.
+
 For the initial rollout, set:
 
 ```bash
@@ -46,5 +48,11 @@ Boolean values accept `0/1` or `false/true`. Invalid boolean values or backend n
 Whitelist enforcement and subprocess rendering are independent switches. Before enabling `enforce`, review expressions and class aliases: `datetime.datetime.now()` requires the `datetime.datetime` import entry; `datetime.date.today()` requires `datetime.date`. Restoring module names alone does not authorize every nested call.
 
 Before setting `BKAPP_MAKO_RENDER_BACKEND=subprocess`, retain the default fallback/network/resource options and validate namespace permissions, Celery process behavior and real application contexts inside the target Linux container. Failure to establish the required network namespace prevents rendering; enabling in-process fallback does not bypass that failure. Passing in-process regression tests does not establish subprocess deployment readiness.
+
+With the coordinated release, worker startup failures, admission or transport timeouts, worker exits, protocol errors and required network-isolation failures raise `RenderInfrastructureError` and explicitly fail the node. They no longer pass an unrendered expression onward as a successful result, and never trigger host rendering even when `FALLBACK_INPROCESS=1`.
+
+The `SystemObject` fix preserves the pickle path `engine_pickle_obj.context.SystemObject`, its attribute dictionary and its string representation. Previously persisted pickles load after the fix and use the engine's existing structural adapter for worker transport, without unpickling the original application class inside the worker. Subclasses with inherited property behavior remain unsupported for portable transport.
+
+Compatibility staging still supports explicitly setting `BKAPP_SOPS_MAKO_WHITELIST_MODE=warn`, `BKAPP_MAKO_RENDER_BACKEND=subprocess`, `BKAPP_MAKO_RENDER_FALLBACK_INPROCESS=1` and `BKAPP_MAKO_RENDER_NO_NETWORK=0`. Only unsupported context/spec values may fall back to host rendering, and a network namespace is not required in this configuration. This does not establish network-isolation readiness or change the defaults in the table above.
 
 [简体中文](../../zh_hans/deploy/mako_render.md)

--- a/docs/en/deploy/mako_render.md
+++ b/docs/en/deploy/mako_render.md
@@ -1,8 +1,8 @@
 # Mako package upgrade and deployment settings
 
-Use `bamboo-pipeline==3.24.18`, which pins `bamboo-engine==2.6.7`. Do not override the engine dependency separately.
+Use `bamboo-pipeline==3.24.19`, which pins `bamboo-engine==2.6.8`. Do not override the engine dependency separately.
 
-These are the currently released dependency versions. The explicit infrastructure-failure behavior described below requires a future engine release containing `RenderInfrastructureError`, a pipeline release pinning that engine, and deployment alongside this bk-sops `SystemObject` source fix. The versions above do not yet include that behavior. This change updates neither dependency versions nor default settings; packaging and publication are separate steps.
+These dependencies are available on PyPI and include the explicit infrastructure-failure behavior through `RenderInfrastructureError` described below. Deploy the dependency update together with this bk-sops `SystemObject` source fix to apply both failure handling and system-context transport fixes. Default settings remain unchanged.
 
 For the initial rollout, set:
 
@@ -49,7 +49,7 @@ Whitelist enforcement and subprocess rendering are independent switches. Before 
 
 Before setting `BKAPP_MAKO_RENDER_BACKEND=subprocess`, retain the default fallback/network/resource options and validate namespace permissions, Celery process behavior and real application contexts inside the target Linux container. Failure to establish the required network namespace prevents rendering; enabling in-process fallback does not bypass that failure. Passing in-process regression tests does not establish subprocess deployment readiness.
 
-With the coordinated release, worker startup failures, admission or transport timeouts, worker exits, protocol errors and required network-isolation failures raise `RenderInfrastructureError` and explicitly fail the node. They no longer pass an unrendered expression onward as a successful result, and never trigger host rendering even when `FALLBACK_INPROCESS=1`.
+With these package versions, worker startup failures, admission or transport timeouts, worker exits, protocol errors and required network-isolation failures raise `RenderInfrastructureError` and explicitly fail the node. They no longer pass an unrendered expression onward as a successful result, and never trigger host rendering even when `FALLBACK_INPROCESS=1`.
 
 The `SystemObject` fix preserves the pickle path `engine_pickle_obj.context.SystemObject`, its attribute dictionary and its string representation. Previously persisted pickles load after the fix and use the engine's existing structural adapter for worker transport, without unpickling the original application class inside the worker. Subclasses with inherited property behavior remain unsupported for portable transport.
 

--- a/docs/zh_hans/deploy/mako_render.md
+++ b/docs/zh_hans/deploy/mako_render.md
@@ -1,8 +1,8 @@
 # Mako 依赖升级与部署配置
 
-对应 `bamboo-pipeline==3.24.18`，其包依赖已固定 `bamboo-engine==2.6.7`，无需另外覆盖 engine 版本。
+对应 `bamboo-pipeline==3.24.19`，其包依赖已固定 `bamboo-engine==2.6.8`，无需另外覆盖 engine 版本。
 
-以上是当前已发布的依赖基线。下述基础设施故障显式失败行为需要后续发布包含 `RenderInfrastructureError` 的 engine 及固定对应 engine 版本的 pipeline，并与本次 bk-sops `SystemObject` 源码修复配套上线；当前版本号不代表已包含该行为。本次不调整依赖版本或默认配置，依赖打包发布是单独步骤。
+以上依赖已发布到 PyPI，并包含下述通过 `RenderInfrastructureError` 显式报告基础设施故障的行为。部署时需同时更新应用依赖和本次 bk-sops `SystemObject` 源码修复，以完整接入故障处理和系统上下文传输修复。默认配置保持不变。
 
 ## 首次发布
 
@@ -48,7 +48,7 @@ BKAPP_MAKO_RENDER_BACKEND=inprocess
 
 切换 `BKAPP_MAKO_RENDER_BACKEND=subprocess` 时，建议保持 `FALLBACK_INPROCESS=0`、`OS_HARDEN=1`、`NO_NETWORK=1`（均指上表完整变量名），先在目标 Linux 容器验证网络命名空间权限、Celery 进程模型和真实业务 context。无网络隔离建立失败时会拒绝渲染；开启进程内回退也不会绕过这种失败。不能把进程内路径回归通过等同于子进程隔离验收。
 
-配套版本发布后，worker 启动、排队或通信超时、进程退出、协议异常及必需的网络隔离建立失败会通过 `RenderInfrastructureError` 显式使节点失败，不再把未渲染的表达式作为成功结果继续执行；即使 `FALLBACK_INPROCESS=1`，这些基础设施故障也不会回退到宿主渲染。
+使用上述配套版本时，worker 启动、排队或通信超时、进程退出、协议异常及必需的网络隔离建立失败会通过 `RenderInfrastructureError` 显式使节点失败，不再把未渲染的表达式作为成功结果继续执行；即使 `FALLBACK_INPROCESS=1`，这些基础设施故障也不会回退到宿主渲染。
 
 本次 `SystemObject` 修复保留 `engine_pickle_obj.context.SystemObject` 的 pickle 路径、属性字典及字符串表现。旧版本持久化的 pickle 可在修复后加载，并经引擎现有结构适配器传输给 worker，无需在 worker 中反序列化原应用类。继承属性行为的子类仍不属于可传输的普通属性对象。
 

--- a/docs/zh_hans/deploy/mako_render.md
+++ b/docs/zh_hans/deploy/mako_render.md
@@ -2,6 +2,8 @@
 
 对应 `bamboo-pipeline==3.24.18`，其包依赖已固定 `bamboo-engine==2.6.7`，无需另外覆盖 engine 版本。
 
+以上是当前已发布的依赖基线。下述基础设施故障显式失败行为需要后续发布包含 `RenderInfrastructureError` 的 engine 及固定对应 engine 版本的 pipeline，并与本次 bk-sops `SystemObject` 源码修复配套上线；当前版本号不代表已包含该行为。本次不调整依赖版本或默认配置，依赖打包发布是单独步骤。
+
 ## 首次发布
 
 按先发布、再回归的安排，在部署平台配置以下环境变量。下面的导入表恢复原有默认模块；若现网还配置了其他业务模块，需合并到同一个值中。
@@ -45,5 +47,11 @@ BKAPP_MAKO_RENDER_BACKEND=inprocess
 白名单与子进程隔离是两个独立开关，可分别回归。切换 `enforce` 前需检查业务表达式及导入别名：例如 `datetime.datetime.now()` 需要在导入表中补 `datetime.datetime`，`datetime.date.today()` 需要补 `datetime.date`；恢复模块名本身不代表所有多级调用都会放行。
 
 切换 `BKAPP_MAKO_RENDER_BACKEND=subprocess` 时，建议保持 `FALLBACK_INPROCESS=0`、`OS_HARDEN=1`、`NO_NETWORK=1`（均指上表完整变量名），先在目标 Linux 容器验证网络命名空间权限、Celery 进程模型和真实业务 context。无网络隔离建立失败时会拒绝渲染；开启进程内回退也不会绕过这种失败。不能把进程内路径回归通过等同于子进程隔离验收。
+
+配套版本发布后，worker 启动、排队或通信超时、进程退出、协议异常及必需的网络隔离建立失败会通过 `RenderInfrastructureError` 显式使节点失败，不再把未渲染的表达式作为成功结果继续执行；即使 `FALLBACK_INPROCESS=1`，这些基础设施故障也不会回退到宿主渲染。
+
+本次 `SystemObject` 修复保留 `engine_pickle_obj.context.SystemObject` 的 pickle 路径、属性字典及字符串表现。旧版本持久化的 pickle 可在修复后加载，并经引擎现有结构适配器传输给 worker，无需在 worker 中反序列化原应用类。继承属性行为的子类仍不属于可传输的普通属性对象。
+
+兼容灰度仍支持显式配置 `BKAPP_SOPS_MAKO_WHITELIST_MODE=warn`、`BKAPP_MAKO_RENDER_BACKEND=subprocess`、`BKAPP_MAKO_RENDER_FALLBACK_INPROCESS=1`、`BKAPP_MAKO_RENDER_NO_NETWORK=0`。此时仅不支持的 context/spec 可走宿主回退，且不要求网络命名空间；这不等于无网络隔离验收，也不改变上表默认值。
 
 [English](../../en/deploy/mako_render.md)

--- a/engine_pickle_obj/context.py
+++ b/engine_pickle_obj/context.py
@@ -14,6 +14,16 @@ specific language governing permissions and limitations under the License.
 from bamboo_engine.utils.object import Representable
 
 
-class SystemObject(Representable):
+class SystemObject(object):
+    # A direct attribute bag is accepted by the engine's strict portable adapter.
+    # Reuse the display methods without inheriting behavior that it cannot transport.
+    __str__ = Representable.__str__
+    __repr__ = Representable.__repr__
+
     def __init__(self, attrs: dict):
         self.__dict__ = attrs
+
+    def __getstate__(self):
+        # Default pickling caches __slotnames__ on the class in Python 3.6,
+        # which would make this attribute bag fail the structural adapter later.
+        return self.__dict__

--- a/gcloud/tests/security/test_system_object_portable.py
+++ b/gcloud/tests/security/test_system_object_portable.py
@@ -1,0 +1,269 @@
+# -*- coding: utf-8 -*-
+"""SystemObject persistence and real subprocess transport, without Django settings.
+
+Run with: python -m unittest gcloud.tests.security.test_system_object_portable -v
+Workers deliberately disable Linux-only hardening for portable POSIX tests.
+"""
+import base64
+import datetime
+import pickle
+import subprocess
+import sys
+from pathlib import Path
+from unittest import TestCase, mock
+
+from bamboo_engine.config import Settings as BambooSettings
+from bamboo_engine.context import Context
+from bamboo_engine.eri import ContextValue, ContextValueType
+from bamboo_engine.template import Template, render_backend
+from bamboo_engine.utils.object import Representable
+from pipeline.eri.imp.serializer import SerializerMixin
+
+from engine_pickle_obj.context import SystemObject
+
+# Frozen BEFORE the fix, from actual engine_pickle_obj.context.SystemObject at
+# bk-sops 954419a23afa396fbb9d20200059913a30ad81a2 with Python 3.6.15/engine 2.6.7:
+#
+# class SystemObject(Representable):
+#     def __init__(self, attrs: dict):
+#         self.__dict__ = attrs
+#
+# base64.b64encode(pickle.dumps(SystemObject(sample_attrs()), protocol)).decode()
+# Protocol 3 is Python 3.6's default, used by SerializerMixin._serialize.
+# Do not regenerate these with the new class: that would lose migration coverage.
+OLD_PICKLES = {
+    2: (
+        "gAJjZW5naW5lX3BpY2tsZV9vYmouY29udGV4dApTeXN0ZW1PYmplY3QKcQApgXEBfXECKFgIAAAAZXhlY3V0b3JxA1gF"
+        "AAAAYWxpY2VxBFgHAAAAdGFza19pZHEFSypYCAAAAHNjaGVkdWxlcQZ9cQcoWAQAAABkYXRlcQhjZGF0ZXRpbWUKZGF0"
+        "ZQpxCWNfY29kZWNzCmVuY29kZQpxClgFAAAAB8OqCQpxC1gGAAAAbGF0aW4xcQyGcQ1ScQ6FcQ9ScRBYBQAAAGhvc3Rz"
+        "cRFdcRIoWAYAAABob3N0LWFxE31xFFgCAAAAaXBxFVgJAAAAMTI3LjAuMC4xcRZzZXV1Yi4="
+    ),
+    3: (
+        "gANjZW5naW5lX3BpY2tsZV9vYmouY29udGV4dApTeXN0ZW1PYmplY3QKcQApgXEBfXECKFgIAAAAZXhlY3V0b3JxA1gF"
+        "AAAAYWxpY2VxBFgHAAAAdGFza19pZHEFSypYCAAAAHNjaGVkdWxlcQZ9cQcoWAQAAABkYXRlcQhjZGF0ZXRpbWUKZGF0"
+        "ZQpxCUMEB+oJCnEKhXELUnEMWAUAAABob3N0c3ENXXEOKFgGAAAAaG9zdC1hcQ99cRBYAgAAAGlwcRFYCQAAADEyNy4w"
+        "LjAuMXESc2V1dWIu"
+    ),
+    4: (
+        "gASVswAAAAAAAACMGWVuZ2luZV9waWNrbGVfb2JqLmNvbnRleHSUjAxTeXN0ZW1PYmplY3SUk5QpgZR9lCiMCGV4ZWN1"
+        "dG9ylIwFYWxpY2WUjAd0YXNrX2lklEsqjAhzY2hlZHVsZZR9lCiMBGRhdGWUjAhkYXRldGltZZSMBGRhdGWUk5RDBAfq"
+        "CQqUhZRSlIwFaG9zdHOUXZQojAZob3N0LWGUfZSMAmlwlIwJMTI3LjAuMC4xlHNldXViLg=="
+    ),
+}
+OLD_REPR = (
+    "<SystemObject: {'executor': 'alice', 'task_id': 42, "
+    "'schedule': {'date': datetime.date(2026, 9, 10), 'hosts': ['host-a', {'ip': '127.0.0.1'}]}}>"
+)
+
+
+def sample_attrs():
+    return {
+        "executor": "alice",
+        "task_id": 42,
+        "schedule": {"date": datetime.date(2026, 9, 10), "hosts": ["host-a", {"ip": "127.0.0.1"}]},
+    }
+
+
+class SystemObjectCompatibilityTestCase(TestCase):
+    def test_dictionary_is_shared_mutable_and_replaceable(self):
+        attrs = sample_attrs()
+        obj = SystemObject(attrs)
+        self.assertIs(vars(obj), attrs)
+        attrs["executor"] = "bob"
+        self.assertEqual(obj.executor, "bob")
+        obj.task_id = 43
+        obj.schedule["hosts"].append("host-b")
+        self.assertEqual(attrs["task_id"], 43)
+        self.assertEqual(attrs["schedule"]["hosts"], ["host-a", {"ip": "127.0.0.1"}, "host-b"])
+        del obj.executor
+        self.assertNotIn("executor", attrs)
+        replacement = {"executor": "carol", "not-an-identifier": 1, 2: "two"}
+        obj.__dict__ = replacement
+        self.assertIs(vars(obj), replacement)
+        self.assertEqual(obj.executor, "carol")
+        self.assertEqual(vars(obj)[2], "two")
+
+    def test_dictionary_subclass_is_preserved_but_not_made_portable(self):
+        class AttributeDict(dict):
+            pass
+
+        attrs = AttributeDict(executor="alice")
+        obj = SystemObject(attrs)
+        self.assertIs(vars(obj), attrs)
+        self.assertEqual(obj.executor, "alice")
+        with self.assertRaises(render_backend.UnsupportedContext):
+            render_backend._portable_context({"_system": obj})
+        for invalid in (None, [], [("executor", "alice")]):
+            with self.subTest(invalid=invalid), self.assertRaises(TypeError):
+                SystemObject(invalid)
+
+    def test_old_persisted_pickles_load_with_original_attributes_and_display(self):
+        serializer = SerializerMixin()
+        for protocol, encoded in OLD_PICKLES.items():
+            with self.subTest(protocol=protocol):
+                obj = serializer._deserialize(encoded, "pickle")
+                self.assertIs(type(obj), SystemObject)
+                self.assertEqual(vars(obj), sample_attrs())
+                self.assertIs(type(obj.schedule["date"]), datetime.date)
+                self.assertEqual(str(obj), OLD_REPR)
+                self.assertEqual(repr(obj), OLD_REPR)
+
+    def test_new_objects_keep_persistence_identity_and_display(self):
+        serializer = SerializerMixin()
+        obj = SystemObject(sample_attrs())
+        self.assertEqual(str(obj), OLD_REPR)
+        self.assertEqual(repr(obj), OLD_REPR)
+        encoded, kind = serializer._serialize(obj)
+        self.assertEqual(kind, "pickle")
+        restored = serializer._deserialize(encoded, kind)
+        self.assertIs(type(restored), SystemObject)
+        self.assertEqual(type(restored).__module__, "engine_pickle_obj.context")
+        self.assertEqual(type(restored).__name__, "SystemObject")
+        self.assertEqual(vars(restored), sample_attrs())
+        self.assertEqual(repr(restored), OLD_REPR)
+
+    def test_engine_normalizes_system_object_without_losing_data_or_display(self):
+        obj = SystemObject(sample_attrs())
+        portable = render_backend._portable_context({"_system": obj})["_system"]
+        self.assertIs(type(portable), render_backend.PortableRenderObject)
+        self.assertEqual(vars(portable), sample_attrs())
+        self.assertEqual(str(portable), OLD_REPR)
+        self.assertEqual(repr(portable), OLD_REPR)
+
+    def test_pickling_does_not_make_current_or_restored_objects_untransportable(self):
+        obj = SystemObject(sample_attrs())
+        for protocol in (2, 3, 4):
+            restored = pickle.loads(pickle.dumps(obj, protocol=protocol))
+            for value in (obj, restored):
+                with self.subTest(protocol=protocol, restored=value is restored):
+                    portable = render_backend._portable_context({"_system": value})["_system"]
+                    self.assertEqual(vars(portable), sample_attrs())
+                    self.assertEqual(repr(portable), OLD_REPR)
+
+    def test_inherited_properties_and_other_representable_subclasses_remain_rejected(self):
+        class PropertySystemObject(SystemObject):
+            @property
+            def computed(self):
+                raise AssertionError("transport must not evaluate a property")
+
+        class InheritedPropertySystemObject(PropertySystemObject):
+            pass
+
+        class OtherRepresentable(Representable):
+            def __init__(self, attrs):
+                self.__dict__ = attrs
+
+        for kind in (PropertySystemObject, InheritedPropertySystemObject, OtherRepresentable):
+            with self.subTest(kind=kind.__name__), self.assertRaises(render_backend.UnsupportedContext):
+                render_backend._portable_context({"_system": kind(sample_attrs())})
+
+
+class SystemObjectSubprocessTestCase(TestCase):
+    def setUp(self):
+        self.backend = render_backend.SubprocessPoolRenderBackend(
+            pool_size=1, timeout=10, fallback_inprocess=False, no_network=False, os_harden=False
+        )
+        self.addCleanup(self.backend.close)
+        spec = render_backend.SandboxSpec("engine", BambooSettings.MAKO_SANDBOX_SHIELD_WORDS, {})
+        self.provider = render_backend.SandboxProvider(spec.build, spec)
+
+    def test_newly_persisted_root_context_renders_in_real_worker(self):
+        serializer = SerializerMixin()
+        root_context = {"${_system}": SystemObject(sample_attrs())}
+        encoded, kind = serializer._serialize(root_context)
+        self.assertEqual(kind, "pickle")
+        restored = serializer._deserialize(encoded, kind)
+        for values in (root_context, restored):
+            with self.subTest(restored=values is restored):
+                self.assertEqual(
+                    self.backend.render(
+                        "by=${_system.executor};task=${_system.task_id}",
+                        {"_system": values["${_system}"]},
+                        self.provider,
+                    ),
+                    "by=alice;task=42",
+                )
+
+    def test_old_pickles_render_in_real_worker_that_cannot_import_application_class(self):
+        root = Path(__file__).resolve().parents[3]
+        worker_paths = [
+            path for path in sys.path if root != Path(path).resolve() and root not in Path(path).resolve().parents
+        ]
+        # Negative control: the same fresh-interpreter import paths cannot load
+        # the original persisted app object. No production class hooks or mocks.
+        probe = subprocess.run(
+            [
+                sys.executable,
+                "-I",
+                "-S",
+                "-c",
+                "import sys,base64,pickle; sys.path={!r}; pickle.loads(base64.b64decode({!r}))".format(
+                    worker_paths, OLD_PICKLES[3]
+                ),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+        )
+        self.assertNotEqual(probe.returncode, 0)
+        self.assertIn(b"No module named 'engine_pickle_obj'", probe.stderr)
+        template = (
+            "by=${_system.executor};date=${_system.schedule['date']};"
+            "ip=${_system.schedule['hosts'][1]['ip']};object=${_system};repr=${[_system]}"
+        )
+        # List display exercises __repr__ without enabling the shielded repr builtin.
+        expected = "by=alice;date=2026-09-10;ip=127.0.0.1;object=" + OLD_REPR + ";repr=[" + OLD_REPR + "]"
+        with mock.patch.object(sys, "path", worker_paths):
+            for protocol, encoded in OLD_PICKLES.items():
+                with self.subTest(protocol=protocol):
+                    obj = pickle.loads(base64.b64decode(encoded))
+                    self.assertEqual(self.backend.render(template, {"_system": obj}, self.provider), expected)
+
+    def test_portable_datetime_forms_render_with_their_values_intact(self):
+        offset = datetime.timezone(datetime.timedelta(hours=8))
+        cases = [
+            (datetime.date(2026, 9, 10), "2026-09-10"),
+            (datetime.datetime(2026, 9, 10, 12, 34, 56), "2026-09-10 12:34:56"),
+            (datetime.datetime(2026, 9, 10, 12, 34, tzinfo=datetime.timezone.utc), "2026-09-10 12:34:00+00:00"),
+            (datetime.datetime(2026, 9, 10, 12, 34, tzinfo=offset), "2026-09-10 12:34:00+08:00"),
+            (datetime.time(12, 34, 56), "12:34:56"),
+            (datetime.time(12, 34, tzinfo=datetime.timezone.utc), "12:34:00+00:00"),
+            (datetime.time(12, 34, tzinfo=offset), "12:34:00+08:00"),
+            (datetime.timedelta(days=1, seconds=2), "1 day, 0:00:02"),
+        ]
+        for value, expected in cases:
+            with self.subTest(value=value):
+                obj = SystemObject({"dates": [{"value": value}]})
+                portable = render_backend._portable_context({"_system": obj})["_system"].dates[0]["value"]
+                self.assertIs(type(portable), type(value))
+                self.assertEqual(portable, value)
+                self.assertEqual(
+                    self.backend.render("value=${_system.dates[0]['value']}", {"_system": obj}, self.provider),
+                    "value=" + expected,
+                )
+
+    def test_root_context_hydration_and_template_render_preserve_system_usage(self):
+        obj = SerializerMixin()._deserialize(OLD_PICKLES[3], "pickle")
+        context = Context(
+            runtime=None,  # Plain/splice values require no runtime or database calls.
+            values=[
+                ContextValue("${_system}", ContextValueType.PLAIN, obj),
+                ContextValue("${summary}", ContextValueType.SPLICE, "by=${_system.executor};task=${_system.task_id}"),
+            ],
+            additional_data={},
+        )
+        # Inject the real backend while preserving any backend owned by other tests.
+        with mock.patch.object(render_backend, "_BACKEND", self.backend), mock.patch.object(
+            BambooSettings, "MAKO_TEMPLATE_NAME_EXTRA_WHITELIST", frozenset({"_system", "_loop"})
+        ):
+            hydrated = context.hydrate()
+            self.assertIs(hydrated["${_system}"], obj)
+            self.assertEqual(hydrated["${summary}"], "by=alice;task=42")
+            data = context.hydrate(deformat=True)
+            self.assertIs(Template("${_system}").render(data), obj)
+            self.assertEqual(
+                Template({"executor": "${_system.executor}", "hosts": ["${_system.schedule['hosts'][0]}"]}).render(
+                    data
+                ),
+                {"executor": "alice", "hosts": ["host-a"]},
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,7 +45,8 @@ prometheus-client==0.9.0
 # （现网 task 138970299 挂 56 天即此形态）。子进程真卡了仍由专属判据接住。
 # 3.24.18（依赖 bamboo-engine==2.6.7）：包含 PR#284 Mako 加固与 PR#285 可选子进程渲染。
 # format 仅在 enforce 下拒绝；默认仍进程内渲染，部署配置见 docs/zh_hans/deploy/mako_render.md。
-bamboo-pipeline==3.24.18
+# 3.24.19（依赖 bamboo-engine==2.6.8）：子进程渲染基础设施故障显式失败，配套 SystemObject 传输修复。
+bamboo-pipeline==3.24.19
 drf-yasg==1.20.0
 typing-extensions==3.7.4.3
 pyyaml==5.4.1


### PR DESCRIPTION
`SystemObject` 原先继承 `Representable`，无法通过引擎跨进程传输的严格属性对象检查，导致包含 `_system` 的渲染上下文进入兼容回退。本次将其调整为直接属性对象，复用原来的字符串表现，并显式保存属性字典，避免 Python 3.6 默认 pickle 给类添加 `__slotnames__` 后再次失去可传输性。

保留 `engine_pickle_obj.context.SystemObject` 的持久化路径和属性字典语义，旧任务数据无需迁移；不放宽引擎对任意继承类或 property 对象的传输限制。

依赖升级到已发布的 `bamboo-pipeline==3.24.19`，由该包固定依赖 `bamboo-engine==2.6.8`，接入配套引擎修复 https://github.com/TencentBlueKing/bamboo-engine/pull/296 。子进程启动、超时、退出、协议及必需的网络隔离故障会显式使节点失败，不再将未渲染表达式当作成功结果继续执行；`FALLBACK_INPROCESS=1` 仅允许不支持的 context/spec 回退，不覆盖基础设施故障。

同步中英文部署说明和仓库 review 的依赖基线。生产环境变量与默认配置不变。

验证：
- 使用 PyPI 正式包 `3.24.19 / 2.6.8`，Python 3.6.15 下运行系统上下文、部署配置和白名单回归：38 passed、1 按既有条件跳过。跳过项是旧引擎 off 模式执行 PoC 的历史用例，新版由 always-on 拦截测试覆盖。
- 覆盖修复前冻结的 pickle 协议 2/3/4、新旧序列化往返、属性字典修改、嵌套时间类型、禁止回退的真实 worker 渲染，以及 worker 无法导入应用类时的 portable 转换。
- 配置回归加载实际 Mako 配置片段，使用独立本地测试环境，不连接业务数据库；属性子类及其他 Representable 子类继续被拒绝。
- 正式包的 11 项 SystemObject 测试也在 Python 3.7.16 下通过。
- 变更文件、敏感信息和提交规范检查通过。

以上为本地定向回归，尚未进行目标 Linux 容器的并发和权限验收。

关联需求：--story=860752509
