### PR TITLE
chore: 多租户升级 bamboo-pipeline 至 4.0.5 --story=860752509

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,10 +22,10 @@ pyinstrument==5.0.0
 djangorestframework==3.15.2
 django-filter==2.4.0
 prometheus-client==0.20.0
-# 流程卡住治理 M1：诊断检测能力对应 4.x 线的 bamboo-pipeline 4.0.4。
+# 流程卡住治理 M1：诊断检测能力对应 4.x 线的 bamboo-pipeline 4.0.5（依赖 bamboo-engine 3.0.6）。
 # 升级后 pipeline.contrib.diagnostics 条件注册生效；
 # SCAN/EVENT/ALERT/APPLY 默认全关，需按运维 checklist 显式开启。
-bamboo-pipeline==4.0.4
+bamboo-pipeline==4.0.5
 drf-yasg==1.21.8
 typing-extensions==4.12.2
 pyyaml==6.0.2


### PR DESCRIPTION
将 dev_multi_tenant 的 bamboo-pipeline 从 4.0.4 升级到 4.0.5，通过包内精确约束同步使用 bamboo-engine 3.0.6，接入 4.0 LTS 上近期的 Mako 渲染兼容性、隔离渲染失败处理及运行时修复。

本 PR 仅更新 requirements.txt 的依赖版本和说明，共两行。现有诊断开关、Mako 配置和其他依赖版本保持不变。

上游修复与发布：
- [修复同步 #299](https://github.com/TencentBlueKing/bamboo-engine/pull/299)
- [engine 3.0.6 发布及旧引擎多回调快照修复 #300](https://github.com/TencentBlueKing/bamboo-engine/pull/300)
- [pipeline 4.0.5 发布 #301](https://github.com/TencentBlueKing/bamboo-engine/pull/301)

验证：
- 两次上游发布提交的完整 6 项 CI 均通过：[engine CI](https://github.com/TencentBlueKing/bamboo-engine/actions/runs/34585995044)、[pipeline CI](https://github.com/TencentBlueKing/bamboo-engine/actions/runs/34587455902)。
- Python 3.11 下保留其余安装依赖，升级前后全量 1122 项测试均通过；使用与目标分支 CI 一致的测试环境配置。
- 安装清单对比只变化 engine/pipeline 两项，pip check 通过。正式 PyPI wheel/sdist 均可下载，哈希及包内源码与发布提交一致，pipeline 精确依赖 engine==3.0.6。
- 从正式 PyPI 强制重新安装后，65 个 engine 和 489 个 pipeline Python 文件与已核验 wheel 完全一致；任务回调、子流程回调补偿、诊断及 Mako 重点回归 60 项通过。
- 已对比 4.0.4→4.0.5 的迁移文件：无新增迁移操作，现有迁移仅清理导入及格式，定义和操作的 AST 一致。
- 本 PR 的 [GitHub 单测 CI](https://github.com/TencentBlueKing/bk-sops/actions/runs/34619850205) 已通过。首次安装时 runner 的包索引尚未包含刚发布的 4.0.5，原提交重跑后成功安装并通过测试。
